### PR TITLE
fix: LoadTableSchema returns NotExist error instead of null when table does not exist

### DIFF
--- a/include/paimon/catalog/catalog.h
+++ b/include/paimon/catalog/catalog.h
@@ -100,10 +100,8 @@ class PAIMON_EXPORT Catalog {
     /// @note System tables will not be supported.
     ///
     /// @param identifier The identifier (database and table name) of the table to load.
-    /// @return A result containing table schema if the table exists, or std::nullopt if it
-    /// doesn't, or an error status on failure.
-    virtual Result<std::optional<std::shared_ptr<Schema>>> LoadTableSchema(
-        const Identifier& identifier) const = 0;
+    /// @return A result containing table schema if the table exists, or an error status on failure.
+    virtual Result<std::shared_ptr<Schema>> LoadTableSchema(const Identifier& identifier) const = 0;
 };
 
 }  // namespace paimon

--- a/src/paimon/core/catalog/file_system_catalog.h
+++ b/src/paimon/core/catalog/file_system_catalog.h
@@ -29,7 +29,7 @@
 struct ArrowSchema;
 
 namespace paimon {
-
+class TableSchema;
 class FileSystem;
 class Identifier;
 class Logger;
@@ -49,8 +49,7 @@ class FileSystemCatalog : public Catalog {
 
     Result<std::vector<std::string>> ListDatabases() const override;
     Result<std::vector<std::string>> ListTables(const std::string& database_names) const override;
-    Result<std::optional<std::shared_ptr<Schema>>> LoadTableSchema(
-        const Identifier& identifier) const override;
+    Result<std::shared_ptr<Schema>> LoadTableSchema(const Identifier& identifier) const override;
 
  private:
     static std::string NewDatabasePath(const std::string& warehouse, const std::string& db_name);
@@ -59,7 +58,8 @@ class FileSystemCatalog : public Catalog {
     static bool IsSpecifiedSystemTable(const Identifier& identifier);
     static bool IsSystemTable(const Identifier& identifier);
     Result<bool> DataBaseExists(const std::string& db_name) const;
-    Result<bool> TableExists(const Identifier& identifier) const;
+    Result<std::optional<std::shared_ptr<TableSchema>>> TableSchemaExists(
+        const Identifier& identifier) const;
 
     Status CreateDatabaseImpl(const std::string& db_name,
                               const std::map<std::string, std::string>& options);

--- a/src/paimon/core/catalog/file_system_catalog_test.cpp
+++ b/src/paimon/core/catalog/file_system_catalog_test.cpp
@@ -180,10 +180,9 @@ TEST(FileSystemCatalogTest, TestCreateTableWithBlob) {
     ASSERT_OK_AND_ASSIGN(std::vector<std::string> table_names, catalog.ListTables("db1"));
     ASSERT_EQ(1, table_names.size());
     ASSERT_EQ(table_names[0], "tbl1");
-    ASSERT_OK_AND_ASSIGN(std::optional<std::shared_ptr<Schema>> table_schema,
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<Schema> table_schema,
                          catalog.LoadTableSchema(Identifier("db1", "tbl1")));
-    ASSERT_TRUE(table_schema.has_value());
-    ASSERT_OK_AND_ASSIGN(auto arrow_schema, (*table_schema)->GetArrowSchema());
+    ASSERT_OK_AND_ASSIGN(auto arrow_schema, table_schema->GetArrowSchema());
     auto loaded_schema = arrow::ImportSchema(arrow_schema.get()).ValueOrDie();
     ASSERT_TRUE(typed_schema.Equals(loaded_schema));
     ArrowSchemaRelease(&schema);
@@ -336,32 +335,32 @@ TEST(FileSystemCatalogTest, TestValidateTableSchema) {
     ASSERT_OK(catalog.CreateTable(Identifier("db1", "tbl1"), &schema, {"f1"}, {}, options,
                                   /*ignore_if_exists=*/false));
 
-    ASSERT_OK_AND_ASSIGN(std::optional<std::shared_ptr<Schema>> table_schema,
-                         catalog.LoadTableSchema(Identifier("db0", "tbl0")));
-    ASSERT_FALSE(table_schema.has_value());
-    ASSERT_OK_AND_ASSIGN(table_schema, catalog.LoadTableSchema(Identifier("db1", "tbl1")));
-    ASSERT_TRUE(table_schema.has_value());
-    ASSERT_EQ(0, (*table_schema)->Id());
-    ASSERT_EQ(3, (*table_schema)->HighestFieldId());
-    ASSERT_EQ(1, (*table_schema)->PartitionKeys().size());
-    ASSERT_EQ(0, (*table_schema)->PrimaryKeys().size());
-    ASSERT_EQ(-1, (*table_schema)->NumBuckets());
-    ASSERT_FALSE((*table_schema)->Comment().has_value());
-    std::vector<std::string> field_names = (*table_schema)->FieldNames();
+    ASSERT_NOK_WITH_MSG(catalog.LoadTableSchema(Identifier("db0", "tbl0")),
+                        "Identifier{database=\'db0\', table=\'tbl0\'} not exist");
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<Schema> table_schema,
+                         catalog.LoadTableSchema(Identifier("db1", "tbl1")));
+    ASSERT_EQ(0, table_schema->Id());
+    ASSERT_EQ(3, table_schema->HighestFieldId());
+    ASSERT_EQ(1, table_schema->PartitionKeys().size());
+    ASSERT_EQ(0, table_schema->PrimaryKeys().size());
+    ASSERT_EQ(-1, table_schema->NumBuckets());
+    ASSERT_FALSE(table_schema->Comment().has_value());
+    std::vector<std::string> field_names = table_schema->FieldNames();
     std::vector<std::string> expected_field_names = {"f0", "f1", "f2", "f3"};
     ASSERT_EQ(field_names, expected_field_names);
 
-    ASSERT_OK_AND_ASSIGN(auto arrow_schema, (*table_schema)->GetArrowSchema());
+    ASSERT_OK_AND_ASSIGN(auto arrow_schema, table_schema->GetArrowSchema());
     auto loaded_schema = arrow::ImportSchema(arrow_schema.get()).ValueOrDie();
     ASSERT_TRUE(typed_schema.Equals(loaded_schema));
 
     ASSERT_OK_AND_ASSIGN(auto fs, FileSystemFactory::Get("local", dir->Str(), {}));
     ASSERT_OK(fs->Delete(PathUtil::JoinPath(dir->Str(), "db1.db/tbl1/schema/schema-0")));
-    ASSERT_OK_AND_ASSIGN(table_schema, catalog.LoadTableSchema(Identifier("db1", "tbl1")));
-    ASSERT_FALSE(table_schema.has_value());
+
+    ASSERT_NOK_WITH_MSG(catalog.LoadTableSchema(Identifier("db1", "tbl1")),
+                        "Identifier{database=\'db1\', table=\'tbl1\'} not exist");
 
     ASSERT_NOK_WITH_MSG(catalog.LoadTableSchema(Identifier("db1", "tbl$11")),
-                        "do not support loading schema for system table.");
+                        "do not support checking TableSchemaExists for system table.");
     ArrowSchemaRelease(&schema);
 }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked pr: #10 

<!-- What is the purpose of the change -->
Previously, `LoadTableSchema()` in `Catalog`returned `nullopt` when the requested table did not exist, which made error handling ambiguous.

This change ensures that a clear `NotExist` error is returned in such cases, aligning with Java implementation.

### Tests
FileSystemCatalogTest.TestValidateTableSchema

<!-- List UT and IT cases to verify this change -->

### API and Format
In `catalog.h`:

```cpp
Result<std::shared_ptr<Schema>> LoadTableSchema(const Identifier& identifier) const;
```

