### PR TITLE
docs: fix global index typo

### DIFF
--- a/docs/source/api/global_index.rst
+++ b/docs/source/api/global_index.rst
@@ -13,7 +13,7 @@
 .. limitations under the License.
 
 ============
-GLobal Index
+Global Index
 ============
 
 .. _cpp-api-global-index:


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

The `GLobal` seems weird in documentations, might be a typo?

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->
