### PR TITLE
fix: lazy create merge function in merge file split read

### DIFF
--- a/src/paimon/core/operation/merge_file_split_read.h
+++ b/src/paimon/core/operation/merge_file_split_read.h
@@ -117,20 +117,24 @@ class MergeFileSplitRead : public AbstractSplitRead {
     Result<std::unique_ptr<SortMergeReader>> CreateSortMergeReader(
         std::vector<std::unique_ptr<KeyValueRecordReader>>&& record_readers) const;
 
-    MergeFileSplitRead(
-        const std::shared_ptr<FileStorePathFactory>& path_factory,
-        const std::shared_ptr<InternalReadContext>& context,
-        std::unique_ptr<SchemaManager>&& schema_manager, int32_t key_arity,
-        const std::shared_ptr<arrow::Schema>& value_schema,
-        const std::shared_ptr<arrow::Schema>& read_schema, const std::vector<int32_t>& projection,
-        const std::shared_ptr<MergeFunctionWrapper<KeyValue>>& merge_function_wrapper,
-        const std::shared_ptr<FieldsComparator>& key_comparator,
-        const std::shared_ptr<FieldsComparator>& interval_partition_comparator,
-        const std::shared_ptr<FieldsComparator>& user_defined_seq_comparator,
-        const std::shared_ptr<Predicate>& predicate_for_keys,
-        const std::shared_ptr<MemoryPool>& memory_pool, const std::shared_ptr<Executor>& executor);
+    MergeFileSplitRead(const std::shared_ptr<FileStorePathFactory>& path_factory,
+                       const std::shared_ptr<InternalReadContext>& context,
+                       std::unique_ptr<SchemaManager>&& schema_manager, int32_t key_arity,
+                       const std::shared_ptr<arrow::Schema>& value_schema,
+                       const std::shared_ptr<arrow::Schema>& read_schema,
+                       const std::vector<int32_t>& projection,
+                       const std::shared_ptr<FieldsComparator>& key_comparator,
+                       const std::shared_ptr<FieldsComparator>& interval_partition_comparator,
+                       const std::shared_ptr<FieldsComparator>& user_defined_seq_comparator,
+                       const std::shared_ptr<Predicate>& predicate_for_keys,
+                       const std::shared_ptr<MemoryPool>& memory_pool,
+                       const std::shared_ptr<Executor>& executor);
 
  private:
+    static Result<std::shared_ptr<MergeFunctionWrapper<KeyValue>>> CreateMergeFunctionWrapper(
+        const CoreOptions& core_options, const std::shared_ptr<TableSchema>& table_schema,
+        const std::shared_ptr<arrow::Schema>& value_schema);
+
     static Status GenerateKeyValueReadSchema(
         const TableSchema& table_schema, const CoreOptions& options,
         const std::shared_ptr<arrow::Schema>& raw_read_schema,


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->

Avoid false "unsupported aggregation method" error reports in scenarios such as PK+DV where reading does not actually require MOR (merge-on-read).

Original version: When reading the PK table, if an unsupported aggregation method is encountered, an error is directly reported during the creation of the reader, regardless of whether the MOR is actually needed during the data reading process.

Updated to: The validation of the aggregation method support will only occur when the DataSplit data requires MOR, avoiding false error reports in scenarios such as PK+DV where reading does not actually require MOR.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
TEST_P(ScanAndReadInteTest, TestWithPKWithDvWithInvalidAggregateBatchScanSnapshot3)
TEST_P(ScanAndReadInteTest, TestWithPKWithMorWithInvalidAggregateBatchScanSnapshot3)

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->
