### PR TITLE
feat: support commit metrics of FileStoreCommitImpl to align with CommitMetrics

### DIFF
--- a/src/paimon/core/operation/file_store_commit_impl.h
+++ b/src/paimon/core/operation/file_store_commit_impl.h
@@ -145,7 +145,11 @@ class FileStoreCommitImpl : public FileStoreCommit {
 
     Status CollectChanges(const std::vector<std::shared_ptr<CommitMessage>>& commit_messages,
                           std::vector<ManifestEntry>* append_table_files,
-                          std::vector<IndexManifestEntry>* append_table_index_files);
+                          std::vector<ManifestEntry>* append_changelog_files,
+                          std::vector<ManifestEntry>* compact_table_files,
+                          std::vector<ManifestEntry>* compact_changelog_files,
+                          std::vector<IndexManifestEntry>* append_table_index_files,
+                          std::vector<IndexManifestEntry>* compact_table_index_files);
 
     Result<int32_t> TryCommit(const std::vector<ManifestEntry>& delta_files,
                               const std::vector<IndexManifestEntry>& index_entries,
@@ -191,6 +195,12 @@ class FileStoreCommitImpl : public FileStoreCommit {
     Result<std::set<std::map<std::string, std::string>>> ChangedPartitions(
         const std::vector<ManifestEntry>& data_files,
         const std::vector<IndexManifestEntry>& index_files) const;
+
+    static int64_t RowCounts(const std::vector<ManifestEntry>& files);
+
+    static int64_t NumChangedPartitions(const std::vector<std::vector<ManifestEntry>>& changes);
+
+    static int64_t NumChangedBuckets(const std::vector<std::vector<ManifestEntry>>& changes);
 
  private:
     std::shared_ptr<MemoryPool> memory_pool_;

--- a/src/paimon/core/operation/file_store_commit_impl_test.cpp
+++ b/src/paimon/core/operation/file_store_commit_impl_test.cpp
@@ -1280,10 +1280,20 @@ TEST_F(FileStoreCommitImplTest, TestCollectChanges) {
     auto commit_impl = std::dynamic_pointer_cast<FileStoreCommitImpl>(
         std::shared_ptr<FileStoreCommit>(std::move(commit)));
     std::vector<ManifestEntry> append_table_files;
+    std::vector<ManifestEntry> append_changelog_files;
+    std::vector<ManifestEntry> compact_table_files;
+    std::vector<ManifestEntry> compact_changelog_files;
     std::vector<IndexManifestEntry> append_table_index_files;
-    ASSERT_OK(commit_impl->CollectChanges(msgs, &append_table_files, &append_table_index_files));
+    std::vector<IndexManifestEntry> compact_table_index_files;
+    ASSERT_OK(commit_impl->CollectChanges(msgs, &append_table_files, &append_changelog_files,
+                                          &compact_table_files, &compact_changelog_files,
+                                          &append_table_index_files, &compact_table_index_files));
     ASSERT_EQ(append_table_files.size(), 3u);
+    ASSERT_EQ(append_changelog_files.size(), 0u);
+    ASSERT_EQ(compact_table_files.size(), 0u);
+    ASSERT_EQ(compact_changelog_files.size(), 0u);
     ASSERT_EQ(append_table_index_files.size(), 0u);
+    ASSERT_EQ(compact_table_index_files.size(), 0u);
     ASSERT_EQ(append_table_files[0].Kind(), FileKind::Add());
     ASSERT_EQ(append_table_files[0].Bucket(), 0);
     ASSERT_EQ(append_table_files[0].TotalBuckets(), 10);

--- a/src/paimon/core/operation/metrics/commit_metrics.h
+++ b/src/paimon/core/operation/metrics/commit_metrics.h
@@ -21,7 +21,25 @@ namespace paimon {
 /// Metrics to measure a commit.
 class CommitMetrics {
  public:
+    static constexpr char LAST_COMMIT_DURATION[] = "lastCommitDuration";
     static constexpr char LAST_COMMIT_ATTEMPTS[] = "lastCommitAttempts";
+    static constexpr char LAST_TABLE_FILES_ADDED[] = "lastTableFilesAdded";
+    static constexpr char LAST_TABLE_FILES_DELETED[] = "lastTableFilesDeleted";
+    static constexpr char LAST_TABLE_FILES_APPENDED[] = "lastTableFilesAppended";
+    static constexpr char LAST_TABLE_FILES_COMMIT_COMPACTED[] = "lastTableFilesCommitCompacted";
+    static constexpr char LAST_CHANGELOG_FILES_APPENDED[] = "lastChangelogFilesAppended";
+    static constexpr char LAST_CHANGELOG_FILES_COMMIT_COMPACTED[] =
+        "lastChangelogFileCommitCompacted";
+    static constexpr char LAST_GENERATED_SNAPSHOTS[] = "lastGeneratedSnapshots";
+    static constexpr char LAST_DELTA_RECORDS_APPENDED[] = "lastDeltaRecordsAppended";
+    static constexpr char LAST_CHANGELOG_RECORDS_APPENDED[] = "lastChangelogRecordsAppended";
+    static constexpr char LAST_DELTA_RECORDS_COMMIT_COMPACTED[] = "lastDeltaRecordsCommitCompacted";
+    static constexpr char LAST_CHANGELOG_RECORDS_COMMIT_COMPACTED[] =
+        "lastChangelogRecordsCommitCompacted";
+    static constexpr char LAST_PARTITIONS_WRITTEN[] = "lastPartitionsWritten";
+    static constexpr char LAST_BUCKETS_WRITTEN[] = "lastBucketsWritten";
+    static constexpr char LAST_COMPACTION_INPUT_FILE_SIZE[] = "lastCompactionInputFileSize";
+    static constexpr char LAST_COMPACTION_OUTPUT_FILE_SIZE[] = "lastCompactionOutputFileSize";
 };
 
 }  // namespace paimon


### PR DESCRIPTION
### Purpose

Linked issue: close #65

Support commit metrics of `FileStoreCommitImpl` to align with [`CommitMetrics`](https://github.com/apache/paimon/blob/master/paimon-core/src/main/java/org/apache/paimon/operation/metrics/CommitMetrics.java) including:

- `lastCommitDuration`
- `lastCommitAttempts`
- `lastTableFilesAdded`
- `lastTableFilesDeleted`
- `lastTableFilesAppended`
- `lastTableFilesCommitCompacted`
- `lastChangelogFilesAppended`
- `lastChangelogFileCommitCompacted`
- `lastGeneratedSnapshots`
- `lastDeltaRecordsAppended`
- `lastChangelogRecordsAppended`
- `lastDeltaRecordsCommitCompacted`
- `lastChangelogRecordsCommitCompacted`
- `lastPartitionsWritten`
- `lastBucketsWritten`
- `lastCompactionInputFileSize`
- `lastCompactionOutputFileSize`

### Tests

CI.

### API and Format

No.

### Documentation

No.