### PR TITLE
fix(lfs): fix pre-commit check for large files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,7 @@ repos:
         exclude: (^test/test_data/.*|^third_party/.*)
       - id: check-yaml
       - id: check-added-large-files
+        args: ["--maxkb=5120", "--enforce-all"]
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v20.1.8


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #71 

Add a limit for large files push, if you want to add large files (> 5MB), you should use git lfs mode.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

<img width="1276" height="666" alt="image" src="https://github.com/user-attachments/assets/5e25ddf5-018e-4aee-95ea-8e8c81dd1cb6" />


### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->
