### PR TITLE
feat: support scan metrics of FileStoreScan to align with ScanMetrics

### DIFF
--- a/src/paimon/core/operation/file_store_commit_impl.cpp
+++ b/src/paimon/core/operation/file_store_commit_impl.cpp
@@ -404,7 +404,7 @@ Status FileStoreCommitImpl::Commit(const std::shared_ptr<ManifestCommittable>& c
         }
     }
     metrics_->SetCounter(CommitMetrics::LAST_COMMIT_DURATION,
-                         std::chrono::duration_cast<std::chrono::nanoseconds>(
+                         std::chrono::duration_cast<std::chrono::milliseconds>(
                              std::chrono::high_resolution_clock::now() - started)
                              .count());
     metrics_->SetCounter(CommitMetrics::LAST_COMMIT_ATTEMPTS, attempt);

--- a/src/paimon/core/operation/metrics/scan_metrics.h
+++ b/src/paimon/core/operation/metrics/scan_metrics.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026-present Alibaba Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace paimon {
+
+/// Metrics to measure scan operation.
+class ScanMetrics {
+ public:
+    static constexpr char LAST_SCAN_DURATION[] = "lastScanDuration";
+    static constexpr char LAST_SCANNED_SNAPSHOT_ID[] = "lastScannedSnapshotId";
+    static constexpr char LAST_SCANNED_MANIFESTS[] = "lastScannedManifests";
+    static constexpr char LAST_SCAN_SKIPPED_TABLE_FILES[] = "lastScanSkippedTableFiles";
+    static constexpr char LAST_SCAN_RESULTED_TABLE_FILES[] = "lastScanResultedTableFiles";
+};
+
+}  // namespace paimon


### PR DESCRIPTION
### Purpose

Linked issue: close #88 

Support scan metrics of `FileStoreScan` to align with [`ScanMetrics`](https://github.com/apache/paimon/blob/master/paimon-core/src/main/java/org/apache/paimon/operation/metrics/ScanMetrics.java) including:

- `lastScanDuration`
- `lastScannedSnapshotId`
- `lastScannedManifests`
- `lastScanSkippedTableFiles`
- `lastScanResultedTableFiles`

### Tests

`KeyValueFileStoreScanTest, TestMaxSequenceNumber`.

### API and Format

No.

### Documentation

No.