### PR TITLE
feat: introduce Like LeafFunction for Predicate

### DIFF
--- a/include/paimon/file_index/file_index_reader.h
+++ b/include/paimon/file_index/file_index_reader.h
@@ -60,6 +60,8 @@ class PAIMON_EXPORT FileIndexReader : public FunctionVisitor<std::shared_ptr<Fil
     Result<std::shared_ptr<FileIndexResult>> VisitEndsWith(const Literal& suffix) override;
 
     Result<std::shared_ptr<FileIndexResult>> VisitContains(const Literal& literal) override;
+
+    Result<std::shared_ptr<FileIndexResult>> VisitLike(const Literal& literal) override;
 };
 
 }  // namespace paimon

--- a/include/paimon/predicate/function_visitor.h
+++ b/include/paimon/predicate/function_visitor.h
@@ -71,5 +71,8 @@ class PAIMON_EXPORT FunctionVisitor {
 
     /// Evaluates whether string values contain the given substring.
     virtual Result<T> VisitContains(const Literal& literal) = 0;
+
+    /// Evaluates whether string values like the given string.
+    virtual Result<T> VisitLike(const Literal& literal) = 0;
 };
 }  // namespace paimon

--- a/src/paimon/common/file_index/empty/empty_file_index_reader.h
+++ b/src/paimon/common/file_index/empty/empty_file_index_reader.h
@@ -46,6 +46,9 @@ class EmptyFileIndexReader : public FileIndexReader {
     Result<std::shared_ptr<FileIndexResult>> VisitContains(const Literal& literal) override {
         return FileIndexResult::Skip();
     }
+    Result<std::shared_ptr<FileIndexResult>> VisitLike(const Literal& literal) override {
+        return FileIndexResult::Skip();
+    }
     Result<std::shared_ptr<FileIndexResult>> VisitLessThan(const Literal& literal) override {
         return FileIndexResult::Skip();
     }

--- a/src/paimon/common/file_index/empty/empty_file_index_reader_test.cpp
+++ b/src/paimon/common/file_index/empty/empty_file_index_reader_test.cpp
@@ -31,6 +31,7 @@ TEST(EmptyFileIndexReaderTest, TestSimple) {
     ASSERT_FALSE(reader.VisitStartsWith(lit0).value()->IsRemain().value());
     ASSERT_FALSE(reader.VisitEndsWith(lit0).value()->IsRemain().value());
     ASSERT_FALSE(reader.VisitContains(lit0).value()->IsRemain().value());
+    ASSERT_FALSE(reader.VisitLike(lit0).value()->IsRemain().value());
     ASSERT_FALSE(reader.VisitLessThan(lit0).value()->IsRemain().value());
     ASSERT_FALSE(reader.VisitGreaterOrEqual(lit0).value()->IsRemain().value());
     ASSERT_FALSE(reader.VisitLessOrEqual(lit0).value()->IsRemain().value());

--- a/src/paimon/common/file_index/file_index_reader.cpp
+++ b/src/paimon/common/file_index/file_index_reader.cpp
@@ -41,6 +41,10 @@ Result<std::shared_ptr<FileIndexResult>> FileIndexReader::VisitContains(const Li
     return FileIndexResult::Remain();
 }
 
+Result<std::shared_ptr<FileIndexResult>> FileIndexReader::VisitLike(const Literal& literal) {
+    return FileIndexResult::Remain();
+}
+
 Result<std::shared_ptr<FileIndexResult>> FileIndexReader::VisitLessThan(const Literal& literal) {
     return FileIndexResult::Remain();
 }

--- a/src/paimon/common/global_index/wrap/file_index_reader_wrapper.h
+++ b/src/paimon/common/global_index/wrap/file_index_reader_wrapper.h
@@ -114,6 +114,12 @@ class FileIndexReaderWrapper : public GlobalIndexReader {
         return transform_(file_index_result);
     }
 
+    Result<std::shared_ptr<GlobalIndexResult>> VisitLike(const Literal& literal) override {
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<FileIndexResult> file_index_result,
+                               reader_->VisitLike(literal));
+        return transform_(file_index_result);
+    }
+
     Result<std::shared_ptr<VectorSearchGlobalIndexResult>> VisitVectorSearch(
         const std::shared_ptr<VectorSearch>& vector_search) override {
         return Status::Invalid(

--- a/src/paimon/global_index/lucene/lucene_global_index.h
+++ b/src/paimon/global_index/lucene/lucene_global_index.h
@@ -158,6 +158,10 @@ class LuceneGlobalIndexReader : public GlobalIndexReader {
         return CreateAllResult();
     }
 
+    Result<std::shared_ptr<GlobalIndexResult>> VisitLike(const Literal& literal) override {
+        return CreateAllResult();
+    }
+
     Result<std::shared_ptr<VectorSearchGlobalIndexResult>> VisitVectorSearch(
         const std::shared_ptr<VectorSearch>& vector_search) override {
         return Status::Invalid(

--- a/src/paimon/global_index/lumina/lumina_global_index.h
+++ b/src/paimon/global_index/lumina/lumina_global_index.h
@@ -183,6 +183,10 @@ class LuminaIndexReader : public GlobalIndexReader {
         return BitmapGlobalIndexResult::FromRanges({Range(0, range_end_)});
     }
 
+    Result<std::shared_ptr<GlobalIndexResult>> VisitLike(const Literal& literal) override {
+        return BitmapGlobalIndexResult::FromRanges({Range(0, range_end_)});
+    }
+
     bool IsThreadSafe() const override {
         return true;
     }


### PR DESCRIPTION
### Purpose

Linked issue: close #108 

`FunctionVisitor` introduces `Like` LeafFunction for `Predicate`, which aligns with https://github.com/apache/paimon/pull/6776.

### Tests

`EmptyFileIndexReaderTest, TestSimple`

### API and Format

Introduce `Like` predicate.

### Documentation

No.