### PR TITLE
fix(cmake): fix factory registry in example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -26,6 +26,8 @@ add_executable(clean_demo clean_demo.cpp)
 
 include_directories(${PAIMON_INCLUDE_DIRS})
 
+set(CMAKE_EXE_LINKER_FLAGS "-Wl,--no-as-needed ${CMAKE_EXE_LINKER_FLAGS}")
+
 target_link_libraries(read_write_demo
                       PRIVATE arrow_shared
                               paimon_shared


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

Added -Wl,--no-as-needed to CMAKE_EXE_LINKER_FLAGS to prevent linker from dropping shared library dependencies that are specified via target_link_libraries but not directly referenced in the code. This ensures expected shared objects show up in the executable’s ldd output.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->
