### PR TITLE
fix: fix std::string_view cast for clang-tidy-check

### DIFF
--- a/src/paimon/common/data/binary_row_test.cpp
+++ b/src/paimon/common/data/binary_row_test.cpp
@@ -539,8 +539,8 @@ TEST_F(BinaryRowTest, TestBinaryRowSerializer) {
         test_string1 += static_cast<char>(paimon::test::RandomNumber(0, 25) + 'a');
         test_string2 += static_cast<char>(paimon::test::RandomNumber(0, 25) + 'a');
     }
-    writer.WriteStringView(1, std::string_view(test_string1));
-    writer.WriteStringView(2, std::string_view(test_string2));
+    writer.WriteStringView(1, std::string_view{test_string1});
+    writer.WriteStringView(2, std::string_view{test_string2});
     writer.Complete();
 
     BinaryRowSerializer row_serializer(3, pool);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
