### PR TITLE
refactor(lookup): Decouple RemoteLookupFileManager from LookupLevels and refactor Levels callback lifecycle

### DIFF
--- a/src/paimon/core/mergetree/compact/changelog_merge_tree_rewriter.cpp
+++ b/src/paimon/core/mergetree/compact/changelog_merge_tree_rewriter.cpp
@@ -24,12 +24,12 @@ ChangelogMergeTreeRewriter::ChangelogMergeTreeRewriter(
     const std::shared_ptr<FileStorePathFactoryCache>& path_factory_cache,
     std::unique_ptr<MergeFileSplitRead>&& merge_file_split_read,
     MergeFunctionWrapperFactory merge_function_wrapper_factory,
-    const std::shared_ptr<MemoryPool>& pool,
-    const std::shared_ptr<CancellationController>& cancellation_controller)
+    const std::shared_ptr<CancellationController>& cancellation_controller,
+    const std::shared_ptr<MemoryPool>& pool)
     : MergeTreeCompactRewriter(
           partition, bucket, schema_id, trimmed_primary_keys, options, data_schema, write_schema,
           std::move(dv_factory), path_factory_cache, std::move(merge_file_split_read),
-          std::move(merge_function_wrapper_factory), pool, cancellation_controller),
+          std::move(merge_function_wrapper_factory), cancellation_controller, pool),
       max_level_(max_level),
       force_drop_delete_(force_drop_delete) {}
 

--- a/src/paimon/core/mergetree/compact/changelog_merge_tree_rewriter.h
+++ b/src/paimon/core/mergetree/compact/changelog_merge_tree_rewriter.h
@@ -40,8 +40,8 @@ class ChangelogMergeTreeRewriter : public MergeTreeCompactRewriter {
         const std::shared_ptr<FileStorePathFactoryCache>& path_factory_cache,
         std::unique_ptr<MergeFileSplitRead>&& merge_file_split_read,
         MergeFunctionWrapperFactory merge_function_wrapper_factory,
-        const std::shared_ptr<MemoryPool>& pool,
-        const std::shared_ptr<CancellationController>& cancellation_controller);
+        const std::shared_ptr<CancellationController>& cancellation_controller,
+        const std::shared_ptr<MemoryPool>& pool);
 
     struct UpgradeStrategy {
         static UpgradeStrategy NoChangelogNoRewrite() {

--- a/src/paimon/core/mergetree/compact/lookup_merge_tree_compact_rewriter.cpp
+++ b/src/paimon/core/mergetree/compact/lookup_merge_tree_compact_rewriter.cpp
@@ -34,18 +34,18 @@ LookupMergeTreeCompactRewriter<T>::LookupMergeTreeCompactRewriter(
     const std::shared_ptr<FileStorePathFactoryCache>& path_factory_cache,
     std::unique_ptr<MergeFileSplitRead>&& merge_file_split_read,
     MergeFunctionWrapperFactory merge_function_wrapper_factory,
-    const std::shared_ptr<MemoryPool>& pool,
     const std::shared_ptr<CancellationController>& cancellation_controller,
-    std::unique_ptr<RemoteLookupFileManager<T>>&& remote_lookup_file_manager)
+    const std::shared_ptr<RemoteLookupFileManager>& remote_lookup_file_manager,
+    const std::shared_ptr<MemoryPool>& pool)
     : ChangelogMergeTreeRewriter(
           max_level, /*force_drop_delete=*/dv_maintainer != nullptr, partition, bucket, schema_id,
           trimmed_primary_keys, options, data_schema, write_schema,
           DeletionVector::CreateFactory(dv_maintainer), path_factory_cache,
-          std::move(merge_file_split_read), std::move(merge_function_wrapper_factory), pool,
-          cancellation_controller),
+          std::move(merge_file_split_read), std::move(merge_function_wrapper_factory),
+          cancellation_controller, pool),
       lookup_levels_(std::move(lookup_levels)),
       dv_maintainer_(dv_maintainer),
-      remote_lookup_file_manager_(std::move(remote_lookup_file_manager)) {}
+      remote_lookup_file_manager_(remote_lookup_file_manager) {}
 
 template <typename T>
 Result<std::unique_ptr<LookupMergeTreeCompactRewriter<T>>>
@@ -55,9 +55,10 @@ LookupMergeTreeCompactRewriter<T>::Create(
     MergeFunctionWrapperFactory merge_function_wrapper_factory, int32_t bucket,
     const BinaryRow& partition, const std::shared_ptr<TableSchema>& table_schema,
     const std::shared_ptr<FileStorePathFactoryCache>& path_factory_cache,
-    const CoreOptions& options, const std::shared_ptr<MemoryPool>& pool,
+    const CoreOptions& options,
     const std::shared_ptr<CancellationController>& cancellation_controller,
-    std::unique_ptr<RemoteLookupFileManager<T>>&& remote_lookup_file_manager) {
+    const std::shared_ptr<RemoteLookupFileManager>& remote_lookup_file_manager,
+    const std::shared_ptr<MemoryPool>& pool) {
     PAIMON_ASSIGN_OR_RAISE(std::vector<std::string> trimmed_primary_keys,
                            table_schema->TrimmedPrimaryKeys());
     auto data_schema = DataField::ConvertDataFieldsToArrowSchema(table_schema->Fields());
@@ -88,8 +89,8 @@ LookupMergeTreeCompactRewriter<T>::Create(
     return std::unique_ptr<LookupMergeTreeCompactRewriter>(new LookupMergeTreeCompactRewriter(
         std::move(lookup_levels), dv_maintainer, max_level, partition, bucket, table_schema->Id(),
         trimmed_primary_keys, options, data_schema, write_schema, path_factory_cache,
-        std::move(merge_file_split_read), std::move(merge_function_wrapper_factory), pool,
-        cancellation_controller, std::move(remote_lookup_file_manager)));
+        std::move(merge_file_split_read), std::move(merge_function_wrapper_factory),
+        cancellation_controller, remote_lookup_file_manager, pool));
 }
 
 template <typename T>
@@ -182,8 +183,9 @@ LookupMergeTreeCompactRewriter<T>::NotifyRewriteCompactAfter(
     std::vector<std::shared_ptr<DataFileMeta>> result;
     result.reserve(files.size());
     for (const auto& file : files) {
-        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<DataFileMeta> new_meta,
-                               remote_lookup_file_manager_->GenRemoteLookupFile(file));
+        PAIMON_ASSIGN_OR_RAISE(
+            std::shared_ptr<DataFileMeta> new_meta,
+            remote_lookup_file_manager_->GenRemoteLookupFile(file, lookup_levels_.get()));
         result.push_back(std::move(new_meta));
     }
     return result;

--- a/src/paimon/core/mergetree/compact/lookup_merge_tree_compact_rewriter.h
+++ b/src/paimon/core/mergetree/compact/lookup_merge_tree_compact_rewriter.h
@@ -36,9 +36,10 @@ class LookupMergeTreeCompactRewriter : public ChangelogMergeTreeRewriter {
         MergeFunctionWrapperFactory merge_function_wrapper_factory, int32_t bucket,
         const BinaryRow& partition, const std::shared_ptr<TableSchema>& table_schema,
         const std::shared_ptr<FileStorePathFactoryCache>& path_factory_cache,
-        const CoreOptions& options, const std::shared_ptr<MemoryPool>& pool,
+        const CoreOptions& options,
         const std::shared_ptr<CancellationController>& cancellation_controller,
-        std::unique_ptr<RemoteLookupFileManager<T>>&& remote_lookup_file_manager);
+        const std::shared_ptr<RemoteLookupFileManager>& remote_lookup_file_manager,
+        const std::shared_ptr<MemoryPool>& pool);
 
     Status Close() override {
         return lookup_levels_->Close();
@@ -66,9 +67,9 @@ class LookupMergeTreeCompactRewriter : public ChangelogMergeTreeRewriter {
         const std::shared_ptr<FileStorePathFactoryCache>& path_factory_cache,
         std::unique_ptr<MergeFileSplitRead>&& merge_file_split_read,
         MergeFunctionWrapperFactory merge_function_wrapper_factory,
-        const std::shared_ptr<MemoryPool>& pool,
         const std::shared_ptr<CancellationController>& cancellation_controller,
-        std::unique_ptr<RemoteLookupFileManager<T>>&& remote_lookup_file_manager);
+        const std::shared_ptr<RemoteLookupFileManager>& remote_lookup_file_manager,
+        const std::shared_ptr<MemoryPool>& pool);
 
     bool RewriteChangelog(int32_t output_level, bool drop_delete,
                           const std::vector<std::vector<SortedRun>>& sections) const override {
@@ -87,6 +88,6 @@ class LookupMergeTreeCompactRewriter : public ChangelogMergeTreeRewriter {
  private:
     std::unique_ptr<LookupLevels<T>> lookup_levels_;
     std::shared_ptr<BucketedDvMaintainer> dv_maintainer_;
-    std::unique_ptr<RemoteLookupFileManager<T>> remote_lookup_file_manager_;
+    std::shared_ptr<RemoteLookupFileManager> remote_lookup_file_manager_;
 };
 }  // namespace paimon

--- a/src/paimon/core/mergetree/compact/lookup_merge_tree_compact_rewriter_test.cpp
+++ b/src/paimon/core/mergetree/compact/lookup_merge_tree_compact_rewriter_test.cpp
@@ -160,8 +160,8 @@ class LookupMergeTreeCompactRewriterTest : public testing::Test {
             /*max_level=*/5, std::move(lookup_levels), /*dv_maintainer=*/nullptr,
             std::move(merge_function_wrapper_factory),
             /*bucket=*/0,
-            /*partition=*/BinaryRow::EmptyRow(), table_schema, path_factory_cache, options, pool_,
-            cancellation_controller, /*remote_lookup_file_manager=*/nullptr);
+            /*partition=*/BinaryRow::EmptyRow(), table_schema, path_factory_cache, options,
+            cancellation_controller, /*remote_lookup_file_manager=*/nullptr, pool_);
     }
 
     Result<std::unique_ptr<LookupMergeTreeCompactRewriter<KeyValue>>>
@@ -190,8 +190,8 @@ class LookupMergeTreeCompactRewriterTest : public testing::Test {
         return LookupMergeTreeCompactRewriter<KeyValue>::Create(
             /*max_level=*/5, std::move(lookup_levels), /*dv_maintainer=*/nullptr,
             std::move(merge_function_wrapper_factory), /*bucket=*/0,
-            /*partition=*/BinaryRow::EmptyRow(), table_schema, path_factory_cache, options, pool_,
-            cancellation_controller, /*remote_lookup_file_manager=*/nullptr);
+            /*partition=*/BinaryRow::EmptyRow(), table_schema, path_factory_cache, options,
+            cancellation_controller, /*remote_lookup_file_manager=*/nullptr, pool_);
     }
 
     Result<std::unique_ptr<LookupMergeTreeCompactRewriter<FilePosition>>>
@@ -225,8 +225,8 @@ class LookupMergeTreeCompactRewriterTest : public testing::Test {
         return LookupMergeTreeCompactRewriter<FilePosition>::Create(
             /*max_level=*/5, std::move(lookup_levels), dv_maintainer,
             std::move(merge_function_wrapper_factory), /*bucket=*/0,
-            /*partition=*/BinaryRow::EmptyRow(), table_schema, path_factory_cache, options, pool_,
-            cancellation_controller, /*remote_lookup_file_manager=*/nullptr);
+            /*partition=*/BinaryRow::EmptyRow(), table_schema, path_factory_cache, options,
+            cancellation_controller, /*remote_lookup_file_manager=*/nullptr, pool_);
     }
 
     Result<std::unique_ptr<LookupMergeTreeCompactRewriter<PositionedKeyValue>>>
@@ -234,7 +234,7 @@ class LookupMergeTreeCompactRewriterTest : public testing::Test {
         const std::string& table_path, const std::shared_ptr<TableSchema>& table_schema,
         const CoreOptions& options,
         std::unique_ptr<LookupLevels<PositionedKeyValue>>&& lookup_levels,
-        std::unique_ptr<RemoteLookupFileManager<PositionedKeyValue>>&& remote_lookup_file_manager =
+        const std::shared_ptr<RemoteLookupFileManager>& remote_lookup_file_manager =
             nullptr) const {
         auto path_factory_cache =
             std::make_shared<FileStorePathFactoryCache>(table_path, table_schema, options, pool_);
@@ -267,8 +267,8 @@ class LookupMergeTreeCompactRewriterTest : public testing::Test {
         return LookupMergeTreeCompactRewriter<PositionedKeyValue>::Create(
             /*max_level=*/5, std::move(lookup_levels), dv_maintainer,
             std::move(merge_function_wrapper_factory), /*bucket=*/0,
-            /*partition=*/BinaryRow::EmptyRow(), table_schema, path_factory_cache, options, pool_,
-            cancellation_controller, std::move(remote_lookup_file_manager));
+            /*partition=*/BinaryRow::EmptyRow(), table_schema, path_factory_cache, options,
+            cancellation_controller, remote_lookup_file_manager, pool_);
     }
 
     void CheckResult(const std::string& compact_file_name,
@@ -313,7 +313,9 @@ class LookupMergeTreeCompactRewriterTest : public testing::Test {
     Result<std::unique_ptr<LookupLevels<T>>> CreateLookupLevels(
         const std::string& table_path, const std::shared_ptr<TableSchema>& table_schema,
         const std::shared_ptr<typename PersistProcessor<T>::Factory>& processor_factory,
-        const std::vector<std::shared_ptr<DataFileMeta>>& files) const {
+        const std::vector<std::shared_ptr<DataFileMeta>>& files,
+        const std::shared_ptr<RemoteLookupFileManager>& remote_lookup_file_manager =
+            nullptr) const {
         auto schema_manager = std::make_shared<SchemaManager>(fs_, table_path);
         PAIMON_ASSIGN_OR_RAISE(auto key_comparator, CreateKeyComparator());
         PAIMON_ASSIGN_OR_RAISE(auto levels,
@@ -333,7 +335,7 @@ class LookupMergeTreeCompactRewriterTest : public testing::Test {
             fs_, BinaryRow::EmptyRow(), /*bucket=*/0, options, schema_manager,
             std::move(io_manager), path_factory, table_schema, std::move(levels),
             DeletionVector::CreateFactory(/*dv_maintainer=*/nullptr), processor_factory,
-            serializer_factory, lookup_store_factory, pool_);
+            serializer_factory, lookup_store_factory, remote_lookup_file_manager, pool_);
     }
 
     Result<std::vector<std::vector<SortedRun>>> GenerateSortedRuns(
@@ -350,27 +352,26 @@ class LookupMergeTreeCompactRewriterTest : public testing::Test {
         const CoreOptions& core_options,
         const std::vector<std::shared_ptr<DataFileMeta>>& total_files,
         const std::vector<std::shared_ptr<DataFileMeta>>& compact_files, bool rewrite) const {
-        auto processor_factory =
-            std::make_shared<PersistValueAndPosProcessor::Factory>(arrow_schema_);
-        EXPECT_OK_AND_ASSIGN(auto lookup_levels,
-                             CreateLookupLevels<PositionedKeyValue>(
-                                 table_path, table_schema, processor_factory, total_files));
-
         EXPECT_OK_AND_ASSIGN(auto file_store_path_factory,
                              CreateFileStorePathFactory(table_path, core_options));
         EXPECT_OK_AND_ASSIGN(
             auto data_file_path_factory,
             file_store_path_factory->CreateDataFilePathFactory(BinaryRow::EmptyRow(),
                                                                /*bucket=*/0));
-        auto remote_lookup_file_manager =
-            std::make_unique<RemoteLookupFileManager<PositionedKeyValue>>(
-                /*level_threshold=*/0, data_file_path_factory, fs_, pool_, lookup_levels.get());
+        auto remote_lookup_file_manager = std::make_shared<RemoteLookupFileManager>(
+            /*level_threshold=*/0, data_file_path_factory, fs_, pool_);
+
+        auto processor_factory =
+            std::make_shared<PersistValueAndPosProcessor::Factory>(arrow_schema_);
+        EXPECT_OK_AND_ASSIGN(auto lookup_levels, CreateLookupLevels<PositionedKeyValue>(
+                                                     table_path, table_schema, processor_factory,
+                                                     total_files, remote_lookup_file_manager));
 
         // Create rewriter with remote lookup file manager
         EXPECT_OK_AND_ASSIGN(auto rewriter,
                              CreateCompactRewriterForPositionedKeyValue(
                                  table_path, table_schema, core_options, std::move(lookup_levels),
-                                 std::move(remote_lookup_file_manager)));
+                                 remote_lookup_file_manager));
         CompactResult result;
         if (rewrite) {
             EXPECT_OK_AND_ASSIGN(auto runs, GenerateSortedRuns(compact_files));
@@ -1070,8 +1071,8 @@ TEST_F(LookupMergeTreeCompactRewriterTest, TestGenerateUpgradeStrategy) {
             /*max_level=*/5, BinaryRow::EmptyRow(), /*bucket=*/0, /*schema_id=*/0,
             /*trimmed_primary_keys=*/{"key"}, core_options, /*data_schema=*/nullptr,
             /*write_schema=*/nullptr, /*path_factory_cache=*/nullptr,
-            /*merge_file_split_read=*/nullptr, /*merge_function_wrapper_factory=*/nullptr, pool_,
-            cancellation_controller, /*remote_lookup_file_manager=*/nullptr);
+            /*merge_file_split_read=*/nullptr, /*merge_function_wrapper_factory=*/nullptr,
+            cancellation_controller, /*remote_lookup_file_manager=*/nullptr, pool_);
         auto file = create_meta(/*level=*/1, /*delete_row_count=*/std::nullopt);
         ASSERT_EQ(ChangelogMergeTreeRewriter::UpgradeStrategy::NoChangelogNoRewrite(),
                   rewriter.GenerateUpgradeStrategy(/*output_level=*/2, file));
@@ -1085,8 +1086,8 @@ TEST_F(LookupMergeTreeCompactRewriterTest, TestGenerateUpgradeStrategy) {
             /*max_level=*/5, BinaryRow::EmptyRow(), /*bucket=*/0, /*schema_id=*/0,
             /*trimmed_primary_keys=*/{"key"}, core_options, /*data_schema=*/nullptr,
             /*write_schema=*/nullptr, /*path_factory_cache=*/nullptr,
-            /*merge_file_split_read=*/nullptr, /*merge_function_wrapper_factory=*/nullptr, pool_,
-            cancellation_controller, /*remote_lookup_file_manager=*/nullptr);
+            /*merge_file_split_read=*/nullptr, /*merge_function_wrapper_factory=*/nullptr,
+            cancellation_controller, /*remote_lookup_file_manager=*/nullptr, pool_);
         auto file = create_meta(/*level=*/0, /*delete_row_count=*/std::nullopt);
         ASSERT_EQ(ChangelogMergeTreeRewriter::UpgradeStrategy::ChangelogWithRewrite(),
                   rewriter.GenerateUpgradeStrategy(/*output_level=*/5, file));
@@ -1104,8 +1105,8 @@ TEST_F(LookupMergeTreeCompactRewriterTest, TestGenerateUpgradeStrategy) {
             /*max_level=*/5, BinaryRow::EmptyRow(), /*bucket=*/0, /*schema_id=*/0,
             /*trimmed_primary_keys=*/{"key"}, core_options, /*data_schema=*/nullptr,
             /*write_schema=*/nullptr, /*path_factory_cache=*/nullptr,
-            /*merge_file_split_read=*/nullptr, /*merge_function_wrapper_factory=*/nullptr, pool_,
-            cancellation_controller, /*remote_lookup_file_manager=*/nullptr);
+            /*merge_file_split_read=*/nullptr, /*merge_function_wrapper_factory=*/nullptr,
+            cancellation_controller, /*remote_lookup_file_manager=*/nullptr, pool_);
         auto file = create_meta(/*level=*/0, /*delete_row_count=*/1);
         ASSERT_EQ(ChangelogMergeTreeRewriter::UpgradeStrategy::ChangelogWithRewrite(),
                   rewriter.GenerateUpgradeStrategy(/*output_level=*/2, file));
@@ -1119,8 +1120,8 @@ TEST_F(LookupMergeTreeCompactRewriterTest, TestGenerateUpgradeStrategy) {
             /*max_level=*/5, BinaryRow::EmptyRow(), /*bucket=*/0, /*schema_id=*/0,
             /*trimmed_primary_keys=*/{"key"}, core_options, /*data_schema=*/nullptr,
             /*write_schema=*/nullptr, /*path_factory_cache=*/nullptr,
-            /*merge_file_split_read=*/nullptr, /*merge_function_wrapper_factory=*/nullptr, pool_,
-            cancellation_controller, /*remote_lookup_file_manager=*/nullptr);
+            /*merge_file_split_read=*/nullptr, /*merge_function_wrapper_factory=*/nullptr,
+            cancellation_controller, /*remote_lookup_file_manager=*/nullptr, pool_);
         auto file = create_meta(/*level=*/0, /*delete_row_count=*/std::nullopt);
         ASSERT_EQ(ChangelogMergeTreeRewriter::UpgradeStrategy::ChangelogNoRewrite(),
                   rewriter.GenerateUpgradeStrategy(/*output_level=*/5, file));
@@ -1134,8 +1135,8 @@ TEST_F(LookupMergeTreeCompactRewriterTest, TestGenerateUpgradeStrategy) {
             /*max_level=*/5, BinaryRow::EmptyRow(), /*bucket=*/0, /*schema_id=*/0,
             /*trimmed_primary_keys=*/{"key"}, core_options, /*data_schema=*/nullptr,
             /*write_schema=*/nullptr, /*path_factory_cache=*/nullptr,
-            /*merge_file_split_read=*/nullptr, /*merge_function_wrapper_factory=*/nullptr, pool_,
-            cancellation_controller, /*remote_lookup_file_manager=*/nullptr);
+            /*merge_file_split_read=*/nullptr, /*merge_function_wrapper_factory=*/nullptr,
+            cancellation_controller, /*remote_lookup_file_manager=*/nullptr, pool_);
         auto file = create_meta(/*level=*/0, /*delete_row_count=*/std::nullopt);
         ASSERT_EQ(ChangelogMergeTreeRewriter::UpgradeStrategy::ChangelogNoRewrite(),
                   rewriter.GenerateUpgradeStrategy(/*output_level=*/2, file));
@@ -1150,8 +1151,8 @@ TEST_F(LookupMergeTreeCompactRewriterTest, TestGenerateUpgradeStrategy) {
             /*max_level=*/5, BinaryRow::EmptyRow(), /*bucket=*/0, /*schema_id=*/0,
             /*trimmed_primary_keys=*/{"key"}, core_options, /*data_schema=*/nullptr,
             /*write_schema=*/nullptr, /*path_factory_cache=*/nullptr,
-            /*merge_file_split_read=*/nullptr, /*merge_function_wrapper_factory=*/nullptr, pool_,
-            cancellation_controller, /*remote_lookup_file_manager=*/nullptr);
+            /*merge_file_split_read=*/nullptr, /*merge_function_wrapper_factory=*/nullptr,
+            cancellation_controller, /*remote_lookup_file_manager=*/nullptr, pool_);
         auto file = create_meta(/*level=*/0, /*delete_row_count=*/std::nullopt);
         ASSERT_EQ(ChangelogMergeTreeRewriter::UpgradeStrategy::ChangelogWithRewrite(),
                   rewriter.GenerateUpgradeStrategy(/*output_level=*/2, file));

--- a/src/paimon/core/mergetree/compact/merge_tree_compact_manager_factory.cpp
+++ b/src/paimon/core/mergetree/compact/merge_tree_compact_manager_factory.cpp
@@ -165,14 +165,14 @@ Result<std::shared_ptr<CompactRewriter>> MergeTreeCompactManagerFactory::CreateL
     const LookupStrategy& lookup_strategy,
     const std::shared_ptr<FileStorePathFactoryCache>& path_factory_cache,
     const std::shared_ptr<CancellationController>& cancellation_controller) const {
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<RemoteLookupFileManager> remote_lookup_file_manager,
+                           CreateRemoteLookupFileManager(partition, bucket));
     if (lookup_strategy.is_first_row) {
         if (options_.DeletionVectorsEnabled()) {
             return Status::Invalid(
                 "First row merge engine does not need deletion vectors because there is no "
                 "deletion of old data in this merge engine.");
         }
-        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<RemoteLookupFileManager> remote_lookup_file_manager,
-                               CreateRemoteLookupFileManager(partition, bucket));
 
         auto processor_factory = std::make_shared<PersistEmptyProcessor::Factory>();
         PAIMON_ASSIGN_OR_RAISE(
@@ -200,14 +200,14 @@ Result<std::shared_ptr<CompactRewriter>> MergeTreeCompactManagerFactory::CreateL
     }
 
     if (lookup_strategy.deletion_vector) {
-        return CreateLookupRewriterWithDeletionVector(partition, bucket, levels, dv_maintainer,
-                                                      max_level, lookup_strategy,
-                                                      path_factory_cache, cancellation_controller);
+        return CreateLookupRewriterWithDeletionVector(
+            partition, bucket, levels, dv_maintainer, max_level, lookup_strategy,
+            path_factory_cache, cancellation_controller, remote_lookup_file_manager);
     }
 
-    return CreateLookupRewriterWithoutDeletionVector(partition, bucket, levels, dv_maintainer,
-                                                     max_level, lookup_strategy, path_factory_cache,
-                                                     cancellation_controller);
+    return CreateLookupRewriterWithoutDeletionVector(
+        partition, bucket, levels, dv_maintainer, max_level, lookup_strategy, path_factory_cache,
+        cancellation_controller, remote_lookup_file_manager);
 }
 
 Result<std::shared_ptr<CompactRewriter>>
@@ -216,15 +216,13 @@ MergeTreeCompactManagerFactory::CreateLookupRewriterWithDeletionVector(
     const std::shared_ptr<BucketedDvMaintainer>& dv_maintainer, int32_t max_level,
     const LookupStrategy& lookup_strategy,
     const std::shared_ptr<FileStorePathFactoryCache>& path_factory_cache,
-    const std::shared_ptr<CancellationController>& cancellation_controller) const {
+    const std::shared_ptr<CancellationController>& cancellation_controller,
+    const std::shared_ptr<RemoteLookupFileManager>& remote_lookup_file_manager) const {
     auto merge_engine = options_.GetMergeEngine();
     PAIMON_ASSIGN_OR_RAISE(std::vector<std::string> trimmed_primary_keys,
                            table_schema_->TrimmedPrimaryKeys());
     if (lookup_strategy.produce_changelog || merge_engine != MergeEngine::DEDUPLICATE ||
         !options_.GetSequenceField().empty()) {
-        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<RemoteLookupFileManager> remote_lookup_file_manager,
-                               CreateRemoteLookupFileManager(partition, bucket));
-
         auto processor_factory = std::make_shared<PersistValueAndPosProcessor::Factory>(schema_);
         PAIMON_ASSIGN_OR_RAISE(
             std::unique_ptr<LookupLevels<PositionedKeyValue>> lookup_levels,
@@ -259,9 +257,6 @@ MergeTreeCompactManagerFactory::CreateLookupRewriterWithDeletionVector(
                 pool_));
         return std::shared_ptr<CompactRewriter>(std::move(rewriter));
     }
-    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<RemoteLookupFileManager> remote_lookup_file_manager,
-                           CreateRemoteLookupFileManager(partition, bucket));
-
     auto processor_factory = std::make_shared<PersistPositionProcessor::Factory>();
     PAIMON_ASSIGN_OR_RAISE(
         std::unique_ptr<LookupLevels<FilePosition>> lookup_levels,
@@ -301,12 +296,10 @@ MergeTreeCompactManagerFactory::CreateLookupRewriterWithoutDeletionVector(
     const std::shared_ptr<BucketedDvMaintainer>& dv_maintainer, int32_t max_level,
     const LookupStrategy& lookup_strategy,
     const std::shared_ptr<FileStorePathFactoryCache>& path_factory_cache,
-    const std::shared_ptr<CancellationController>& cancellation_controller) const {
+    const std::shared_ptr<CancellationController>& cancellation_controller,
+    const std::shared_ptr<RemoteLookupFileManager>& remote_lookup_file_manager) const {
     PAIMON_ASSIGN_OR_RAISE(std::vector<std::string> trimmed_primary_keys,
                            table_schema_->TrimmedPrimaryKeys());
-    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<RemoteLookupFileManager> remote_lookup_file_manager,
-                           CreateRemoteLookupFileManager(partition, bucket));
-
     auto processor_factory = std::make_shared<PersistValueProcessor::Factory>(schema_);
     PAIMON_ASSIGN_OR_RAISE(
         std::unique_ptr<LookupLevels<KeyValue>> lookup_levels,

--- a/src/paimon/core/mergetree/compact/merge_tree_compact_manager_factory.cpp
+++ b/src/paimon/core/mergetree/compact/merge_tree_compact_manager_factory.cpp
@@ -58,6 +58,7 @@ Result<std::unique_ptr<LookupLevels<T>>> CreateLookupLevelsInternal(
     const std::shared_ptr<Levels>& levels,
     const std::shared_ptr<typename PersistProcessor<T>::Factory>& processor_factory,
     const std::shared_ptr<BucketedDvMaintainer>& dv_maintainer,
+    const std::shared_ptr<RemoteLookupFileManager>& remote_lookup_file_manager,
     const std::shared_ptr<MemoryPool>& pool) {
     if (io_manager == nullptr) {
         return Status::Invalid("Can not use lookup, there is no temp disk directory to use.");
@@ -71,10 +72,10 @@ Result<std::unique_ptr<LookupLevels<T>>> CreateLookupLevelsInternal(
         LookupStoreFactory::Create(lookup_key_comparator, cache_manager, options));
     auto dv_factory = DeletionVector::CreateFactory(dv_maintainer);
     auto serializer_factory = std::make_shared<DefaultLookupSerializerFactory>();
-    return LookupLevels<T>::Create(options.GetFileSystem(), partition, bucket, options,
-                                   schema_manager, io_manager, file_store_path_factory,
-                                   table_schema, levels, dv_factory, processor_factory,
-                                   serializer_factory, lookup_store_factory, pool);
+    return LookupLevels<T>::Create(
+        options.GetFileSystem(), partition, bucket, options, schema_manager, io_manager,
+        file_store_path_factory, table_schema, levels, dv_factory, processor_factory,
+        serializer_factory, lookup_store_factory, remote_lookup_file_manager, pool);
 }
 
 }  // namespace
@@ -154,7 +155,7 @@ Result<std::shared_ptr<CompactRewriter>> MergeTreeCompactManagerFactory::CreateR
     PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<MergeTreeCompactRewriter> rewriter,
                            MergeTreeCompactRewriter::Create(
                                bucket, partition, table_schema_, dv_factory, path_factory_cache,
-                               options_, pool_, cancellation_controller));
+                               options_, cancellation_controller, pool_));
     return std::shared_ptr<CompactRewriter>(std::move(rewriter));
 }
 
@@ -170,12 +171,16 @@ Result<std::shared_ptr<CompactRewriter>> MergeTreeCompactManagerFactory::CreateL
                 "First row merge engine does not need deletion vectors because there is no "
                 "deletion of old data in this merge engine.");
         }
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<RemoteLookupFileManager> remote_lookup_file_manager,
+                               CreateRemoteLookupFileManager(partition, bucket));
+
         auto processor_factory = std::make_shared<PersistEmptyProcessor::Factory>();
         PAIMON_ASSIGN_OR_RAISE(
             std::unique_ptr<LookupLevels<bool>> lookup_levels,
-            CreateLookupLevelsInternal<bool>(
-                options_, schema_manager_, io_manager_, cache_manager_, file_store_path_factory_,
-                table_schema_, partition, bucket, levels, processor_factory, dv_maintainer, pool_));
+            CreateLookupLevelsInternal<bool>(options_, schema_manager_, io_manager_, cache_manager_,
+                                             file_store_path_factory_, table_schema_, partition,
+                                             bucket, levels, processor_factory, dv_maintainer,
+                                             remote_lookup_file_manager, pool_));
         auto merge_function_wrapper_factory =
             [lookup_levels_ptr = lookup_levels.get(), ignore_delete = options_.IgnoreDelete()](
                 int32_t output_level) -> Result<std::shared_ptr<MergeFunctionWrapper<KeyValue>>> {
@@ -185,15 +190,12 @@ Result<std::shared_ptr<CompactRewriter>> MergeTreeCompactManagerFactory::CreateL
                     lookup_levels_ptr);
             return merge_function_wrapper;
         };
-        PAIMON_ASSIGN_OR_RAISE(
-            std::unique_ptr<RemoteLookupFileManager<bool>> remote_lookup_file_manager,
-            CreateRemoteLookupFileManager<bool>(partition, bucket, lookup_levels.get()));
         PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<LookupMergeTreeCompactRewriter<bool>> rewriter,
                                LookupMergeTreeCompactRewriter<bool>::Create(
                                    max_level, std::move(lookup_levels), dv_maintainer,
                                    std::move(merge_function_wrapper_factory), bucket, partition,
-                                   table_schema_, path_factory_cache, options_, pool_,
-                                   cancellation_controller, std::move(remote_lookup_file_manager)));
+                                   table_schema_, path_factory_cache, options_,
+                                   cancellation_controller, remote_lookup_file_manager, pool_));
         return std::shared_ptr<CompactRewriter>(std::move(rewriter));
     }
 
@@ -220,12 +222,16 @@ MergeTreeCompactManagerFactory::CreateLookupRewriterWithDeletionVector(
                            table_schema_->TrimmedPrimaryKeys());
     if (lookup_strategy.produce_changelog || merge_engine != MergeEngine::DEDUPLICATE ||
         !options_.GetSequenceField().empty()) {
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<RemoteLookupFileManager> remote_lookup_file_manager,
+                               CreateRemoteLookupFileManager(partition, bucket));
+
         auto processor_factory = std::make_shared<PersistValueAndPosProcessor::Factory>(schema_);
         PAIMON_ASSIGN_OR_RAISE(
             std::unique_ptr<LookupLevels<PositionedKeyValue>> lookup_levels,
             CreateLookupLevelsInternal<PositionedKeyValue>(
                 options_, schema_manager_, io_manager_, cache_manager_, file_store_path_factory_,
-                table_schema_, partition, bucket, levels, processor_factory, dv_maintainer, pool_));
+                table_schema_, partition, bucket, levels, processor_factory, dv_maintainer,
+                remote_lookup_file_manager, pool_));
         auto merge_function_wrapper_factory =
             [data_schema = schema_, options = options_, trimmed_primary_keys,
              lookup_levels_ptr = lookup_levels.get(), lookup_strategy,
@@ -245,25 +251,24 @@ MergeTreeCompactManagerFactory::CreateLookupRewriterWithDeletionVector(
             return merge_function_wrapper;
         };
         PAIMON_ASSIGN_OR_RAISE(
-            std::unique_ptr<RemoteLookupFileManager<PositionedKeyValue>> remote_lookup_file_manager,
-            CreateRemoteLookupFileManager<PositionedKeyValue>(partition, bucket,
-                                                              lookup_levels.get()));
-        PAIMON_ASSIGN_OR_RAISE(
             std::unique_ptr<LookupMergeTreeCompactRewriter<PositionedKeyValue>> rewriter,
             LookupMergeTreeCompactRewriter<PositionedKeyValue>::Create(
                 max_level, std::move(lookup_levels), dv_maintainer,
                 std::move(merge_function_wrapper_factory), bucket, partition, table_schema_,
-                path_factory_cache, options_, pool_, cancellation_controller,
-                std::move(remote_lookup_file_manager)));
+                path_factory_cache, options_, cancellation_controller, remote_lookup_file_manager,
+                pool_));
         return std::shared_ptr<CompactRewriter>(std::move(rewriter));
     }
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<RemoteLookupFileManager> remote_lookup_file_manager,
+                           CreateRemoteLookupFileManager(partition, bucket));
 
     auto processor_factory = std::make_shared<PersistPositionProcessor::Factory>();
     PAIMON_ASSIGN_OR_RAISE(
         std::unique_ptr<LookupLevels<FilePosition>> lookup_levels,
         CreateLookupLevelsInternal<FilePosition>(
             options_, schema_manager_, io_manager_, cache_manager_, file_store_path_factory_,
-            table_schema_, partition, bucket, levels, processor_factory, dv_maintainer, pool_));
+            table_schema_, partition, bucket, levels, processor_factory, dv_maintainer,
+            remote_lookup_file_manager, pool_));
     auto merge_function_wrapper_factory =
         [data_schema = schema_, options = options_, trimmed_primary_keys,
          lookup_levels_ptr = lookup_levels.get(), lookup_strategy,
@@ -281,15 +286,12 @@ MergeTreeCompactManagerFactory::CreateLookupRewriterWithDeletionVector(
                 lookup_levels_ptr));
         return merge_function_wrapper;
     };
-    PAIMON_ASSIGN_OR_RAISE(
-        std::unique_ptr<RemoteLookupFileManager<FilePosition>> remote_lookup_file_manager,
-        CreateRemoteLookupFileManager<FilePosition>(partition, bucket, lookup_levels.get()));
     PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<LookupMergeTreeCompactRewriter<FilePosition>> rewriter,
                            LookupMergeTreeCompactRewriter<FilePosition>::Create(
                                max_level, std::move(lookup_levels), dv_maintainer,
                                std::move(merge_function_wrapper_factory), bucket, partition,
-                               table_schema_, path_factory_cache, options_, pool_,
-                               cancellation_controller, std::move(remote_lookup_file_manager)));
+                               table_schema_, path_factory_cache, options_, cancellation_controller,
+                               remote_lookup_file_manager, pool_));
     return std::shared_ptr<CompactRewriter>(std::move(rewriter));
 }
 
@@ -302,12 +304,16 @@ MergeTreeCompactManagerFactory::CreateLookupRewriterWithoutDeletionVector(
     const std::shared_ptr<CancellationController>& cancellation_controller) const {
     PAIMON_ASSIGN_OR_RAISE(std::vector<std::string> trimmed_primary_keys,
                            table_schema_->TrimmedPrimaryKeys());
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<RemoteLookupFileManager> remote_lookup_file_manager,
+                           CreateRemoteLookupFileManager(partition, bucket));
+
     auto processor_factory = std::make_shared<PersistValueProcessor::Factory>(schema_);
     PAIMON_ASSIGN_OR_RAISE(
         std::unique_ptr<LookupLevels<KeyValue>> lookup_levels,
-        CreateLookupLevelsInternal<KeyValue>(
-            options_, schema_manager_, io_manager_, cache_manager_, file_store_path_factory_,
-            table_schema_, partition, bucket, levels, processor_factory, dv_maintainer, pool_));
+        CreateLookupLevelsInternal<KeyValue>(options_, schema_manager_, io_manager_, cache_manager_,
+                                             file_store_path_factory_, table_schema_, partition,
+                                             bucket, levels, processor_factory, dv_maintainer,
+                                             remote_lookup_file_manager, pool_));
     auto merge_function_wrapper_factory =
         [data_schema = schema_, options = options_, trimmed_primary_keys,
          lookup_levels_ptr = lookup_levels.get(), lookup_strategy,
@@ -325,17 +331,28 @@ MergeTreeCompactManagerFactory::CreateLookupRewriterWithoutDeletionVector(
                 lookup_levels_ptr));
         return merge_function_wrapper;
     };
-    PAIMON_ASSIGN_OR_RAISE(
-        std::unique_ptr<RemoteLookupFileManager<KeyValue>> remote_lookup_file_manager,
-        CreateRemoteLookupFileManager<KeyValue>(partition, bucket, lookup_levels.get()));
 
     PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<LookupMergeTreeCompactRewriter<KeyValue>> rewriter,
                            LookupMergeTreeCompactRewriter<KeyValue>::Create(
                                max_level, std::move(lookup_levels), dv_maintainer,
                                std::move(merge_function_wrapper_factory), bucket, partition,
-                               table_schema_, path_factory_cache, options_, pool_,
-                               cancellation_controller, std::move(remote_lookup_file_manager)));
+                               table_schema_, path_factory_cache, options_, cancellation_controller,
+                               remote_lookup_file_manager, pool_));
     return std::shared_ptr<CompactRewriter>(std::move(rewriter));
+}
+
+Result<std::shared_ptr<RemoteLookupFileManager>>
+MergeTreeCompactManagerFactory::CreateRemoteLookupFileManager(const BinaryRow& partition,
+                                                              int32_t bucket) const {
+    if (options_.LookupRemoteFileEnabled()) {
+        PAIMON_ASSIGN_OR_RAISE(
+            std::shared_ptr<DataFilePathFactory> data_path_factory,
+            file_store_path_factory_->CreateDataFilePathFactory(partition, bucket));
+        return std::make_shared<RemoteLookupFileManager>(options_.GetLookupRemoteLevelThreshold(),
+                                                         data_path_factory,
+                                                         options_.GetFileSystem(), pool_);
+    }
+    return std::shared_ptr<RemoteLookupFileManager>();
 }
 
 }  // namespace paimon

--- a/src/paimon/core/mergetree/compact/merge_tree_compact_manager_factory.h
+++ b/src/paimon/core/mergetree/compact/merge_tree_compact_manager_factory.h
@@ -113,14 +113,16 @@ class MergeTreeCompactManagerFactory {
         const std::shared_ptr<BucketedDvMaintainer>& dv_maintainer, int32_t max_level,
         const LookupStrategy& lookup_strategy,
         const std::shared_ptr<FileStorePathFactoryCache>& path_factory_cache,
-        const std::shared_ptr<CancellationController>& cancellation_controller) const;
+        const std::shared_ptr<CancellationController>& cancellation_controller,
+        const std::shared_ptr<RemoteLookupFileManager>& remote_lookup_file_manager) const;
 
     Result<std::shared_ptr<CompactRewriter>> CreateLookupRewriterWithoutDeletionVector(
         const BinaryRow& partition, int32_t bucket, const std::shared_ptr<Levels>& levels,
         const std::shared_ptr<BucketedDvMaintainer>& dv_maintainer, int32_t max_level,
         const LookupStrategy& lookup_strategy,
         const std::shared_ptr<FileStorePathFactoryCache>& path_factory_cache,
-        const std::shared_ptr<CancellationController>& cancellation_controller) const;
+        const std::shared_ptr<CancellationController>& cancellation_controller,
+        const std::shared_ptr<RemoteLookupFileManager>& remote_lookup_file_manager) const;
 
     Result<std::shared_ptr<RemoteLookupFileManager>> CreateRemoteLookupFileManager(
         const BinaryRow& partition, int32_t bucket) const;

--- a/src/paimon/core/mergetree/compact/merge_tree_compact_manager_factory.h
+++ b/src/paimon/core/mergetree/compact/merge_tree_compact_manager_factory.h
@@ -122,19 +122,9 @@ class MergeTreeCompactManagerFactory {
         const std::shared_ptr<FileStorePathFactoryCache>& path_factory_cache,
         const std::shared_ptr<CancellationController>& cancellation_controller) const;
 
-    template <typename T>
-    Result<std::unique_ptr<RemoteLookupFileManager<T>>> CreateRemoteLookupFileManager(
-        const BinaryRow& partition, int32_t bucket, LookupLevels<T>* lookup_levels) const {
-        if (options_.LookupRemoteFileEnabled()) {
-            PAIMON_ASSIGN_OR_RAISE(
-                std::shared_ptr<DataFilePathFactory> data_path_factory,
-                file_store_path_factory_->CreateDataFilePathFactory(partition, bucket));
-            return std::make_unique<RemoteLookupFileManager<T>>(
-                options_.GetLookupRemoteLevelThreshold(), data_path_factory,
-                options_.GetFileSystem(), pool_, lookup_levels);
-        }
-        return std::unique_ptr<RemoteLookupFileManager<T>>();
-    }
+    Result<std::shared_ptr<RemoteLookupFileManager>> CreateRemoteLookupFileManager(
+        const BinaryRow& partition, int32_t bucket) const;
+
     CoreOptions options_;
     std::shared_ptr<MemoryPool> pool_;
     std::shared_ptr<FieldsComparator> key_comparator_;

--- a/src/paimon/core/mergetree/compact/merge_tree_compact_rewriter.cpp
+++ b/src/paimon/core/mergetree/compact/merge_tree_compact_rewriter.cpp
@@ -40,8 +40,8 @@ MergeTreeCompactRewriter::MergeTreeCompactRewriter(
     const std::shared_ptr<FileStorePathFactoryCache>& path_factory_cache,
     std::unique_ptr<MergeFileSplitRead>&& merge_file_split_read,
     MergeFunctionWrapperFactory merge_function_wrapper_factory,
-    const std::shared_ptr<MemoryPool>& pool,
-    const std::shared_ptr<CancellationController>& cancellation_controller)
+    const std::shared_ptr<CancellationController>& cancellation_controller,
+    const std::shared_ptr<MemoryPool>& pool)
     : options_(options),
       merge_file_split_read_(std::move(merge_file_split_read)),
       pool_(pool),
@@ -62,8 +62,9 @@ Result<std::unique_ptr<MergeTreeCompactRewriter>> MergeTreeCompactRewriter::Crea
     int32_t bucket, const BinaryRow& partition, const std::shared_ptr<TableSchema>& table_schema,
     DeletionVector::Factory dv_factory,
     const std::shared_ptr<FileStorePathFactoryCache>& path_factory_cache,
-    const CoreOptions& options, const std::shared_ptr<MemoryPool>& pool,
-    const std::shared_ptr<CancellationController>& cancellation_controller) {
+    const CoreOptions& options,
+    const std::shared_ptr<CancellationController>& cancellation_controller,
+    const std::shared_ptr<MemoryPool>& pool) {
     PAIMON_ASSIGN_OR_RAISE(std::vector<std::string> trimmed_primary_keys,
                            table_schema->TrimmedPrimaryKeys());
     auto data_schema = DataField::ConvertDataFieldsToArrowSchema(table_schema->Fields());
@@ -98,7 +99,7 @@ Result<std::unique_ptr<MergeTreeCompactRewriter>> MergeTreeCompactRewriter::Crea
     return std::unique_ptr<MergeTreeCompactRewriter>(new MergeTreeCompactRewriter(
         partition, bucket, table_schema->Id(), trimmed_primary_keys, options, data_schema,
         write_schema, std::move(dv_factory), path_factory_cache, std::move(merge_file_split_read),
-        merge_function_wrapper_factory, pool, cancellation_controller));
+        merge_function_wrapper_factory, cancellation_controller, pool));
 }
 
 Result<CompactResult> MergeTreeCompactRewriter::Upgrade(int32_t output_level,

--- a/src/paimon/core/mergetree/compact/merge_tree_compact_rewriter.h
+++ b/src/paimon/core/mergetree/compact/merge_tree_compact_rewriter.h
@@ -40,8 +40,9 @@ class MergeTreeCompactRewriter : public CompactRewriter {
         int32_t bucket, const BinaryRow& partition,
         const std::shared_ptr<TableSchema>& table_schema, DeletionVector::Factory dv_factory,
         const std::shared_ptr<FileStorePathFactoryCache>& path_factory_cache,
-        const CoreOptions& options, const std::shared_ptr<MemoryPool>& memory_pool,
-        const std::shared_ptr<CancellationController>& cancellation_controller);
+        const CoreOptions& options,
+        const std::shared_ptr<CancellationController>& cancellation_controller,
+        const std::shared_ptr<MemoryPool>& memory_pool);
 
     Result<CompactResult> Rewrite(int32_t output_level, bool drop_delete,
                                   const std::vector<std::vector<SortedRun>>& sections) override;
@@ -68,16 +69,17 @@ class MergeTreeCompactRewriter : public CompactRewriter {
     static std::vector<std::shared_ptr<DataFileMeta>> ExtractFilesFromSections(
         const std::vector<std::vector<SortedRun>>& sections);
 
-    MergeTreeCompactRewriter(
-        const BinaryRow& partition, int32_t bucket, int64_t schema_id,
-        const std::vector<std::string>& trimmed_primary_keys, const CoreOptions& options,
-        const std::shared_ptr<arrow::Schema>& data_schema,
-        const std::shared_ptr<arrow::Schema>& write_schema, DeletionVector::Factory dv_factory,
-        const std::shared_ptr<FileStorePathFactoryCache>& path_factory_cache,
-        std::unique_ptr<MergeFileSplitRead>&& merge_file_split_read,
-        MergeFunctionWrapperFactory merge_function_wrapper_factory,
-        const std::shared_ptr<MemoryPool>& pool,
-        const std::shared_ptr<CancellationController>& cancellation_controller);
+    MergeTreeCompactRewriter(const BinaryRow& partition, int32_t bucket, int64_t schema_id,
+                             const std::vector<std::string>& trimmed_primary_keys,
+                             const CoreOptions& options,
+                             const std::shared_ptr<arrow::Schema>& data_schema,
+                             const std::shared_ptr<arrow::Schema>& write_schema,
+                             DeletionVector::Factory dv_factory,
+                             const std::shared_ptr<FileStorePathFactoryCache>& path_factory_cache,
+                             std::unique_ptr<MergeFileSplitRead>&& merge_file_split_read,
+                             MergeFunctionWrapperFactory merge_function_wrapper_factory,
+                             const std::shared_ptr<CancellationController>& cancellation_controller,
+                             const std::shared_ptr<MemoryPool>& pool);
 
     using KeyValueRollingFileWriter =
         RollingFileWriter<KeyValueBatch, std::shared_ptr<DataFileMeta>>;

--- a/src/paimon/core/mergetree/compact/merge_tree_compact_rewriter_test.cpp
+++ b/src/paimon/core/mergetree/compact/merge_tree_compact_rewriter_test.cpp
@@ -48,8 +48,8 @@ class MergeTreeCompactRewriterTest : public testing::Test {
         auto path_factory_cache =
             std::make_shared<FileStorePathFactoryCache>(table_path, table_schema, options, pool_);
         return MergeTreeCompactRewriter::Create(bucket, partition, table_schema, dv_factory,
-                                                path_factory_cache, options, pool_,
-                                                cancellation_controller);
+                                                path_factory_cache, options,
+                                                cancellation_controller, pool_);
     }
 
     Result<std::vector<std::vector<SortedRun>>> GenerateSortedRuns(

--- a/src/paimon/core/mergetree/levels.cpp
+++ b/src/paimon/core/mergetree/levels.cpp
@@ -96,6 +96,12 @@ void Levels::AddDropFileCallback(DropFileCallback* callback) {
     drop_file_callbacks_.push_back(callback);
 }
 
+void Levels::RemoveDropFileCallback(DropFileCallback* callback) {
+    drop_file_callbacks_.erase(
+        std::remove(drop_file_callbacks_.begin(), drop_file_callbacks_.end(), callback),
+        drop_file_callbacks_.end());
+}
+
 Status Levels::AddLevel0File(const std::shared_ptr<DataFileMeta>& file) {
     if (file->level != 0) {
         return Status::Invalid("must add level0 file in AddLevel0File");

--- a/src/paimon/core/mergetree/levels.h
+++ b/src/paimon/core/mergetree/levels.h
@@ -61,6 +61,8 @@ class Levels {
 
     void AddDropFileCallback(DropFileCallback* callback);
 
+    void RemoveDropFileCallback(DropFileCallback* callback);
+
     Status AddLevel0File(const std::shared_ptr<DataFileMeta>& file);
 
     /// @return the highest non-empty level or -1 if all levels empty.

--- a/src/paimon/core/mergetree/levels_test.cpp
+++ b/src/paimon/core/mergetree/levels_test.cpp
@@ -231,6 +231,13 @@ TEST_F(LevelsTest, TestUpdateDropFileCallback) {
     std::set<std::string> dropped_set(callback.dropped_files.begin(), callback.dropped_files.end());
     ASSERT_TRUE(dropped_set.count(input_files[0]->file_name));
     ASSERT_TRUE(dropped_set.count(input_files[2]->file_name));
+
+    // Remove callback
+    ASSERT_EQ(levels->drop_file_callbacks_.size(), 1);
+    levels->RemoveDropFileCallback(nullptr);
+    ASSERT_EQ(levels->drop_file_callbacks_.size(), 1);
+    levels->RemoveDropFileCallback(&callback);
+    ASSERT_TRUE(levels->drop_file_callbacks_.empty());
 }
 
 TEST_F(LevelsTest, TestUpdateDropFileCallbackExcludesUpgradeFiles) {

--- a/src/paimon/core/mergetree/lookup/remote_lookup_file_manager.cpp
+++ b/src/paimon/core/mergetree/lookup/remote_lookup_file_manager.cpp
@@ -20,33 +20,29 @@
 #include "paimon/core/mergetree/lookup/file_position.h"
 #include "paimon/core/mergetree/lookup/positioned_key_value.h"
 namespace paimon {
-template <typename T>
-RemoteLookupFileManager<T>::RemoteLookupFileManager(
+
+RemoteLookupFileManager::RemoteLookupFileManager(
     int32_t level_threshold, const std::shared_ptr<DataFilePathFactory>& path_factory,
-    const std::shared_ptr<FileSystem>& file_system, const std::shared_ptr<MemoryPool>& pool,
-    LookupLevels<T>* lookup_levels)
+    const std::shared_ptr<FileSystem>& file_system, const std::shared_ptr<MemoryPool>& pool)
     : level_threshold_(level_threshold),
       pool_(pool),
       path_factory_(path_factory),
-      file_system_(file_system),
-      lookup_levels_(lookup_levels) {
-    lookup_levels_->SetRemoteLookupFileManager(this);
-}
+      file_system_(file_system) {}
 
 template <typename T>
-Result<std::shared_ptr<DataFileMeta>> RemoteLookupFileManager<T>::GenRemoteLookupFile(
-    const std::shared_ptr<DataFileMeta>& file) {
+Result<std::shared_ptr<DataFileMeta>> RemoteLookupFileManager::GenRemoteLookupFile(
+    const std::shared_ptr<DataFileMeta>& file, LookupLevels<T>* lookup_levels) const {
     if (file->level < level_threshold_) {
         return file;
     }
 
-    if (lookup_levels_->RemoteSst(file).has_value()) {
+    if (lookup_levels->RemoteSst(file).has_value()) {
         // ignore existed
         return file;
     }
 
     PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<LookupFile> lookup_file,
-                           lookup_levels_->CreateLookupFile(file));
+                           lookup_levels->CreateLookupFile(file));
     std::string local_file_path = lookup_file->LocalFile();
 
     // Get the file size from the local file system
@@ -54,7 +50,7 @@ Result<std::shared_ptr<DataFileMeta>> RemoteLookupFileManager<T>::GenRemoteLooku
                            file_system_->GetFileStatus(local_file_path));
     auto length = static_cast<int64_t>(local_file_status->GetLen());
 
-    std::string remote_sst_name = lookup_levels_->NewRemoteSst(file, length);
+    std::string remote_sst_name = lookup_levels->NewRemoteSst(file, length);
     std::string remote_sst_path = RemoteSstPath(file, remote_sst_name);
 
     // Upload local lookup file to remote storage
@@ -65,17 +61,16 @@ Result<std::shared_ptr<DataFileMeta>> RemoteLookupFileManager<T>::GenRemoteLooku
 
     PAIMON_RETURN_NOT_OK(CopyFromInputToOutput(std::move(input_stream), std::move(output_stream)));
 
-    lookup_levels_->AddLocalFile(file, lookup_file);
+    lookup_levels->AddLocalFile(file, lookup_file);
 
     std::vector<std::optional<std::string>> new_extra_files(file->extra_files);
     new_extra_files.push_back(remote_sst_name);
     return file->CopyWithExtraFiles(new_extra_files);
 }
 
-template <typename T>
-bool RemoteLookupFileManager<T>::TryToDownload(const std::shared_ptr<DataFileMeta>& data_file,
-                                               const std::string& remote_sst_file,
-                                               const std::string& local_file) const {
+bool RemoteLookupFileManager::TryToDownload(const std::shared_ptr<DataFileMeta>& data_file,
+                                            const std::string& remote_sst_file,
+                                            const std::string& local_file) const {
     std::string remote_path = RemoteSstPath(data_file, remote_sst_file);
 
     auto status = CopyRemoteToLocal(remote_path, local_file);
@@ -86,17 +81,15 @@ bool RemoteLookupFileManager<T>::TryToDownload(const std::shared_ptr<DataFileMet
     return true;
 }
 
-template <typename T>
-std::string RemoteLookupFileManager<T>::RemoteSstPath(const std::shared_ptr<DataFileMeta>& file,
-                                                      const std::string& remote_sst_name) const {
+std::string RemoteLookupFileManager::RemoteSstPath(const std::shared_ptr<DataFileMeta>& file,
+                                                   const std::string& remote_sst_name) const {
     std::string data_file_path = path_factory_->ToPath(file);
     std::string parent_dir = PathUtil::GetParentDirPath(data_file_path);
     return PathUtil::JoinPath(parent_dir, remote_sst_name);
 }
 
-template <typename T>
-Status RemoteLookupFileManager<T>::CopyRemoteToLocal(const std::string& remote_path,
-                                                     const std::string& local_path) const {
+Status RemoteLookupFileManager::CopyRemoteToLocal(const std::string& remote_path,
+                                                  const std::string& local_path) const {
     PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<InputStream> input_stream,
                            file_system_->Open(remote_path));
     PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<OutputStream> output_stream,
@@ -104,8 +97,7 @@ Status RemoteLookupFileManager<T>::CopyRemoteToLocal(const std::string& remote_p
     return CopyFromInputToOutput(std::move(input_stream), std::move(output_stream));
 }
 
-template <typename T>
-Status RemoteLookupFileManager<T>::CopyFromInputToOutput(
+Status RemoteLookupFileManager::CopyFromInputToOutput(
     std::unique_ptr<InputStream>&& input_stream,
     std::unique_ptr<OutputStream>&& output_stream) const {
     auto buffer = std::make_shared<Bytes>(kBufferSize, pool_.get());
@@ -136,8 +128,16 @@ Status RemoteLookupFileManager<T>::CopyFromInputToOutput(
     PAIMON_RETURN_NOT_OK(input_stream->Close());
     return Status::OK();
 }
-template class RemoteLookupFileManager<KeyValue>;
-template class RemoteLookupFileManager<FilePosition>;
-template class RemoteLookupFileManager<PositionedKeyValue>;
-template class RemoteLookupFileManager<bool>;
+template Result<std::shared_ptr<DataFileMeta>>
+RemoteLookupFileManager::GenRemoteLookupFile<KeyValue>(const std::shared_ptr<DataFileMeta>&,
+                                                       LookupLevels<KeyValue>*) const;
+template Result<std::shared_ptr<DataFileMeta>>
+RemoteLookupFileManager::GenRemoteLookupFile<FilePosition>(const std::shared_ptr<DataFileMeta>&,
+                                                           LookupLevels<FilePosition>*) const;
+template Result<std::shared_ptr<DataFileMeta>>
+RemoteLookupFileManager::GenRemoteLookupFile<PositionedKeyValue>(
+    const std::shared_ptr<DataFileMeta>&, LookupLevels<PositionedKeyValue>*) const;
+template Result<std::shared_ptr<DataFileMeta>> RemoteLookupFileManager::GenRemoteLookupFile<bool>(
+    const std::shared_ptr<DataFileMeta>&, LookupLevels<bool>*) const;
+
 }  // namespace paimon

--- a/src/paimon/core/mergetree/lookup/remote_lookup_file_manager.cpp
+++ b/src/paimon/core/mergetree/lookup/remote_lookup_file_manager.cpp
@@ -32,6 +32,9 @@ RemoteLookupFileManager::RemoteLookupFileManager(
 template <typename T>
 Result<std::shared_ptr<DataFileMeta>> RemoteLookupFileManager::GenRemoteLookupFile(
     const std::shared_ptr<DataFileMeta>& file, LookupLevels<T>* lookup_levels) const {
+    if (!lookup_levels) {
+        return Status::Invalid("lookup_levels must not be null in GenRemoteLookupFile");
+    }
     if (file->level < level_threshold_) {
         return file;
     }

--- a/src/paimon/core/mergetree/lookup/remote_lookup_file_manager.h
+++ b/src/paimon/core/mergetree/lookup/remote_lookup_file_manager.h
@@ -25,17 +25,16 @@
 namespace paimon {
 
 /// Manager to manage remote files for lookup.
-template <typename T>
 class RemoteLookupFileManager {
  public:
     RemoteLookupFileManager(int32_t level_threshold,
                             const std::shared_ptr<DataFilePathFactory>& path_factory,
                             const std::shared_ptr<FileSystem>& file_system,
-                            const std::shared_ptr<MemoryPool>& pool,
-                            LookupLevels<T>* lookup_levels);
+                            const std::shared_ptr<MemoryPool>& pool);
 
+    template <typename T>
     Result<std::shared_ptr<DataFileMeta>> GenRemoteLookupFile(
-        const std::shared_ptr<DataFileMeta>& file);
+        const std::shared_ptr<DataFileMeta>& file, LookupLevels<T>* lookup_levels) const;
 
     bool TryToDownload(const std::shared_ptr<DataFileMeta>& data_file,
                        const std::string& remote_sst_file, const std::string& local_file) const;
@@ -56,7 +55,6 @@ class RemoteLookupFileManager {
     std::shared_ptr<MemoryPool> pool_;
     std::shared_ptr<DataFilePathFactory> path_factory_;
     std::shared_ptr<FileSystem> file_system_;
-    LookupLevels<T>* lookup_levels_;
 };
 
 }  // namespace paimon

--- a/src/paimon/core/mergetree/lookup/remote_lookup_file_manager_test.cpp
+++ b/src/paimon/core/mergetree/lookup/remote_lookup_file_manager_test.cpp
@@ -136,7 +136,8 @@ class RemoteLookupFileManagerTest : public testing::Test {
     }
 
     Result<std::unique_ptr<LookupLevels<PositionedKeyValue>>> CreateLookupLevels(
-        const std::string& table_path, const std::shared_ptr<Levels>& levels) const {
+        const std::string& table_path, const std::shared_ptr<Levels>& levels,
+        const std::shared_ptr<RemoteLookupFileManager>& remote_lookup_file_manager) const {
         auto schema_manager = std::make_shared<SchemaManager>(fs_, table_path);
         PAIMON_ASSIGN_OR_RAISE(auto table_schema, schema_manager->ReadSchema(0));
         PAIMON_ASSIGN_OR_RAISE(CoreOptions options, CoreOptions::FromMap(table_schema->Options()));
@@ -155,20 +156,20 @@ class RemoteLookupFileManagerTest : public testing::Test {
         return LookupLevels<PositionedKeyValue>::Create(
             fs_, BinaryRow::EmptyRow(), /*bucket=*/0, options, schema_manager,
             std::move(io_manager), path_factory, table_schema, levels,
-            /*dv_factory=*/{}, processor_factory, serializer_factory, lookup_store_factory, pool_);
+            /*dv_factory=*/{}, processor_factory, serializer_factory, lookup_store_factory,
+            remote_lookup_file_manager, pool_);
     }
 
-    Result<std::unique_ptr<RemoteLookupFileManager<PositionedKeyValue>>>
-    CreateRemoteLookupFileManager(const std::string& table_path, CoreOptions& core_options,
-                                  LookupLevels<PositionedKeyValue>* lookup_levels) const {
+    Result<std::shared_ptr<RemoteLookupFileManager>> CreateRemoteLookupFileManager(
+        const std::string& table_path, CoreOptions& core_options) const {
         PAIMON_ASSIGN_OR_RAISE(auto path_factory,
                                CreateFileStorePathFactory(table_path, core_options));
         PAIMON_ASSIGN_OR_RAISE(auto data_path_factory,
                                path_factory->CreateDataFilePathFactory(BinaryRow::EmptyRow(),
                                                                        /*bucket=*/0));
 
-        return std::make_unique<RemoteLookupFileManager<PositionedKeyValue>>(
-            /*level_threshold=*/1, data_path_factory, fs_, pool_, lookup_levels);
+        return std::make_shared<RemoteLookupFileManager>(
+            /*level_threshold=*/1, data_path_factory, fs_, pool_);
     }
 
  private:
@@ -196,25 +197,25 @@ TEST_F(RemoteLookupFileManagerTest, GenRemoteLookupFileSimple) {
     std::vector<std::shared_ptr<DataFileMeta>> files = {file1, file0};
     ASSERT_OK_AND_ASSIGN(std::shared_ptr<Levels> levels,
                          Levels::Create(key_comparator, files, /*num_levels=*/3));
-    ASSERT_OK_AND_ASSIGN(auto lookup_levels, CreateLookupLevels(table_path, levels));
-
     // level_threshold=1 means files at level >= 1 will be processed
-    ASSERT_OK_AND_ASSIGN(
-        auto manager, CreateRemoteLookupFileManager(table_path, core_options, lookup_levels.get()));
+    ASSERT_OK_AND_ASSIGN(auto manager, CreateRemoteLookupFileManager(table_path, core_options));
+    ASSERT_OK_AND_ASSIGN(auto lookup_levels, CreateLookupLevels(table_path, levels, manager));
 
     // level0 < level_threshold and will not produce lookup file
-    ASSERT_OK_AND_ASSIGN(auto result_file, manager->GenRemoteLookupFile(file0));
+    ASSERT_OK_AND_ASSIGN(auto result_file,
+                         manager->GenRemoteLookupFile(file0, lookup_levels.get()));
     ASSERT_TRUE(result_file->extra_files.empty());
 
     // First call: file has no .lookup extra file, so GenRemoteLookupFile should do the upload
-    ASSERT_OK_AND_ASSIGN(result_file, manager->GenRemoteLookupFile(file1));
+    ASSERT_OK_AND_ASSIGN(result_file, manager->GenRemoteLookupFile(file1, lookup_levels.get()));
     // After upload, the result should have an extra file ending with .lookup
     ASSERT_EQ(result_file->extra_files.size(), 1);
     ASSERT_TRUE(StringUtils::EndsWith(result_file->extra_files[0].value(), ".lookup"));
 
     // Second call with the result_file (which already has .lookup extra file):
     // GenRemoteLookupFile should short-circuit and return the same file
-    ASSERT_OK_AND_ASSIGN(auto short_circuit_result, manager->GenRemoteLookupFile(result_file));
+    ASSERT_OK_AND_ASSIGN(auto short_circuit_result,
+                         manager->GenRemoteLookupFile(result_file, lookup_levels.get()));
     ASSERT_EQ(*short_circuit_result, *result_file);
     ASSERT_OK(lookup_levels->Close());
 }
@@ -231,10 +232,8 @@ TEST_F(RemoteLookupFileManagerTest, TryToDownloadReturnsFalseOnFailure) {
     std::vector<std::shared_ptr<DataFileMeta>> files = {file0};
     ASSERT_OK_AND_ASSIGN(std::shared_ptr<Levels> levels,
                          Levels::Create(key_comparator, files, /*num_levels=*/3));
-    ASSERT_OK_AND_ASSIGN(auto lookup_levels, CreateLookupLevels(table_path, levels));
-
-    ASSERT_OK_AND_ASSIGN(
-        auto manager, CreateRemoteLookupFileManager(table_path, core_options, lookup_levels.get()));
+    ASSERT_OK_AND_ASSIGN(auto manager, CreateRemoteLookupFileManager(table_path, core_options));
+    ASSERT_OK_AND_ASSIGN(auto lookup_levels, CreateLookupLevels(table_path, levels, manager));
 
     bool download_result = manager->TryToDownload(file0, "non-exist-remote_sst.lookup",
                                                   dir_->Str() + "/local_sst.lookup");
@@ -256,10 +255,8 @@ TEST_F(RemoteLookupFileManagerTest, TryToDownloadLargeFileAcrossMultipleBuffers)
     std::vector<std::shared_ptr<DataFileMeta>> files = {file0};
     ASSERT_OK_AND_ASSIGN(std::shared_ptr<Levels> levels,
                          Levels::Create(key_comparator, files, /*num_levels=*/3));
-    ASSERT_OK_AND_ASSIGN(auto lookup_levels, CreateLookupLevels(table_path, levels));
-
-    ASSERT_OK_AND_ASSIGN(
-        auto manager, CreateRemoteLookupFileManager(table_path, core_options, lookup_levels.get()));
+    ASSERT_OK_AND_ASSIGN(auto manager, CreateRemoteLookupFileManager(table_path, core_options));
+    ASSERT_OK_AND_ASSIGN(auto lookup_levels, CreateLookupLevels(table_path, levels, manager));
 
     // Prepare a 2.3MB file (2.3 * 1024 * 1024 bytes) to test multi-buffer copy.
     // file_size is 1MB, so this requires 3 iterations: 1MB + 1MB + 0.3MB.

--- a/src/paimon/core/mergetree/lookup_levels.cpp
+++ b/src/paimon/core/mergetree/lookup_levels.cpp
@@ -38,6 +38,7 @@ Result<std::unique_ptr<LookupLevels<T>>> LookupLevels<T>::Create(
     const std::shared_ptr<typename PersistProcessor<T>::Factory>& processor_factory,
     const std::shared_ptr<LookupSerializerFactory>& serializer_factory,
     const std::shared_ptr<LookupStoreFactory>& lookup_store_factory,
+    const std::shared_ptr<RemoteLookupFileManager>& remote_lookup_file_manager,
     const std::shared_ptr<MemoryPool>& pool) {
     PAIMON_ASSIGN_OR_RAISE(std::vector<DataField> pk_fields,
                            table_schema->TrimmedPrimaryKeyFields());
@@ -77,7 +78,7 @@ Result<std::unique_ptr<LookupLevels<T>>> LookupLevels<T>::Create(
         fs, partition, bucket, options, schema_manager, io_manager, std::move(key_comparator),
         data_file_path_factory, std::move(split_read), table_schema, partition_schema, pk_schema,
         levels, dv_factory, processor_factory, std::move(key_serializer), serializer_factory,
-        lookup_store_factory, pool));
+        lookup_store_factory, remote_lookup_file_manager, pool));
 }
 template <typename T>
 Result<std::optional<T>> LookupLevels<T>::Lookup(const std::shared_ptr<InternalRow>& key,
@@ -131,6 +132,7 @@ LookupLevels<T>::LookupLevels(
     std::unique_ptr<RowCompactedSerializer>&& key_serializer,
     const std::shared_ptr<LookupSerializerFactory>& serializer_factory,
     const std::shared_ptr<LookupStoreFactory>& lookup_store_factory,
+    const std::shared_ptr<RemoteLookupFileManager>& remote_lookup_file_manager,
     const std::shared_ptr<MemoryPool>& pool)
     : pool_(pool),
       fs_(fs),
@@ -150,7 +152,8 @@ LookupLevels<T>::LookupLevels(
       processor_factory_(processor_factory),
       key_serializer_(std::move(key_serializer)),
       serializer_factory_(serializer_factory),
-      lookup_store_factory_(lookup_store_factory) {
+      lookup_store_factory_(lookup_store_factory),
+      remote_lookup_file_manager_(remote_lookup_file_manager) {
     if constexpr (std::is_same_v<T, FilePosition>) {
         // if T is FilePosition, only read key fields to create sst file is enough
         value_schema_ = key_schema_;
@@ -159,6 +162,11 @@ LookupLevels<T>::LookupLevels(
     }
     read_schema_ = SpecialFields::CompleteSequenceAndValueKindField(value_schema_);
     levels_->AddDropFileCallback(this);
+}
+
+template <typename T>
+LookupLevels<T>::~LookupLevels() {
+    [[maybe_unused]] auto status = Close();
 }
 
 template <typename T>
@@ -385,6 +393,14 @@ Result<std::shared_ptr<PersistProcessor<T>>> LookupLevels<T>::GetOrCreateProcess
         processor_factory_->Create(ser_version, serializer_factory_, file_schema, pool_));
     schema_id_and_ser_version_to_processors_[key] = processor;
     return processor;
+}
+
+template <typename T>
+Status LookupLevels<T>::Close() {
+    // TODO(xinyu.lxy): invalid cache
+    levels_->RemoveDropFileCallback(this);
+    lookup_file_cache_.clear();
+    return Status::OK();
 }
 
 template class LookupLevels<KeyValue>;

--- a/src/paimon/core/mergetree/lookup_levels.h
+++ b/src/paimon/core/mergetree/lookup_levels.h
@@ -29,8 +29,6 @@
 #include "paimon/result.h"
 
 namespace paimon {
-
-template <typename T>
 class RemoteLookupFileManager;
 
 /// Remote sst file with serVersion.
@@ -53,6 +51,7 @@ class LookupLevels : public Levels::DropFileCallback {
         const std::shared_ptr<typename PersistProcessor<T>::Factory>& processor_factory,
         const std::shared_ptr<LookupSerializerFactory>& serializer_factory,
         const std::shared_ptr<LookupStoreFactory>& lookup_store_factory,
+        const std::shared_ptr<RemoteLookupFileManager>& remote_lookup_file_manager,
         const std::shared_ptr<MemoryPool>& pool);
 
     const std::shared_ptr<Levels>& GetLevels() const {
@@ -70,10 +69,6 @@ class LookupLevels : public Levels::DropFileCallback {
 
     void NotifyDropFile(const std::string& file) override;
 
-    void SetRemoteLookupFileManager(RemoteLookupFileManager<T>* manager) {
-        remote_lookup_file_manager_ = manager;
-    }
-
     std::optional<RemoteSstFile> RemoteSst(const std::shared_ptr<DataFileMeta>& file) const;
 
     std::string NewRemoteSst(const std::shared_ptr<DataFileMeta>& file, int64_t length) const;
@@ -83,11 +78,9 @@ class LookupLevels : public Levels::DropFileCallback {
     void AddLocalFile(const std::shared_ptr<DataFileMeta>& file,
                       const std::shared_ptr<LookupFile>& lookup_file);
 
-    Status Close() {
-        // TODO(xinyu.lxy): invalid cache
-        lookup_file_cache_.clear();
-        return Status::OK();
-    }
+    ~LookupLevels() override;
+
+    Status Close();
 
  private:
     LookupLevels(const std::shared_ptr<FileSystem>& fs, const BinaryRow& partition, int32_t bucket,
@@ -104,6 +97,7 @@ class LookupLevels : public Levels::DropFileCallback {
                  std::unique_ptr<RowCompactedSerializer>&& key_serializer,
                  const std::shared_ptr<LookupSerializerFactory>& serializer_factory,
                  const std::shared_ptr<LookupStoreFactory>& lookup_store_factory,
+                 const std::shared_ptr<RemoteLookupFileManager>& remote_lookup_file_manager,
                  const std::shared_ptr<MemoryPool>& pool);
 
     Result<std::optional<T>> Lookup(const std::shared_ptr<InternalRow>& key,
@@ -150,6 +144,6 @@ class LookupLevels : public Levels::DropFileCallback {
     std::map<std::pair<int64_t, std::string>, std::shared_ptr<PersistProcessor<T>>>
         schema_id_and_ser_version_to_processors_;
 
-    RemoteLookupFileManager<T>* remote_lookup_file_manager_ = nullptr;
+    std::shared_ptr<RemoteLookupFileManager> remote_lookup_file_manager_;
 };
 }  // namespace paimon

--- a/src/paimon/core/mergetree/lookup_levels_test.cpp
+++ b/src/paimon/core/mergetree/lookup_levels_test.cpp
@@ -155,7 +155,8 @@ class LookupLevelsTest : public testing::Test {
         return LookupLevels<PositionedKeyValue>::Create(
             fs_, BinaryRow::EmptyRow(), /*bucket=*/0, options, schema_manager,
             std::move(io_manager), path_factory, table_schema, levels,
-            /*dv_factory=*/{}, processor_factory, serializer_factory, lookup_store_factory, pool_);
+            /*dv_factory=*/{}, processor_factory, serializer_factory, lookup_store_factory,
+            /*remote_lookup_file_manager=*/nullptr, pool_);
     }
 
  private:

--- a/src/paimon/core/mergetree/lookup_levels_test.cpp
+++ b/src/paimon/core/mergetree/lookup_levels_test.cpp
@@ -226,11 +226,14 @@ TEST_F(LookupLevelsTest, TestMultiLevels) {
     std::vector<std::unique_ptr<BasicFileStatus>> file_status_list;
     ASSERT_OK(fs_->ListDir(tmp_dir_->Str(), &file_status_list));
     ASSERT_EQ(file_status_list.size(), 2);
+    ASSERT_EQ(levels->drop_file_callbacks_.size(), 1);
+
     // test close will rm local lookup file
     ASSERT_OK(lookup_levels->Close());
     file_status_list.clear();
     ASSERT_OK(fs_->ListDir(tmp_dir_->Str(), &file_status_list));
     ASSERT_TRUE(file_status_list.empty());
+    ASSERT_TRUE(levels->drop_file_callbacks_.empty());
     // TODO(lisizhuo.lsz): test lookuplevels close
 }
 


### PR DESCRIPTION

<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: #93 

Previously, `RemoteLookupFileManager` was a template class (`RemoteLookupFileManager<T>`) that held a raw pointer to `LookupLevels<T>`, creating a tight coupling and circular dependency: `LookupMergeTreeCompactRewriter` owned both `LookupLevels` (via `unique_ptr`) and `RemoteLookupFileManager` (via `unique_ptr`), while `RemoteLookupFileManager` held a raw back-pointer to `LookupLevels`. This made the construction order fragile and introduced use-after-free risks if the destruction order was not carefully managed.

Additionally, `LookupLevels` registered itself as a `DropFileCallback` on `Levels`, but never unregistered — meaning if `LookupLevels` was destroyed before `Levels`, the dangling callback pointer could be invoked, leading to undefined behavior.

1. Remove template parameter and raw pointer from `RemoteLookupFileManager` construction.
2. Add deregistration mechanism for `Levels::DropFileCallback`
3. Inject `RemoteLookupFileManager` into `LookupLevels` at construction
4. Reorder `pool` parameter to last position in compact rewriter hierarchy

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling
Partially Generated-by: Claude-4.6-Opus
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->