### PR TITLE
fix: reject nullable map keys in schema parsing instead of silently overriding

### DIFF
--- a/docs/source/user_guide/data_types.rst
+++ b/docs/source/user_guide/data_types.rst
@@ -171,11 +171,15 @@ and `Arrow DataTypes <https://arrow.apache.org/docs/format/Columnar.html#data-ty
 
    * - ``MAP<kt, vt>``
      - Map
-     - Data type of an associative array that maps keys (including NULL) to values (including NULL). A map cannot contain duplicate keys; each key can map to at most one value.
+     - Data type of an associative array that maps keys to values (including NULL). A map cannot contain duplicate keys; each key can map to at most one value.
 
        There is no restriction of element types; it is the responsibility of the user to ensure uniqueness.
 
        The type can be declared using ``MAP<kt, vt>`` where kt is the data type of the key elements and vt is the data type of the value elements.
+
+       **Note:** In C++ Paimon, map keys must be explicitly marked as ``NOT NULL``.
+       Apache Arrow does not support nullable map keys. If the key type is not
+       marked as ``NOT NULL`` in the schema, parsing will fail with an error.
 
    * - ``MULTISET<t>``
      - Not Supported

--- a/docs/source/user_guide/schema.rst
+++ b/docs/source/user_guide/schema.rst
@@ -84,6 +84,36 @@ DataField represents a column of the table.
 3. ``type``: data type, very similar to SQL type string.
 4. ``description``: string.
 
+Limitations
+-----------
+
+MAP Key Must Be NOT NULL
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Apache Arrow does not support nullable map keys. When defining a ``MAP`` type in the schema,
+the key must be explicitly marked as ``NOT NULL``. If the key is not marked as ``NOT NULL``,
+schema parsing will fail with an error.
+
+For example, the following is **valid**:
+
+.. code-block:: json
+
+   {
+     "type": "MAP",
+     "key": "TINYINT NOT NULL",
+     "value": "SMALLINT"
+   }
+
+The following is **invalid** and will be rejected:
+
+.. code-block:: json
+
+   {
+     "type": "MAP",
+     "key": "TINYINT",
+     "value": "SMALLINT"
+   }
+
 Update Schema
 -------------
 

--- a/src/paimon/common/types/data_type_json_parser.cpp
+++ b/src/paimon/common/types/data_type_json_parser.cpp
@@ -657,10 +657,14 @@ Result<std::shared_ptr<arrow::Field>> DataTypeJsonParser::ParseMapType(
     // MapType. This is a limitation of Apache Arrow, which does not allow null keys in its
     // MapType. As a result, we validate `nullable = false` for the map key.
     if (key->nullable()) {
-        return Status::Invalid(
-            "Map key must be explicitly marked as NOT NULL in the schema for paimon-cpp as "
-            "Apache Arrow does not support nullable map keys. "
-            "Please add 'NOT NULL' to the key type definition.");
+        return Status::Invalid(fmt::format(
+            "Map field '{}' has a nullable key (parsed key field '{}', nullable={}). "
+            "Map keys must be explicitly marked as NOT NULL in the schema for paimon-cpp "
+            "because Apache Arrow does not support nullable map keys. "
+            "Please add 'NOT NULL' to the key type definition.",
+            name,
+            key->name(),
+            key->nullable()));
     }
     PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Field> value,
                            ParseType("value", type_json_value["value"]));

--- a/src/paimon/common/types/data_type_json_parser.cpp
+++ b/src/paimon/common/types/data_type_json_parser.cpp
@@ -653,13 +653,15 @@ Result<std::shared_ptr<arrow::Field>> DataTypeJsonParser::ParseMapType(
 
     PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Field> key,
                            ParseType("key", type_json_value["key"]));
-
     // NOTE: Unlike Java Paimon, this C++ implementation does not support nullable keys in
     // MapType. This is a limitation of Apache Arrow, which does not allow null keys in its
-    // MapType. As a result, we explicitly set `nullable = false` for the map key, regardless of
-    // the original schema. Please be aware of this behavioral difference when migrating or
-    // interoperating with Java Paimon.
-    key = key->WithNullable(false);
+    // MapType. As a result, we validate `nullable = false` for the map key.
+    if (key->nullable()) {
+        return Status::Invalid(
+            "Map key must be explicitly marked as NOT NULL in the schema for paimon-cpp as "
+            "Apache Arrow does not support nullable map keys. "
+            "Please add 'NOT NULL' to the key type definition.");
+    }
     PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Field> value,
                            ParseType("value", type_json_value["value"]));
     return arrow::field(name, std::make_shared<arrow::MapType>(key, value), nullable);

--- a/src/paimon/common/types/data_type_json_parser.cpp
+++ b/src/paimon/common/types/data_type_json_parser.cpp
@@ -658,13 +658,11 @@ Result<std::shared_ptr<arrow::Field>> DataTypeJsonParser::ParseMapType(
     // MapType. As a result, we validate `nullable = false` for the map key.
     if (key->nullable()) {
         return Status::Invalid(fmt::format(
-            "Map field '{}' has a nullable key (parsed key field '{}', nullable={}). "
+            "Map field '{}' has a nullable key."
             "Map keys must be explicitly marked as NOT NULL in the schema for paimon-cpp "
             "because Apache Arrow does not support nullable map keys. "
             "Please add 'NOT NULL' to the key type definition.",
-            name,
-            key->name(),
-            key->nullable()));
+            name));
     }
     PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Field> value,
                            ParseType("value", type_json_value["value"]));

--- a/src/paimon/common/types/data_type_json_parser_test.cpp
+++ b/src/paimon/common/types/data_type_json_parser_test.cpp
@@ -47,7 +47,7 @@ TEST(DataTypeJsonParserTest, ParseTypeMapTypeSuccess) {
     const std::string name = "map_field";
     const char* json = R"({
         "type": "MAP",
-        "key": "STRING",
+        "key": "STRING NOT NULL",
         "value": "INT"
     })";
     rapidjson::Document doc;

--- a/src/paimon/core/schema/table_schema_test.cpp
+++ b/src/paimon/core/schema/table_schema_test.cpp
@@ -1259,7 +1259,7 @@ TEST_F(TableSchemaTest, MapKeyMustBeNotNull) {
         "timeMillis" : 1721614341162
     })";
     ASSERT_NOK_WITH_MSG(TableSchema::CreateFromJson(table_schema_str),
-                        "Map key must be explicitly marked as NOT NULL");
+                        "Map field 'f0' has a nullable key.");
 }
 
 TEST_F(TableSchemaTest, CrossPartitionUpdate) {

--- a/src/paimon/core/schema/table_schema_test.cpp
+++ b/src/paimon/core/schema/table_schema_test.cpp
@@ -1239,6 +1239,29 @@ TEST_F(TableSchemaTest, SetFieldIdNestedListInStruct) {
     }
 }
 
+TEST_F(TableSchemaTest, MapKeyMustBeNotNull) {
+    std::string table_schema_str = R"({
+        "version" : 3,
+        "id" : 0,
+        "fields" : [ {
+                "id" : 0,
+                "name" : "f0",
+                "type" : {
+                    "type": "MAP",
+                    "key": "TINYINT",
+                    "value": "SMALLINT"
+                }
+        } ],
+        "highestFieldId" : 0,
+        "partitionKeys" : [],
+        "primaryKeys" : [],
+        "options" : {},
+        "timeMillis" : 1721614341162
+    })";
+    ASSERT_NOK_WITH_MSG(TableSchema::CreateFromJson(table_schema_str),
+                        "Map key must be explicitly marked as NOT NULL");
+}
+
 TEST_F(TableSchemaTest, CrossPartitionUpdate) {
     arrow::FieldVector fields = {
         arrow::field("f0", arrow::boolean()), arrow::field("f1", arrow::int8()),

--- a/test/test_data/avro/append_multiple.db/append_multiple/schema/schema-0
+++ b/test/test_data/avro/append_multiple.db/append_multiple/schema/schema-0
@@ -93,7 +93,7 @@
             "name": "f0",
             "type": {
               "type": "MAP",
-              "key": "STRING",
+              "key": "STRING NOT NULL",
               "value": "INT"
             }
           },

--- a/test/test_data/avro/append_simple.db/append_simple/schema/schema-0
+++ b/test/test_data/avro/append_simple.db/append_simple/schema/schema-0
@@ -23,7 +23,7 @@
         "name" : "f0",
         "type" : {
           "type" : "MAP",
-          "key" : "STRING",
+          "key" : "STRING NOT NULL",
           "value" : "INT"
         }
       }, {

--- a/test/test_data/avro/append_with_multiple_map.db/append_with_multiple_map/schema/schema-0
+++ b/test/test_data/avro/append_with_multiple_map.db/append_with_multiple_map/schema/schema-0
@@ -6,7 +6,7 @@
     "name" : "f0",
     "type" : {
       "type" : "MAP",
-      "key" : "INT",
+      "key" : "INT NOT NULL",
       "value" : "INT"
     }
   }, {
@@ -14,7 +14,7 @@
     "name" : "f1",
     "type" : {
       "type" : "MAP",
-      "key" : "DOUBLE",
+      "key" : "DOUBLE NOT NULL",
       "value" : "DOUBLE"
     }
   }, {
@@ -22,7 +22,7 @@
     "name" : "f2",
     "type" : {
       "type" : "MAP",
-      "key" : "STRING",
+      "key" : "STRING NOT NULL",
       "value" : "STRING"
     }
   }, {
@@ -30,7 +30,7 @@
     "name" : "f3",
     "type" : {
       "type" : "MAP",
-      "key" : "STRING",
+      "key" : "STRING NOT NULL",
       "value" : "BINARY(6)"
     }
   }, {
@@ -38,7 +38,7 @@
     "name" : "f4",
     "type" : {
       "type" : "MAP",
-      "key" : "TIMESTAMP(6)",
+      "key" : "TIMESTAMP(6) NOT NULL",
       "value" : "TIMESTAMP(6)"
     }
   }, {
@@ -46,7 +46,7 @@
     "name" : "f5",
     "type" : {
       "type" : "MAP",
-      "key" : "STRING",
+      "key" : "STRING NOT NULL",
       "value" : {
         "type" : "ARRAY",
         "element" : "DOUBLE"
@@ -57,10 +57,10 @@
     "name" : "f6",
     "type" : {
       "type" : "MAP",
-      "key" : "STRING",
+      "key" : "STRING NOT NULL",
       "value" : {
         "type" : "MAP",
-        "key" : "DOUBLE",
+        "key" : "DOUBLE NOT NULL",
         "value" : "STRING"
       }
     }
@@ -69,7 +69,7 @@
     "name" : "f7",
     "type" : {
       "type" : "MAP",
-      "key" : "BIGINT",
+      "key" : "BIGINT NOT NULL",
       "value" : {
         "type" : "ROW",
         "fields" : [ {

--- a/test/test_data/avro/pk_with_multiple_type.db/pk_with_multiple_type/schema/schema-0
+++ b/test/test_data/avro/pk_with_multiple_type.db/pk_with_multiple_type/schema/schema-0
@@ -55,7 +55,7 @@
         "name" : "f0",
         "type" : {
           "type" : "MAP",
-          "key" : "STRING",
+          "key" : "STRING NOT NULL",
           "value" : "INT"
         }
       }, {

--- a/test/test_data/orc/append_complex_build_in_fieldid.db/append_complex_build_in_fieldid/schema/schema-0
+++ b/test/test_data/orc/append_complex_build_in_fieldid.db/append_complex_build_in_fieldid/schema/schema-0
@@ -6,7 +6,7 @@
     "name" : "f1",
     "type" : {
       "type" : "MAP",
-      "key" : "TINYINT",
+      "key" : "TINYINT NOT NULL",
       "value" : "SMALLINT"
     }
   }, {

--- a/test/test_data/orc/append_table_with_nested_type.db/append_table_with_nested_type/schema/schema-0
+++ b/test/test_data/orc/append_table_with_nested_type.db/append_table_with_nested_type/schema/schema-0
@@ -64,7 +64,7 @@
     "type" : {
       "type" : "MAP",
       "key" : {
-        "type" : "ROW",
+        "type" : "ROW NOT NULL",
         "fields" : [ {
           "id" : 13,
           "name" : "sub1",

--- a/test/test_data/orc/pk_table_nested_type.db/pk_table_nested_type/schema/schema-0
+++ b/test/test_data/orc/pk_table_nested_type.db/pk_table_nested_type/schema/schema-0
@@ -44,7 +44,7 @@
     "name" : "col2",
     "type" : {
       "type" : "MAP",
-      "key" : "INT",
+      "key" : "INT NOT NULL",
       "value" : "INT"
     }
   } ],

--- a/test/test_data/parquet/append_complex_build_in_fieldid.db/append_complex_build_in_fieldid/schema/schema-0
+++ b/test/test_data/parquet/append_complex_build_in_fieldid.db/append_complex_build_in_fieldid/schema/schema-0
@@ -6,7 +6,7 @@
     "name" : "f1",
     "type" : {
       "type" : "MAP",
-      "key" : "TINYINT",
+      "key" : "TINYINT NOT NULL",
       "value" : "SMALLINT"
     }
   }, {

--- a/test/test_data/parquet/parquet_append_table.db/parquet_append_table/schema/schema-0
+++ b/test/test_data/parquet/parquet_append_table.db/parquet_append_table/schema/schema-0
@@ -43,7 +43,7 @@
     "type" : {
       "type" : "MAP",
       "key" : {
-        "type" : "ARRAY",
+        "type" : "ARRAY NOT NULL",
         "element" : "FLOAT"
       },
       "value" : {

--- a/test/test_data/parquet/pk_table_nested_type.db/pk_table_nested_type/schema/schema-0
+++ b/test/test_data/parquet/pk_table_nested_type.db/pk_table_nested_type/schema/schema-0
@@ -44,7 +44,7 @@
     "name" : "col2",
     "type" : {
       "type" : "MAP",
-      "key" : "INT",
+      "key" : "INT NOT NULL",
       "value" : "INT"
     }
   } ],


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
No Linked issue.

<!-- What is the purpose of the change -->
Previously, `DataTypeJsonParser::ParseMapType` silently forced map keys to `nullable=false` regardless of the schema definition. This hid potential data inconsistencies — if a schema defined a nullable map key, the parser would quietly change the semantics without any warning. And read process may fail when read map field with null key.

This PR changes the behavior to **fail fast**: if a MAP key is not explicitly marked as `NOT NULL` in the schema, parsing returns an error. This aligns with Apache Arrow's constraint that map keys must be non-nullable, and ensures schema authors are aware of this requirement upfront.

### Tests
TableSchemaTest.MapKeyMustBeNotNull

<!-- List UT and IT cases to verify this change -->

### API and Format
Schemas that previously relied on the silent override will now receive a clear error message guiding them to add `NOT NULL`.
<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation
schema and data_types
<!-- Does this change introduce a new feature -->

### Generative AI tooling
Generated-by: Aone Copilot (Claude claude4.6)
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->