### PR TITLE
fix: Fix date type not supported in LiteralConverter::ConvertLiteralsFromString (#217)

### DIFF
--- a/include/paimon/defs.h
+++ b/include/paimon/defs.h
@@ -113,7 +113,7 @@ struct PAIMON_EXPORT Options {
     static const char BLOB_TARGET_FILE_SIZE[];
 
     /// "partition.default-name" - The default partition name in case the dynamic partition column
-    /// value is null/empty string.
+    /// value is null/empty string. Default is "__DEFAULT_PARTITION__".
     static const char PARTITION_DEFAULT_NAME[];
 
     /// "file.compression" - The default file compression is zstd. For faster read and write, it is

--- a/src/paimon/common/predicate/literal_converter.cpp
+++ b/src/paimon/common/predicate/literal_converter.cpp
@@ -72,6 +72,10 @@ Result<Literal> LiteralConverter::ConvertLiteralsFromString(const FieldType& typ
             }
             return Literal(value.value());
         }
+        case FieldType::DATE: {
+            PAIMON_ASSIGN_OR_RAISE(int32_t value, StringUtils::StringToDate(value_str));
+            return Literal(FieldType::DATE, value);
+        }
         case FieldType::BIGINT: {
             auto value = StringUtils::StringToValue<int64_t>(value_str);
             if (value == std::nullopt) {
@@ -98,7 +102,8 @@ Result<Literal> LiteralConverter::ConvertLiteralsFromString(const FieldType& typ
             return Literal(type, value_str.data(), value_str.size());
         default:
             return Status::Invalid(
-                fmt::format("Do not support type {}", FieldTypeUtils::FieldTypeToString(type)));
+                fmt::format("Do not support type {} in ConvertLiteralsFromString",
+                            FieldTypeUtils::FieldTypeToString(type)));
     }
 }
 

--- a/src/paimon/common/predicate/literal_converter_test.cpp
+++ b/src/paimon/common/predicate/literal_converter_test.cpp
@@ -400,6 +400,11 @@ TEST_F(LiteralConverterTest, TestDateLiteral) {
     CheckResult(field_array,
                 std::vector<Literal>({Literal(FieldType::DATE, 0l), Literal(FieldType::DATE, 4l),
                                       Literal(FieldType::DATE, -5l), Literal(FieldType::DATE)}));
+    CheckLiteralsFromString(
+        FieldType::DATE, {"1", "0", "1970-01-02", "1969-12-31"},
+        std::vector<Literal>({Literal(FieldType::DATE, 1), Literal(FieldType::DATE, 0),
+                              Literal(FieldType::DATE, 1), Literal(FieldType::DATE, -1)}));
+
     CheckLiteralFromRow(arrow::date32(), {0, 4, -5, NullType()}, FieldType::DATE,
                         {Literal(FieldType::DATE, 0l), Literal(FieldType::DATE, 4l),
                          Literal(FieldType::DATE, -5l), Literal(FieldType::DATE)});

--- a/test/inte/write_and_read_inte_test.cpp
+++ b/test/inte/write_and_read_inte_test.cpp
@@ -663,6 +663,196 @@ TEST_P(WriteAndReadInteTest, TestPKWithSequenceFieldPartialInPKField) {
     ASSERT_TRUE(success);
 }
 
+TEST_P(WriteAndReadInteTest, TestWriteSamePartitionTwiceWithAllBasicTypesForAppend) {
+    arrow::FieldVector fields = {
+        arrow::field("f_bool", arrow::boolean()),   arrow::field("f_int8", arrow::int8()),
+        arrow::field("f_int16", arrow::int16()),    arrow::field("f_int32", arrow::int32()),
+        arrow::field("f_int64", arrow::int64()),    arrow::field("f_float", arrow::float32()),
+        arrow::field("f_double", arrow::float64()), arrow::field("f_string", arrow::utf8()),
+        arrow::field("f_date", arrow::date32()),    arrow::field("f_value", arrow::int32())};
+    auto schema = arrow::schema(fields);
+    auto [file_format, file_system] = GetParam();
+    std::map<std::string, std::string> options = {
+        {Options::FILE_FORMAT, file_format},
+        {Options::TARGET_FILE_SIZE, "1024"},
+        {Options::BUCKET, "1"},
+        {Options::BUCKET_KEY, "f_value"},
+        {Options::FILE_SYSTEM, file_system},
+        {Options::PARTITION_GENERATE_LEGACY_NAME, "false"},
+        {Options::PARTITION_DEFAULT_NAME, "null"}};
+    if (file_system == "jindo") {
+        options = AddOptionsForJindo(options);
+    }
+    ASSERT_OK_AND_ASSIGN(
+        auto helper, TestHelper::Create(test_dir_, schema,
+                                        /*partition_keys=*/
+                                        {"f_bool", "f_int8", "f_int16", "f_int32", "f_int64",
+                                         "f_float", "f_double", "f_string", "f_date"},
+                                        /*primary_keys=*/{}, options, /*is_streaming_mode=*/true));
+    int64_t commit_identifier = 0;
+
+    {
+        std::map<std::string, std::string> partition_map = {
+            {"f_bool", "true"},   {"f_int8", "1"},       {"f_int16", "100"},
+            {"f_int32", "10000"}, {"f_int64", "100000"}, {"f_float", "1.5"},
+            {"f_double", "2.5"},  {"f_string", "hello"}, {"f_date", "1970-01-02"}};
+
+        // First write to the same partition
+        std::string data1 = R"([
+            [true, 1, 100, 10000, 100000, 1.5, 2.5, "hello", 1, 10],
+            [true, 1, 100, 10000, 100000, 1.5, 2.5, "hello", 1, 20]
+    ])";
+        ASSERT_OK_AND_ASSIGN(
+            std::unique_ptr<RecordBatch> batch1,
+            TestHelper::MakeRecordBatch(arrow::struct_(fields), data1, partition_map,
+                                        /*bucket=*/0, {}));
+        ASSERT_OK_AND_ASSIGN(auto commit_msgs,
+                             helper->WriteAndCommit(std::move(batch1), commit_identifier++,
+                                                    /*expected_commit_messages=*/std::nullopt));
+
+        // Second write to the same partition
+        std::string data2 = R"([
+            [true, 1, 100, 10000, 100000, 1.5, 2.5, "hello", 1, 30],
+            [true, 1, 100, 10000, 100000, 1.5, 2.5, "hello", 1, 40]
+    ])";
+        ASSERT_OK_AND_ASSIGN(
+            std::unique_ptr<RecordBatch> batch2,
+            TestHelper::MakeRecordBatch(arrow::struct_(fields), data2, partition_map,
+                                        /*bucket=*/0, {}));
+        ASSERT_OK_AND_ASSIGN(commit_msgs,
+                             helper->WriteAndCommit(std::move(batch2), commit_identifier++,
+                                                    /*expected_commit_messages=*/std::nullopt));
+    }
+    {
+        // write all null for partition fields
+        std::map<std::string, std::string> partition_map = {
+            {"f_bool", "null"},   {"f_int8", "null"},   {"f_int16", "null"},
+            {"f_int32", "null"},  {"f_int64", "null"},  {"f_float", "null"},
+            {"f_double", "null"}, {"f_string", "null"}, {"f_date", "null"}};
+
+        // First write to the same partition
+        std::string data1 = R"([
+            [null, null, null, null, null, null, null, null, null, 50]
+    ])";
+        ASSERT_OK_AND_ASSIGN(
+            std::unique_ptr<RecordBatch> batch1,
+            TestHelper::MakeRecordBatch(arrow::struct_(fields), data1, partition_map,
+                                        /*bucket=*/0, {}));
+        ASSERT_OK_AND_ASSIGN(auto commit_msgs,
+                             helper->WriteAndCommit(std::move(batch1), commit_identifier++,
+                                                    /*expected_commit_messages=*/std::nullopt));
+
+        // Second write to the same partition
+        std::string data2 = R"([
+            [null, null, null, null, null, null, null, null, null, 60]
+    ])";
+        ASSERT_OK_AND_ASSIGN(
+            std::unique_ptr<RecordBatch> batch2,
+            TestHelper::MakeRecordBatch(arrow::struct_(fields), data2, partition_map,
+                                        /*bucket=*/0, {}));
+        ASSERT_OK_AND_ASSIGN(commit_msgs,
+                             helper->WriteAndCommit(std::move(batch2), commit_identifier++,
+                                                    /*expected_commit_messages=*/std::nullopt));
+    }
+    // Read and verify
+    arrow::FieldVector fields_with_row_kind = fields;
+    fields_with_row_kind.insert(fields_with_row_kind.begin(),
+                                arrow::field("_VALUE_KIND", arrow::int8()));
+    auto data_type = arrow::struct_(fields_with_row_kind);
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<Split>> data_splits,
+                         helper->NewScan(StartupMode::LatestFull(), /*snapshot_id=*/std::nullopt));
+    std::string expected_data = R"([
+            [0, true, 1, 100, 10000, 100000, 1.5, 2.5, "hello", 1, 10],
+            [0, true, 1, 100, 10000, 100000, 1.5, 2.5, "hello", 1, 20],
+            [0, true, 1, 100, 10000, 100000, 1.5, 2.5, "hello", 1, 30],
+            [0, true, 1, 100, 10000, 100000, 1.5, 2.5, "hello", 1, 40],
+            [0, null, null, null, null, null, null, null, null, null, 50],
+            [0, null, null, null, null, null, null, null, null, null, 60]
+    ])";
+    ASSERT_OK_AND_ASSIGN(bool success,
+                         helper->ReadAndCheckResult(data_type, data_splits, expected_data));
+    ASSERT_TRUE(success);
+}
+
+TEST_P(WriteAndReadInteTest, TestWriteSamePartitionTwiceWithAllBasicTypesForPk) {
+    arrow::FieldVector fields = {
+        arrow::field("f_bool", arrow::boolean()),   arrow::field("f_int8", arrow::int8()),
+        arrow::field("f_int16", arrow::int16()),    arrow::field("f_int32", arrow::int32()),
+        arrow::field("f_int64", arrow::int64()),    arrow::field("f_float", arrow::float32()),
+        arrow::field("f_double", arrow::float64()), arrow::field("f_string", arrow::utf8()),
+        arrow::field("f_date", arrow::date32()),    arrow::field("f_value", arrow::int32()),
+        arrow::field("pk", arrow::utf8())};
+    auto schema = arrow::schema(fields);
+    auto [file_format, file_system] = GetParam();
+    std::map<std::string, std::string> options = {{Options::FILE_FORMAT, file_format},
+                                                  {Options::TARGET_FILE_SIZE, "1024"},
+                                                  {Options::BUCKET, "1"},
+                                                  {Options::FILE_SYSTEM, file_system},
+                                                  {Options::PARTITION_GENERATE_LEGACY_NAME, "true"},
+                                                  {Options::PARTITION_DEFAULT_NAME, "null"}};
+    if (file_system == "jindo") {
+        options = AddOptionsForJindo(options);
+    }
+    ASSERT_OK_AND_ASSIGN(
+        auto helper, TestHelper::Create(test_dir_, schema,
+                                        /*partition_keys=*/
+                                        {"f_bool", "f_int8", "f_int16", "f_int32", "f_int64",
+                                         "f_float", "f_double", "f_string", "f_date"},
+                                        /*primary_keys=*/
+                                        {"pk", "f_bool", "f_int8", "f_int16", "f_int32", "f_int64",
+                                         "f_float", "f_double", "f_string", "f_date"},
+                                        options, /*is_streaming_mode=*/true));
+    int64_t commit_identifier = 0;
+
+    {
+        std::map<std::string, std::string> partition_map = {
+            {"f_bool", "true"},   {"f_int8", "1"},       {"f_int16", "100"},
+            {"f_int32", "10000"}, {"f_int64", "100000"}, {"f_float", "1.5"},
+            {"f_double", "2.5"},  {"f_string", "hello"}, {"f_date", "1970-01-02"}};
+
+        // First write to the same partition
+        std::string data1 = R"([
+            [true, 1, 100, 10000, 100000, 1.5, 2.5, "hello", 1, 10, "pk1"],
+            [true, 1, 100, 10000, 100000, 1.5, 2.5, "hello", 1, 20, "pk2"]
+    ])";
+        ASSERT_OK_AND_ASSIGN(
+            std::unique_ptr<RecordBatch> batch1,
+            TestHelper::MakeRecordBatch(arrow::struct_(fields), data1, partition_map,
+                                        /*bucket=*/0, {}));
+        ASSERT_OK_AND_ASSIGN(auto commit_msgs,
+                             helper->WriteAndCommit(std::move(batch1), commit_identifier++,
+                                                    /*expected_commit_messages=*/std::nullopt));
+
+        // Second write to the same partition
+        std::string data2 = R"([
+            [true, 1, 100, 10000, 100000, 1.5, 2.5, "hello", 1, 30, "pk1"],
+            [true, 1, 100, 10000, 100000, 1.5, 2.5, "hello", 1, 40, "pk3"]
+    ])";
+        ASSERT_OK_AND_ASSIGN(
+            std::unique_ptr<RecordBatch> batch2,
+            TestHelper::MakeRecordBatch(arrow::struct_(fields), data2, partition_map,
+                                        /*bucket=*/0, {}));
+        ASSERT_OK_AND_ASSIGN(commit_msgs,
+                             helper->WriteAndCommit(std::move(batch2), commit_identifier++,
+                                                    /*expected_commit_messages=*/std::nullopt));
+    }
+    // Read and verify
+    arrow::FieldVector fields_with_row_kind = fields;
+    fields_with_row_kind.insert(fields_with_row_kind.begin(),
+                                arrow::field("_VALUE_KIND", arrow::int8()));
+    auto data_type = arrow::struct_(fields_with_row_kind);
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<Split>> data_splits,
+                         helper->NewScan(StartupMode::LatestFull(), /*snapshot_id=*/std::nullopt));
+    std::string expected_data = R"([
+            [0, true, 1, 100, 10000, 100000, 1.5, 2.5, "hello", 1, 30, "pk1"],
+            [0, true, 1, 100, 10000, 100000, 1.5, 2.5, "hello", 1, 20, "pk2"],
+            [0, true, 1, 100, 10000, 100000, 1.5, 2.5, "hello", 1, 40, "pk3"]
+    ])";
+    ASSERT_OK_AND_ASSIGN(bool success,
+                         helper->ReadAndCheckResult(data_type, data_splits, expected_data));
+    ASSERT_TRUE(success);
+}
+
 std::vector<std::pair<std::string, std::string>> GetTestValuesForWriteAndReadInteTest() {
     std::vector<std::pair<std::string, std::string>> values = {{"parquet", "local"}};
 #ifdef PAIMON_ENABLE_ORC


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: cherry-pick #217.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
