### PR TITLE
fix: unstable ut for LookupLevelsTest

### DIFF
--- a/src/paimon/core/mergetree/lookup_levels_test.cpp
+++ b/src/paimon/core/mergetree/lookup_levels_test.cpp
@@ -884,8 +884,8 @@ TEST_F(LookupLevelsTest, TestCacheEvictionByExpiration) {
     ASSERT_OK_AND_ASSIGN(std::shared_ptr<Levels> levels,
                          Levels::Create(key_comparator, files, /*num_levels=*/3));
 
-    // Create a cache with a very short expiration (50ms).
-    auto expiring_cache = LookupFile::CreateLookupFileCache(/*file_retention_ms=*/50,
+    // Create a cache with a very short expiration (300ms).
+    auto expiring_cache = LookupFile::CreateLookupFileCache(/*file_retention_ms=*/300,
                                                             /*max_disk_size=*/INT64_MAX);
     ASSERT_OK_AND_ASSIGN(auto lookup_levels,
                          CreateLookupLevels(table_path, levels, expiring_cache));
@@ -905,7 +905,7 @@ TEST_F(LookupLevelsTest, TestCacheEvictionByExpiration) {
     ASSERT_EQ(expiring_cache->Size(), 2);
 
     // Wait for entries to expire.
-    std::this_thread::sleep_for(std::chrono::milliseconds(80));
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
     // Entries should be expired now. GetIfPresent triggers expiration check.
     ASSERT_FALSE(expiring_cache->GetIfPresent(file0->file_name).has_value());


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->
Fix unstable ut: LookupLevelsTest, TestCacheEvictionByExpiration.
### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: #93 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
