### PR TITLE
fix: fix compile error on macOS with clang 21

### DIFF
--- a/src/paimon/common/data/blob.cpp
+++ b/src/paimon/common/data/blob.cpp
@@ -33,19 +33,6 @@ namespace paimon {
 
 class MemoryPool;
 
-Result<std::unique_ptr<Blob>> Blob::FromPath(const std::string& path) {
-    return FromPath(path, /*offset=*/0, /*length=*/-1);
-}
-
-Result<std::unique_ptr<Blob>> Blob::FromPath(const std::string& path, int64_t offset,
-                                             int64_t length) {
-    PAIMON_ASSIGN_OR_RAISE(std::string normalized_path, PathUtil::NormalizePath(path));
-    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<BlobDescriptor> descriptor,
-                           BlobDescriptor::Create(normalized_path, offset, length));
-    auto impl = std::make_unique<Blob::Impl>(std::move(descriptor), descriptor->Uri());
-    return std::unique_ptr<Blob>(new Blob(std::move(impl)));
-}
-
 class Blob::Impl {
  public:
     Impl(std::unique_ptr<BlobDescriptor>&& descriptor, const std::string& uri)
@@ -67,6 +54,19 @@ class Blob::Impl {
     std::unique_ptr<BlobDescriptor> descriptor_;
     std::string uri_;
 };
+
+Result<std::unique_ptr<Blob>> Blob::FromPath(const std::string& path) {
+    return FromPath(path, /*offset=*/0, /*length=*/-1);
+}
+
+Result<std::unique_ptr<Blob>> Blob::FromPath(const std::string& path, int64_t offset,
+                                             int64_t length) {
+    PAIMON_ASSIGN_OR_RAISE(std::string normalized_path, PathUtil::NormalizePath(path));
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<BlobDescriptor> descriptor,
+                           BlobDescriptor::Create(normalized_path, offset, length));
+    auto impl = std::make_unique<Blob::Impl>(std::move(descriptor), descriptor->Uri());
+    return std::unique_ptr<Blob>(new Blob(std::move(impl)));
+}
 
 Blob::Blob(std::unique_ptr<Impl>&& impl) : impl_(std::move(impl)) {}
 Blob::~Blob() = default;

--- a/src/paimon/common/memory/memory_pool.cpp
+++ b/src/paimon/common/memory/memory_pool.cpp
@@ -55,7 +55,7 @@ void* MemoryPoolImpl::Malloc(uint64_t size, uint64_t alignment) {
     return memptr;
 }
 
-void* MemoryPoolImpl::Realloc(void* p, size_t old_size, size_t new_size, size_t alignment) {
+void* MemoryPoolImpl::Realloc(void* p, size_t old_size, size_t new_size, uint64_t alignment) {
     if (alignment == 0) {
         void* memptr = ::realloc(p, new_size);
         total_allocated_size.fetch_add(new_size - old_size);

--- a/src/paimon/format/avro/avro_input_stream_impl.cpp
+++ b/src/paimon/format/avro/avro_input_stream_impl.cpp
@@ -68,7 +68,8 @@ bool AvroInputStreamImpl::next(const uint8_t** data, size_t* len) {
         return false;  // eof
     }
     auto read_length =
-        in_->Read(reinterpret_cast<char*>(buffer_), std::min(buffer_size_, remaining));
+        in_->Read(reinterpret_cast<char*>(buffer_),
+                  static_cast<uint32_t>(std::min<uint64_t>(buffer_size_, remaining)));
     if (!read_length.ok()) {
         throw ::avro::Exception("Read failed: {}", read_length.status().ToString());
     }

--- a/src/paimon/format/blob/blob_format_writer.cpp
+++ b/src/paimon/format/blob/blob_format_writer.cpp
@@ -138,7 +138,7 @@ Status BlobFormatWriter::WriteBlob(std::string_view blob_data) {
     }
     PAIMON_ASSIGN_OR_RAISE(uint64_t file_length, in->Length());
     uint64_t total_read_length = 0;
-    uint32_t read_len = std::min(file_length, tmp_buffer_->size());
+    auto read_len = static_cast<uint32_t>(std::min<uint64_t>(file_length, tmp_buffer_->size()));
     while (read_len > 0) {
         PAIMON_ASSIGN_OR_RAISE(int32_t actual_read_len, in->Read(tmp_buffer_->data(), read_len));
         if (static_cast<uint32_t>(actual_read_len) != read_len) {
@@ -147,7 +147,8 @@ Status BlobFormatWriter::WriteBlob(std::string_view blob_data) {
         }
         PAIMON_RETURN_NOT_OK(WriteWithCrc32(tmp_buffer_->data(), actual_read_len));
         total_read_length += actual_read_len;
-        read_len = std::min(file_length - total_read_length, tmp_buffer_->size());
+        read_len = static_cast<uint32_t>(
+            std::min<uint64_t>(file_length - total_read_length, tmp_buffer_->size()));
     }
 
     // write bin length


### PR DESCRIPTION
### Purpose

Compiling paimon-cpp on macOS with clang 21 has some minor issues.

### Tests

N/A

### API and Format

N/A

### Documentation

N/A

### Generative AI tooling

No
