### PR TITLE
fix(global_index): compatibility for legacy lumina index type

### DIFF
--- a/src/paimon/common/global_index/global_indexer_factory.cpp
+++ b/src/paimon/common/global_index/global_indexer_factory.cpp
@@ -28,7 +28,9 @@ const char GlobalIndexerFactory::GLOBAL_INDEX_IDENTIFIER_SUFFIX[] = "-global";
 
 Result<std::unique_ptr<GlobalIndexer>> GlobalIndexerFactory::Get(
     const std::string& identifier, const std::map<std::string, std::string>& options) {
-    std::string global_index_identifier = identifier + GLOBAL_INDEX_IDENTIFIER_SUFFIX;
+    // Compatibility: "lumina-vector-ann" was the old identifier for lumina global index.
+    std::string final_identifier = (identifier == "lumina-vector-ann" ? "lumina" : identifier);
+    std::string global_index_identifier = final_identifier + GLOBAL_INDEX_IDENTIFIER_SUFFIX;
     auto factory_creator = FactoryCreator::GetInstance();
     if (factory_creator == nullptr) {
         assert(false);

--- a/src/paimon/common/global_index/global_indexer_factory_test.cpp
+++ b/src/paimon/common/global_index/global_indexer_factory_test.cpp
@@ -38,4 +38,17 @@ TEST(GlobalIndexerFactoryTest, TestNonExist) {
                          GlobalIndexerFactory::Get("nonexist", options));
     ASSERT_FALSE(indexer);
 }
+
+TEST(GlobalIndexerFactoryTest, TestLuminaVectorAnnCompatibility) {
+    // "lumina-vector-ann" should be treated as "lumina" for backward compatibility.
+    // Both identifiers should produce the same result (either both succeed or both return nullptr
+    // depending on whether the lumina module is linked).
+    std::map<std::string, std::string> options;
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<GlobalIndexer> lumina_vector_ann_indexer,
+                         GlobalIndexerFactory::Get("lumina-vector-ann", options));
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<GlobalIndexer> lumina_indexer,
+                         GlobalIndexerFactory::Get("lumina", options));
+
+    ASSERT_EQ(static_cast<bool>(lumina_vector_ann_indexer), static_cast<bool>(lumina_indexer));
+}
 }  // namespace paimon::test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose
This PR adds a compatibility mapping in GlobalIndexerFactory::Get: when the identifier is "lumina-vector-ann", it is transparently rewritten to "lumina" before looking up the factory.

### Generative AI tooling
No