### PR TITLE
fix: Fix missing StatusCode switch cases and correct Literal hash qualifier

### DIFF
--- a/include/paimon/predicate/literal.h
+++ b/include/paimon/predicate/literal.h
@@ -106,7 +106,7 @@ class PAIMON_EXPORT Literal {
 
 namespace std {
 template <>
-struct hash<paimon::Literal> {
+struct hash<::paimon::Literal> {
     size_t operator()(const paimon::Literal& literal) const {
         return literal.HashCode();
     }

--- a/src/paimon/common/utils/status.cpp
+++ b/src/paimon/common/utils/status.cpp
@@ -105,6 +105,12 @@ std::string Status::CodeAsString(StatusCode code) {
         case StatusCode::SerializationError:
             type = "Serialization error";
             break;
+        case StatusCode::NotExist:
+            type = "Not exist";
+            break;
+        case StatusCode::Exist:
+            type = "Exist";
+            break;
         default:
             type = "Unknown";
             break;


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

- Add missing StatusCode::NotExist and StatusCode::Exist cases in Status::CodeAsString(StatusCode), so these error codes produce proper string representations instead of falling through to "Unknown".
- Fix `std::hash<paimon::Literal>` specialization to use `::paimon::Literal` (global namespace qualifier) instead of `paimon::Literal`, avoiding potential ambiguity in nested namespace contexts.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
