### PR TITLE
feat: support file type classify

### DIFF
--- a/src/paimon/common/utils/file_type.cpp
+++ b/src/paimon/common/utils/file_type.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026-present Alibaba Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/common/utils/file_type.h"
+
+#include "paimon/common/utils/path_util.h"
+#include "paimon/common/utils/string_utils.h"
+
+namespace paimon {
+
+namespace {
+
+constexpr char SNAPSHOT_PREFIX[] = "snapshot-";
+constexpr char SCHEMA_PREFIX[] = "schema-";
+constexpr char STATISTICS_PREFIX[] = "stat-";
+constexpr char TAG_PREFIX[] = "tag-";
+constexpr char CONSUMER_PREFIX[] = "consumer-";
+constexpr char SERVICE_PREFIX[] = "service-";
+constexpr char INDEX_PATH_SUFFIX[] = ".index";
+constexpr char INDEX_PREFIX[] = "index-";
+constexpr char CHANGELOG_PREFIX[] = "changelog-";
+
+constexpr char MANIFEST[] = "manifest";
+constexpr char CHANGELOG_DIR[] = "changelog";
+constexpr char GLOBAL_INDEX_INFIX[] = "global-index-";
+constexpr char TEMP_FILE_SUFFIX[] = ".tmp";
+
+std::string UnwrapTempFileName(const std::string& name) {
+    // format: .{originalName}.{UUID}.tmp
+    // suffix ".{UUID}.tmp" is 41 chars: 1(dot) + 36(UUID) + 4(.tmp)
+    // minimum total: 1(leading dot) + 1(name) + 41(suffix) = 43
+    if (name.size() < 43 || name[0] != '.' || !StringUtils::EndsWith(name, TEMP_FILE_SUFFIX)) {
+        return name;
+    }
+
+    size_t dot_before_uuid = name.size() - 41;
+    if (name[dot_before_uuid] != '.') {
+        return name;
+    }
+
+    return name.substr(1, dot_before_uuid - 1);
+}
+
+}  // namespace
+
+bool FileTypeUtils::IsIndex(FileType file_type) {
+    return file_type == FileType::kBucketIndex || file_type == FileType::kGlobalIndex ||
+           file_type == FileType::kFileIndex;
+}
+
+std::string FileTypeUtils::ToString(FileType file_type) {
+    switch (file_type) {
+        case FileType::kMeta:
+            return "meta";
+        case FileType::kData:
+            return "data";
+        case FileType::kBucketIndex:
+            return "bucket_index";
+        case FileType::kGlobalIndex:
+            return "global_index";
+        case FileType::kFileIndex:
+            return "file_index";
+    }
+    return "data";
+}
+
+FileType FileTypeUtils::Classify(const std::string& file_path) {
+    std::string name = PathUtil::GetName(file_path);
+    name = UnwrapTempFileName(name);
+
+    if (StringUtils::StartsWith(name, SNAPSHOT_PREFIX) ||
+        StringUtils::StartsWith(name, SCHEMA_PREFIX) ||
+        StringUtils::StartsWith(name, STATISTICS_PREFIX) ||
+        StringUtils::StartsWith(name, TAG_PREFIX) ||
+        StringUtils::StartsWith(name, CONSUMER_PREFIX) ||
+        StringUtils::StartsWith(name, SERVICE_PREFIX)) {
+        return FileType::kMeta;
+    }
+
+    if (StringUtils::EndsWith(name, INDEX_PATH_SUFFIX)) {
+        if (name.find(GLOBAL_INDEX_INFIX) != std::string::npos) {
+            return FileType::kGlobalIndex;
+        }
+        return FileType::kFileIndex;
+    }
+
+    if (name.find(MANIFEST) != std::string::npos) {
+        return FileType::kMeta;
+    }
+
+    if (StringUtils::StartsWith(name, INDEX_PREFIX)) {
+        return FileType::kBucketIndex;
+    }
+
+    if (name == "EARLIEST" || name == "LATEST") {
+        return FileType::kMeta;
+    }
+
+    if (StringUtils::EndsWith(name, "_SUCCESS")) {
+        return FileType::kMeta;
+    }
+
+    const std::string parent = PathUtil::GetParentDirPath(file_path);
+    if (StringUtils::StartsWith(name, CHANGELOG_PREFIX) &&
+        PathUtil::GetName(parent) == CHANGELOG_DIR) {
+        return FileType::kMeta;
+    }
+
+    return FileType::kData;
+}
+
+}  // namespace paimon

--- a/src/paimon/common/utils/file_type.h
+++ b/src/paimon/common/utils/file_type.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026-present Alibaba Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+#include "paimon/visibility.h"
+
+namespace paimon {
+
+enum class FileType {
+    kMeta,
+    kData,
+    kBucketIndex,
+    kGlobalIndex,
+    kFileIndex,
+};
+
+class PAIMON_EXPORT FileTypeUtils {
+ public:
+    static bool IsIndex(FileType file_type);
+    static FileType Classify(const std::string& file_path);
+    static std::string ToString(FileType file_type);
+};
+
+}  // namespace paimon

--- a/src/paimon/common/utils/file_type_test.cpp
+++ b/src/paimon/common/utils/file_type_test.cpp
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2026-present Alibaba Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/common/utils/file_type.h"
+
+#include "gtest/gtest.h"
+
+namespace paimon::test {
+
+TEST(FileTypeTest, TestIsIndex) {
+    ASSERT_TRUE(FileTypeUtils::IsIndex(FileType::kBucketIndex));
+    ASSERT_TRUE(FileTypeUtils::IsIndex(FileType::kGlobalIndex));
+    ASSERT_TRUE(FileTypeUtils::IsIndex(FileType::kFileIndex));
+    ASSERT_FALSE(FileTypeUtils::IsIndex(FileType::kMeta));
+    ASSERT_FALSE(FileTypeUtils::IsIndex(FileType::kData));
+}
+
+TEST(FileTypeTest, TestMetaPrefix) {
+    ASSERT_EQ(FileTypeUtils::Classify("dfs://cluster/db/snapshot/snapshot-1"), FileType::kMeta);
+    ASSERT_EQ(FileTypeUtils::Classify("dfs://cluster/db/schema/schema-2"), FileType::kMeta);
+    ASSERT_EQ(FileTypeUtils::Classify("dfs://cluster/db/statistics/stat-a1b2c3d4-0"),
+              FileType::kMeta);
+    ASSERT_EQ(FileTypeUtils::Classify("dfs://cluster/db/tag/tag-3"), FileType::kMeta);
+    ASSERT_EQ(FileTypeUtils::Classify("dfs://cluster/db/consumer/consumer-myGroup"),
+              FileType::kMeta);
+    ASSERT_EQ(FileTypeUtils::Classify("dfs://cluster/db/service/service-4"), FileType::kMeta);
+}
+
+TEST(FileTypeTest, TestIndexTypes) {
+    ASSERT_EQ(FileTypeUtils::Classify("dfs://cluster/db/index/bitmap.index"), FileType::kFileIndex);
+    ASSERT_EQ(FileTypeUtils::Classify("dfs://cluster/db/index/btree-global-index-a1b2.index"),
+              FileType::kGlobalIndex);
+    ASSERT_EQ(FileTypeUtils::Classify("dfs://cluster/db/index/bitmap-global-index-1.index"),
+              FileType::kGlobalIndex);
+    ASSERT_EQ(
+        FileTypeUtils::Classify("dfs://cluster/db/index/lumina-vector-ann-global-index-a1b2.index"),
+        FileType::kGlobalIndex);
+    ASSERT_EQ(
+        FileTypeUtils::Classify("dfs://cluster/db/index/tantivy-fulltext-global-index-a1b2.index"),
+        FileType::kGlobalIndex);
+    ASSERT_EQ(FileTypeUtils::Classify("dfs://cluster/db/p=1/bucket-0/index-abcdef-1"),
+              FileType::kBucketIndex);
+}
+
+TEST(FileTypeTest, TestMetaSpecialNames) {
+    ASSERT_EQ(FileTypeUtils::Classify("dfs://cluster/db/manifest/manifest-a1b2c3d4-0"),
+              FileType::kMeta);
+    ASSERT_EQ(FileTypeUtils::Classify("dfs://cluster/db/manifest/manifest-list-1"),
+              FileType::kMeta);
+    ASSERT_EQ(FileTypeUtils::Classify("dfs://cluster/db/manifest/index-manifest-a1b2c3d4-0"),
+              FileType::kMeta);
+    ASSERT_EQ(FileTypeUtils::Classify("dfs://cluster/db/_SUCCESS"), FileType::kMeta);
+    ASSERT_EQ(FileTypeUtils::Classify("dfs://cluster/db/part-1_SUCCESS"), FileType::kMeta);
+    ASSERT_EQ(FileTypeUtils::Classify("dfs://cluster/db/hint/EARLIEST"), FileType::kMeta);
+    ASSERT_EQ(FileTypeUtils::Classify("dfs://cluster/db/hint/LATEST"), FileType::kMeta);
+    ASSERT_EQ(FileTypeUtils::Classify("dfs://cluster/db/changelog/changelog-123"), FileType::kMeta);
+}
+
+TEST(FileTypeTest, TestDefaultData) {
+    ASSERT_EQ(FileTypeUtils::Classify("dfs://cluster/db/p=1/bucket-0/data-1.orc"), FileType::kData);
+    ASSERT_EQ(FileTypeUtils::Classify("dfs://cluster/db/p=1/bucket-0/data-1.parquet"),
+              FileType::kData);
+    ASSERT_EQ(FileTypeUtils::Classify("dfs://cluster/db/p=1/bucket-0/changelog-a1b2c3d4-0.orc"),
+              FileType::kData);
+    ASSERT_EQ(FileTypeUtils::Classify("dfs://cluster/db/p=1/bucket-0/data-a1b2c3d4-0.blob"),
+              FileType::kData);
+    ASSERT_EQ(FileTypeUtils::Classify("dfs://cluster/db/p=1/bucket-0/data-a1b2c3d4-0.vector.lance"),
+              FileType::kData);
+    ASSERT_EQ(FileTypeUtils::Classify("dfs://cluster/db/random/unknown.bin"), FileType::kData);
+}
+
+TEST(FileTypeTest, TestChangelogInAncestorPathNotMisclassified) {
+    const std::string root = "hdfs://cluster/changelog/warehouse/db.db/table";
+    ASSERT_EQ(FileTypeUtils::Classify(root + "/dt=2024-01-01/bucket-0/data-a1b2c3d4-0.orc"),
+              FileType::kData);
+    ASSERT_EQ(FileTypeUtils::Classify(root + "/dt=2024-01-01/bucket-0/changelog-a1b2c3d4-0.orc"),
+              FileType::kData);
+}
+
+TEST(FileTypeTest, TestBranchPaths) {
+    const std::string branch_root = "hdfs://cluster/warehouse/db.db/table/branch/branch-dev";
+    ASSERT_EQ(FileTypeUtils::Classify(branch_root + "/snapshot/snapshot-1"), FileType::kMeta);
+    ASSERT_EQ(FileTypeUtils::Classify(branch_root + "/schema/schema-0"), FileType::kMeta);
+    ASSERT_EQ(FileTypeUtils::Classify(branch_root + "/changelog/changelog-1"), FileType::kMeta);
+    ASSERT_EQ(FileTypeUtils::Classify(branch_root + "/index/index-a1b2c3d4-0"),
+              FileType::kBucketIndex);
+    ASSERT_EQ(FileTypeUtils::Classify(branch_root + "/index/btree-global-index-a1b2c3d4.index"),
+              FileType::kGlobalIndex);
+}
+
+TEST(FileTypeTest, TestTempWrappedName) {
+    ASSERT_EQ(FileTypeUtils::Classify(
+                  "dfs://cluster/db/snapshot/.snapshot-1.12345678-1234-1234-1234-123456789abc.tmp"),
+              FileType::kMeta);
+
+    ASSERT_EQ(FileTypeUtils::Classify(
+                  "dfs://cluster/db/schema/.schema-0.12345678-1234-1234-1234-123456789abc.tmp"),
+              FileType::kMeta);
+
+    ASSERT_EQ(FileTypeUtils::Classify(
+                  "dfs://cluster/db/tag/.tag-myTag.12345678-1234-1234-1234-123456789abc.tmp"),
+              FileType::kMeta);
+
+    ASSERT_EQ(FileTypeUtils::Classify(
+                  "dfs://cluster/db/consumer/.consumer-myGroup.12345678-1234-1234-1234-"
+                  "123456789abc.tmp"),
+              FileType::kMeta);
+
+    ASSERT_EQ(FileTypeUtils::Classify(
+                  "dfs://cluster/db/service/.service-primary-key-lookup.12345678-1234-1234-1234-"
+                  "123456789abc.tmp"),
+              FileType::kMeta);
+
+    ASSERT_EQ(FileTypeUtils::Classify(
+                  "dfs://cluster/db/snapshot/.EARLIEST.12345678-1234-1234-1234-123456789abc.tmp"),
+              FileType::kMeta);
+
+    ASSERT_EQ(FileTypeUtils::Classify(
+                  "dfs://cluster/db/snapshot/.LATEST.12345678-1234-1234-1234-123456789abc.tmp"),
+              FileType::kMeta);
+
+    ASSERT_EQ(
+        FileTypeUtils::Classify(
+            "dfs://cluster/db/p=1/bucket-0/._SUCCESS.12345678-1234-1234-1234-123456789abc.tmp"),
+        FileType::kMeta);
+
+    ASSERT_EQ(
+        FileTypeUtils::Classify(
+            "dfs://cluster/db/changelog/.changelog-1.12345678-1234-1234-1234-123456789abc.tmp"),
+        FileType::kMeta);
+
+    ASSERT_EQ(FileTypeUtils::Classify(
+                  "dfs://cluster/db/statistics/.stat-a1b2c3d4-0.12345678-1234-1234-1234-"
+                  "123456789abc.tmp"),
+              FileType::kMeta);
+
+    ASSERT_EQ(
+        FileTypeUtils::Classify(
+            "dfs://cluster/db/p=1/bucket-0/.data-1.orc.12345678-1234-1234-1234-123456789abc.tmp"),
+        FileType::kData);
+
+    ASSERT_EQ(FileTypeUtils::Classify(
+                  "dfs://cluster/db/index/.bitmap.index.12345678-1234-1234-1234-123456789abc.tmp"),
+              FileType::kFileIndex);
+
+    ASSERT_EQ(FileTypeUtils::Classify(
+                  "dfs://cluster/db/index/.bitmap-global-index-1.index.12345678-1234-1234-1234-"
+                  "123456789abc.tmp"),
+              FileType::kGlobalIndex);
+}
+
+TEST(FileTypeTest, TestInvalidTempWrapperFallsBackToOriginalName) {
+    // No leading dot -> should not unwrap.
+    ASSERT_EQ(FileTypeUtils::Classify(
+                  "dfs://cluster/db/snapshot/snapshot-1.12345678-1234-1234-1234-123456789abc.tmp"),
+              FileType::kMeta);
+
+    // No .tmp suffix -> should not unwrap.
+    ASSERT_EQ(FileTypeUtils::Classify(
+                  "dfs://cluster/db/snapshot/.snapshot-1.12345678-1234-1234-1234-123456789abc"),
+              FileType::kData);
+
+    // Too short -> should not unwrap.
+    ASSERT_EQ(FileTypeUtils::Classify("dfs://cluster/db/snapshot/.x.tmp"), FileType::kData);
+}
+
+}  // namespace paimon::test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

Adds a FileType abstraction and utility methods to classify Paimon file paths into meta/data/index categories.

<!-- What is the purpose of the change -->

### Tests

FileTypeTest
    TestIsIndex
    TestMetaPrefix
    TestIndexTypes
    TestMetaSpecialNames
    TestDefaultData
    TestChangelogInAncestorPathNotMisclassified
    TestBranchPaths
    TestTempWrappedName
    TestInvalidTempWrapperFallsBackToOriginalName

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
