### PR TITLE
feat(spill): support to create ExternalSortBuffer in WriteBuffer

### DIFF
--- a/src/paimon/core/mergetree/compact/lookup_merge_tree_compact_rewriter_test.cpp
+++ b/src/paimon/core/mergetree/compact/lookup_merge_tree_compact_rewriter_test.cpp
@@ -44,12 +44,10 @@
 #include "paimon/core/mergetree/lookup_levels.h"
 #include "paimon/core/mergetree/merge_tree_writer.h"
 #include "paimon/core/schema/schema_manager.h"
-#include "paimon/core/table/source/data_split_impl.h"
 #include "paimon/format/file_format_factory.h"
 #include "paimon/memory/memory_pool.h"
 #include "paimon/record_batch.h"
 #include "paimon/scan_context.h"
-#include "paimon/table/source/table_scan.h"
 #include "paimon/testing/mock/mock_index_path_factory.h"
 #include "paimon/testing/utils/binary_row_generator.h"
 #include "paimon/testing/utils/io_exception_helper.h"
@@ -96,12 +94,14 @@ class LookupMergeTreeCompactRewriterTest : public ::testing::TestWithParam<std::
         if (!latest_schema) {
             return Status::Invalid("cannot find latest schema");
         }
-        auto writer = std::make_shared<MergeTreeWriter>(
-            /*last_sequence_number=*/last_sequence_number, std::vector<std::string>({"key"}),
-            data_path_factory, key_comparator,
-            /*user_defined_seq_comparator=*/nullptr, merge_function_wrapper,
-            /*schema_id=*/latest_schema.value()->Id(), arrow_schema_, options,
-            std::make_shared<NoopCompactManager>(), pool_);
+
+        PAIMON_ASSIGN_OR_RAISE(
+            auto writer,
+            MergeTreeWriter::Create(
+                /*last_sequence_number=*/last_sequence_number, std::vector<std::string>({"key"}),
+                data_path_factory, key_comparator, /*user_defined_seq_comparator=*/nullptr,
+                merge_function_wrapper, /*schema_id=*/latest_schema.value()->Id(), arrow_schema_,
+                options, std::make_shared<NoopCompactManager>(), /*io_manager=*/nullptr, pool_));
 
         // write data
         ArrowArray c_src_array;

--- a/src/paimon/core/mergetree/lookup/remote_lookup_file_manager_test.cpp
+++ b/src/paimon/core/mergetree/lookup/remote_lookup_file_manager_test.cpp
@@ -38,7 +38,6 @@
 #include "paimon/core/schema/schema_manager.h"
 #include "paimon/memory/memory_pool.h"
 #include "paimon/record_batch.h"
-#include "paimon/testing/utils/binary_row_generator.h"
 #include "paimon/testing/utils/testharness.h"
 
 namespace paimon::test {
@@ -77,11 +76,13 @@ class RemoteLookupFileManagerTest : public testing::Test {
         auto merge_function_wrapper =
             std::make_shared<ReducerMergeFunctionWrapper>(std::move(mfunc));
 
-        auto writer = std::make_shared<MergeTreeWriter>(
-            /*last_sequence_number=*/last_sequence_number, std::vector<std::string>({"key"}),
-            data_path_factory, key_comparator,
-            /*user_defined_seq_comparator=*/nullptr, merge_function_wrapper, /*schema_id=*/0,
-            arrow_schema_, options, noop_compact_manager_, pool_);
+        PAIMON_ASSIGN_OR_RAISE(
+            auto writer,
+            MergeTreeWriter::Create(/*last_sequence_number=*/last_sequence_number,
+                                    std::vector<std::string>({"key"}), data_path_factory,
+                                    key_comparator, /*user_defined_seq_comparator=*/nullptr,
+                                    merge_function_wrapper, /*schema_id=*/0, arrow_schema_, options,
+                                    noop_compact_manager_, /*io_manager=*/nullptr, pool_));
 
         ArrowArray c_src_array;
         PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportArray(*src_array, &c_src_array));

--- a/src/paimon/core/mergetree/lookup_levels_test.cpp
+++ b/src/paimon/core/mergetree/lookup_levels_test.cpp
@@ -29,6 +29,7 @@
 #include "paimon/common/utils/path_util.h"
 #include "paimon/core/compact/noop_compact_manager.h"
 #include "paimon/core/core_options.h"
+#include "paimon/core/disk/io_manager.h"
 #include "paimon/core/io/data_file_path_factory.h"
 #include "paimon/core/mergetree/compact/deduplicate_merge_function.h"
 #include "paimon/core/mergetree/compact/reducer_merge_function_wrapper.h"
@@ -79,11 +80,13 @@ class LookupLevelsTest : public testing::Test {
         auto merge_function_wrapper =
             std::make_shared<ReducerMergeFunctionWrapper>(std::move(mfunc));
 
-        auto writer = std::make_shared<MergeTreeWriter>(
-            /*last_sequence_number=*/last_sequence_number, std::vector<std::string>({"key"}),
-            data_path_factory, key_comparator,
-            /*user_defined_seq_comparator=*/nullptr, merge_function_wrapper, /*schema_id=*/0,
-            arrow_schema_, options, noop_compact_manager_, pool_);
+        PAIMON_ASSIGN_OR_RAISE(
+            auto writer,
+            MergeTreeWriter::Create(/*last_sequence_number=*/last_sequence_number,
+                                    std::vector<std::string>({"key"}), data_path_factory,
+                                    key_comparator, /*user_defined_seq_comparator=*/nullptr,
+                                    merge_function_wrapper, /*schema_id=*/0, arrow_schema_, options,
+                                    noop_compact_manager_, /*io_manager=*/nullptr, pool_));
 
         // write data
         ArrowArray c_src_array;
@@ -429,7 +432,7 @@ TEST_F(LookupLevelsTest, TestLookupLevel0WithMultipleFiles) {
     ASSERT_FALSE(positioned_kv);
 }
 
-TEST_F(LookupLevelsTest, TestWithPosistion) {
+TEST_F(LookupLevelsTest, TestWithPosition) {
     std::map<std::string, std::string> options = {};
     ASSERT_OK_AND_ASSIGN(CoreOptions core_options, CoreOptions::FromMap(options));
     ASSERT_OK_AND_ASSIGN(auto table_path, CreateTable(options));

--- a/src/paimon/core/mergetree/merge_tree_writer.cpp
+++ b/src/paimon/core/mergetree/merge_tree_writer.cpp
@@ -18,7 +18,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cstddef>
 #include <unordered_set>
 #include <utility>
 
@@ -29,6 +28,7 @@
 #include "paimon/common/table/special_fields.h"
 #include "paimon/common/utils/arrow/status_utils.h"
 #include "paimon/common/utils/scope_guard.h"
+#include "paimon/core/disk/io_manager.h"
 #include "paimon/core/io/async_key_value_producer_and_consumer.h"
 #include "paimon/core/io/compact_increment.h"
 #include "paimon/core/io/data_file_path_factory.h"
@@ -44,12 +44,11 @@
 #include "paimon/core/utils/commit_increment.h"
 #include "paimon/format/file_format.h"
 #include "paimon/format/writer_builder.h"
-#include "paimon/metrics.h"
 
 namespace paimon {
 class FormatStatsExtractor;
 
-MergeTreeWriter::MergeTreeWriter(
+Result<std::shared_ptr<MergeTreeWriter>> MergeTreeWriter::Create(
     int64_t last_sequence_number, const std::vector<std::string>& trimmed_primary_keys,
     const std::shared_ptr<DataFilePathFactory>& path_factory,
     const std::shared_ptr<FieldsComparator>& key_comparator,
@@ -57,7 +56,28 @@ MergeTreeWriter::MergeTreeWriter(
     const std::shared_ptr<MergeFunctionWrapper<KeyValue>>& merge_function_wrapper,
     int64_t schema_id, const std::shared_ptr<arrow::Schema>& value_schema,
     const CoreOptions& options, const std::shared_ptr<CompactManager>& compact_manager,
-    const std::shared_ptr<MemoryPool>& pool)
+    const std::shared_ptr<IOManager>& io_manager, const std::shared_ptr<MemoryPool>& pool) {
+    auto write_schema = SpecialFields::CompleteSequenceAndValueKindField(value_schema);
+    PAIMON_ASSIGN_OR_RAISE(
+        auto write_buffer,
+        WriteBuffer::Create(last_sequence_number, value_schema, trimmed_primary_keys,
+                            options.GetSequenceField(), key_comparator, user_defined_seq_comparator,
+                            merge_function_wrapper, options, io_manager, pool));
+    return std::shared_ptr<MergeTreeWriter>(
+        new MergeTreeWriter(pool, trimmed_primary_keys, options, path_factory, key_comparator,
+                            user_defined_seq_comparator, merge_function_wrapper, schema_id,
+                            write_schema, compact_manager, std::move(write_buffer)));
+}
+
+MergeTreeWriter::MergeTreeWriter(
+    const std::shared_ptr<MemoryPool>& pool, const std::vector<std::string>& trimmed_primary_keys,
+    const CoreOptions& options, const std::shared_ptr<DataFilePathFactory>& path_factory,
+    const std::shared_ptr<FieldsComparator>& key_comparator,
+    const std::shared_ptr<FieldsComparator>& user_defined_seq_comparator,
+    const std::shared_ptr<MergeFunctionWrapper<KeyValue>>& merge_function_wrapper,
+    int64_t schema_id, const std::shared_ptr<arrow::Schema>& write_schema,
+    const std::shared_ptr<CompactManager>& compact_manager,
+    std::unique_ptr<WriteBuffer>&& write_buffer)
     : pool_(pool),
       trimmed_primary_keys_(trimmed_primary_keys),
       options_(options),
@@ -66,13 +86,10 @@ MergeTreeWriter::MergeTreeWriter(
       user_defined_seq_comparator_(user_defined_seq_comparator),
       merge_function_wrapper_(merge_function_wrapper),
       schema_id_(schema_id),
+      write_schema_(write_schema),
       compact_manager_(compact_manager),
-      metrics_(std::make_shared<MetricsImpl>()) {
-    write_schema_ = SpecialFields::CompleteSequenceAndValueKindField(value_schema);
-    write_buffer_ = std::make_unique<WriteBuffer>(
-        last_sequence_number, arrow::struct_(value_schema->fields()), trimmed_primary_keys_,
-        options_.GetSequenceField(), key_comparator_, merge_function_wrapper_, pool_);
-}
+      write_buffer_(std::move(write_buffer)),
+      metrics_(std::make_shared<MetricsImpl>()) {}
 
 Status MergeTreeWriter::DoClose() {
     // Request cancellation and wait for running compaction to exit.
@@ -115,16 +132,26 @@ Status MergeTreeWriter::DoClose() {
     return Status::OK();
 }
 
+Status MergeTreeWriter::FlushMemory() {
+    PAIMON_ASSIGN_OR_RAISE(bool has_remaining_quota, write_buffer_->FlushMemory());
+    if (!has_remaining_quota) {
+        PAIMON_RETURN_NOT_OK(FlushWriteBuffer(/*wait_for_latest_compaction=*/false,
+                                              /*forced_full_compaction=*/false));
+    }
+    return Status::OK();
+}
+
 Status MergeTreeWriter::Write(std::unique_ptr<RecordBatch>&& moved_batch) {
-    PAIMON_RETURN_NOT_OK(write_buffer_->Write(std::move(moved_batch)));
-    if (write_buffer_->GetMemoryUsage() >= static_cast<uint64_t>(options_.GetWriteBufferSize())) {
-        return Flush(/*wait_for_latest_compaction=*/false, /*forced_full_compaction=*/false);
+    PAIMON_ASSIGN_OR_RAISE(bool has_remaining_quota, write_buffer_->Write(std::move(moved_batch)));
+    if (!has_remaining_quota) {
+        return FlushWriteBuffer(/*wait_for_latest_compaction=*/false,
+                                /*forced_full_compaction=*/false);
     }
     return Status::OK();
 }
 
 Status MergeTreeWriter::Compact(bool full_compaction) {
-    return Flush(/*wait_for_latest_compaction=*/true, full_compaction);
+    return FlushWriteBuffer(/*wait_for_latest_compaction=*/true, full_compaction);
 }
 
 Status MergeTreeWriter::Sync() {
@@ -197,7 +224,7 @@ Status MergeTreeWriter::UpdateCompactDeletionFile(
 }
 
 Result<CommitIncrement> MergeTreeWriter::PrepareCommit(bool wait_compaction) {
-    PAIMON_RETURN_NOT_OK(Flush(wait_compaction, /*forced_full_compaction=*/false));
+    PAIMON_RETURN_NOT_OK(FlushWriteBuffer(wait_compaction, /*forced_full_compaction=*/false));
     if (options_.CommitForceCompact()) {
         wait_compaction = true;
     }
@@ -218,13 +245,14 @@ Result<bool> MergeTreeWriter::CompactNotCompleted() {
     return compact_manager_->CompactNotCompleted();
 }
 
-Status MergeTreeWriter::Flush(bool wait_for_latest_compaction, bool forced_full_compaction) {
+Status MergeTreeWriter::FlushWriteBuffer(bool wait_for_latest_compaction,
+                                         bool forced_full_compaction) {
     if (!write_buffer_->IsEmpty()) {
         if (compact_manager_->ShouldWaitForLatestCompaction()) {
             wait_for_latest_compaction = true;
         }
         auto cleanup_guard = ScopeGuard([&]() { write_buffer_->Clear(); });
-        // 1. flush write buffer to get in-memory readers
+        // 1. flush write buffer to get sorted readers
         PAIMON_ASSIGN_OR_RAISE(std::vector<std::unique_ptr<KeyValueRecordReader>> readers,
                                write_buffer_->CreateReaders());
         // 2. prepare loser tree sort merge reader
@@ -257,6 +285,7 @@ Status MergeTreeWriter::Flush(bool wait_for_latest_compaction, bool forced_full_
         PAIMON_RETURN_NOT_OK(rolling_writer->Close());
         PAIMON_ASSIGN_OR_RAISE(std::vector<std::shared_ptr<DataFileMeta>> flushed_files,
                                rolling_writer->GetResult());
+        async_key_value_producer_consumer->Close();
         write_guard.Release();
 
         for (const auto& flushed_file : flushed_files) {

--- a/src/paimon/core/mergetree/merge_tree_writer.cpp
+++ b/src/paimon/core/mergetree/merge_tree_writer.cpp
@@ -59,7 +59,7 @@ Result<std::shared_ptr<MergeTreeWriter>> MergeTreeWriter::Create(
     const std::shared_ptr<IOManager>& io_manager, const std::shared_ptr<MemoryPool>& pool) {
     auto write_schema = SpecialFields::CompleteSequenceAndValueKindField(value_schema);
     PAIMON_ASSIGN_OR_RAISE(
-        auto write_buffer,
+        std::unique_ptr<WriteBuffer> write_buffer,
         WriteBuffer::Create(last_sequence_number, value_schema, trimmed_primary_keys,
                             options.GetSequenceField(), key_comparator, user_defined_seq_comparator,
                             merge_function_wrapper, options, io_manager, pool));

--- a/src/paimon/core/mergetree/merge_tree_writer.h
+++ b/src/paimon/core/mergetree/merge_tree_writer.h
@@ -32,7 +32,6 @@
 #include "paimon/core/mergetree/write_buffer.h"
 #include "paimon/core/utils/batch_writer.h"
 #include "paimon/core/utils/commit_increment.h"
-#include "paimon/core/utils/path_factory.h"
 #include "paimon/record_batch.h"
 #include "paimon/result.h"
 #include "paimon/status.h"
@@ -46,6 +45,7 @@ class StructArray;
 
 namespace paimon {
 class DataFilePathFactory;
+class IOManager;
 class FieldsComparator;
 class MemoryPool;
 class Metrics;
@@ -54,16 +54,15 @@ class MergeFunctionWrapper;
 
 class MergeTreeWriter : public BatchWriter {
  public:
-    MergeTreeWriter(int64_t last_sequence_number,
-                    const std::vector<std::string>& trimmed_primary_keys,
-                    const std::shared_ptr<DataFilePathFactory>& path_factory,
-                    const std::shared_ptr<FieldsComparator>& key_comparator,
-                    const std::shared_ptr<FieldsComparator>& user_defined_seq_comparator,
-                    const std::shared_ptr<MergeFunctionWrapper<KeyValue>>& merge_function_wrapper,
-                    int64_t schema_id, const std::shared_ptr<arrow::Schema>& value_schema,
-                    const CoreOptions& options,
-                    const std::shared_ptr<CompactManager>& compact_manager,
-                    const std::shared_ptr<MemoryPool>& pool);
+    static Result<std::shared_ptr<MergeTreeWriter>> Create(
+        int64_t last_sequence_number, const std::vector<std::string>& trimmed_primary_keys,
+        const std::shared_ptr<DataFilePathFactory>& path_factory,
+        const std::shared_ptr<FieldsComparator>& key_comparator,
+        const std::shared_ptr<FieldsComparator>& user_defined_seq_comparator,
+        const std::shared_ptr<MergeFunctionWrapper<KeyValue>>& merge_function_wrapper,
+        int64_t schema_id, const std::shared_ptr<arrow::Schema>& value_schema,
+        const CoreOptions& options, const std::shared_ptr<CompactManager>& compact_manager,
+        const std::shared_ptr<IOManager>& io_manager, const std::shared_ptr<MemoryPool>& pool);
 
     Status Write(std::unique_ptr<RecordBatch>&& batch) override;
 
@@ -76,12 +75,10 @@ class MergeTreeWriter : public BatchWriter {
     Result<CommitIncrement> PrepareCommit(bool wait_compaction) override;
 
     uint64_t GetMemoryUsage() const override {
-        return 0;
+        return write_buffer_->GetMemoryUsage();
     }
 
-    Status FlushMemory() override {
-        return Flush(/*wait_for_latest_compaction=*/false, /*forced_full_compaction=*/false);
-    }
+    Status FlushMemory() override;
 
     Status Close() override {
         return DoClose();
@@ -94,7 +91,7 @@ class MergeTreeWriter : public BatchWriter {
  private:
     Status DoClose();
 
-    Status Flush(bool wait_for_latest_compaction, bool forced_full_compaction);
+    Status FlushWriteBuffer(bool wait_for_latest_compaction, bool forced_full_compaction);
     Result<CommitIncrement> DrainIncrement();
 
     std::unique_ptr<RollingFileWriter<KeyValueBatch, std::shared_ptr<DataFileMeta>>>
@@ -105,6 +102,17 @@ class MergeTreeWriter : public BatchWriter {
     Status UpdateCompactDeletionFile(const std::shared_ptr<CompactDeletionFile>& new_deletion_file);
 
  private:
+    MergeTreeWriter(const std::shared_ptr<MemoryPool>& pool,
+                    const std::vector<std::string>& trimmed_primary_keys,
+                    const CoreOptions& options,
+                    const std::shared_ptr<DataFilePathFactory>& path_factory,
+                    const std::shared_ptr<FieldsComparator>& key_comparator,
+                    const std::shared_ptr<FieldsComparator>& user_defined_seq_comparator,
+                    const std::shared_ptr<MergeFunctionWrapper<KeyValue>>& merge_function_wrapper,
+                    int64_t schema_id, const std::shared_ptr<arrow::Schema>& write_schema,
+                    const std::shared_ptr<CompactManager>& compact_manager,
+                    std::unique_ptr<WriteBuffer>&& write_buffer);
+
     std::shared_ptr<MemoryPool> pool_;
     std::vector<std::string> trimmed_primary_keys_;
     CoreOptions options_;

--- a/src/paimon/core/mergetree/merge_tree_writer_test.cpp
+++ b/src/paimon/core/mergetree/merge_tree_writer_test.cpp
@@ -1063,4 +1063,7 @@ TEST_F(MergeTreeWriterTest, TestUpdateCompactResultWithFileInCompactBefore) {
     ASSERT_EQ(merge_writer->compact_after_, std::vector<std::shared_ptr<DataFileMeta>>({file_y}));
 }
 
+INSTANTIATE_TEST_SUITE_P(WithOptionalIOManager, MergeTreeWriterTest,
+                         ::testing::Values(false, true));
+
 }  // namespace paimon::test

--- a/src/paimon/core/mergetree/merge_tree_writer_test.cpp
+++ b/src/paimon/core/mergetree/merge_tree_writer_test.cpp
@@ -18,6 +18,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <functional>
 #include <map>
 #include <optional>
 #include <utility>
@@ -34,6 +35,7 @@
 #include "paimon/common/utils/fields_comparator.h"
 #include "paimon/common/utils/scope_guard.h"
 #include "paimon/core/compact/noop_compact_manager.h"
+#include "paimon/core/disk/io_manager.h"
 #include "paimon/core/io/compact_increment.h"
 #include "paimon/core/io/data_file_path_factory.h"
 #include "paimon/core/io/data_increment.h"
@@ -47,7 +49,6 @@
 #include "paimon/fs/file_system.h"
 #include "paimon/fs/local/local_file_system.h"
 #include "paimon/memory/memory_pool.h"
-#include "paimon/testing/mock/mock_file_system.h"
 #include "paimon/testing/utils/binary_row_generator.h"
 #include "paimon/testing/utils/io_exception_helper.h"
 #include "paimon/testing/utils/read_result_collector.h"
@@ -59,7 +60,7 @@ class MergeFunctionWrapper;
 }  // namespace paimon
 
 namespace paimon::test {
-class MergeTreeWriterTest : public ::testing::Test {
+class MergeTreeWriterTest : public ::testing::TestWithParam<bool> {
  public:
     class FakeCompactManager : public paimon::CompactManager {
      public:
@@ -177,7 +178,7 @@ class MergeTreeWriterTest : public ::testing::Test {
     std::shared_ptr<NoopCompactManager> noop_compact_manager_;
 };
 
-TEST_F(MergeTreeWriterTest, TestSimple) {
+TEST_P(MergeTreeWriterTest, TestSimple) {
     ASSERT_OK_AND_ASSIGN(CoreOptions options,
                          CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"}}));
 
@@ -187,10 +188,14 @@ TEST_F(MergeTreeWriterTest, TestSimple) {
     ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
     std::string uuid = path_factory->uuid_;
 
-    auto merge_writer = std::make_shared<MergeTreeWriter>(
-        /*last_sequence_number=*/-1, primary_keys_, path_factory, key_comparator_,
-        /*user_defined_seq_comparator=*/nullptr, merge_function_wrapper_, /*schema_id=*/1,
-        value_schema_, options, noop_compact_manager_, pool_);
+    std::shared_ptr<IOManager> io_manager =
+        GetParam() ? std::make_shared<IOManager>(dir->Str() + "/tmp", file_system_) : nullptr;
+    ASSERT_OK_AND_ASSIGN(
+        auto merge_writer,
+        MergeTreeWriter::Create(/*last_sequence_number=*/-1, primary_keys_, path_factory,
+                                key_comparator_, /*user_defined_seq_comparator=*/nullptr,
+                                merge_function_wrapper_, /*schema_id=*/1, value_schema_, options,
+                                noop_compact_manager_, io_manager, pool_));
 
     // write batch
     std::shared_ptr<arrow::Array> array1 =
@@ -249,7 +254,7 @@ TEST_F(MergeTreeWriterTest, TestSimple) {
     ASSERT_EQ(expected_data_increment, commit_increment.GetNewFilesIncrement());
 }
 
-TEST_F(MergeTreeWriterTest, TestWriteMultiBatch) {
+TEST_P(MergeTreeWriterTest, TestWriteMultiBatch) {
     ASSERT_OK_AND_ASSIGN(CoreOptions options,
                          CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"}}));
 
@@ -259,10 +264,14 @@ TEST_F(MergeTreeWriterTest, TestWriteMultiBatch) {
     ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
     std::string uuid = path_factory->uuid_;
 
-    auto merge_writer = std::make_shared<MergeTreeWriter>(
-        /*last_sequence_number=*/9, primary_keys_, path_factory, key_comparator_,
-        /*user_defined_seq_comparator=*/nullptr, merge_function_wrapper_, /*schema_id=*/0,
-        value_schema_, options, noop_compact_manager_, pool_);
+    std::shared_ptr<IOManager> io_manager =
+        GetParam() ? std::make_shared<IOManager>(dir->Str() + "/tmp", file_system_) : nullptr;
+    ASSERT_OK_AND_ASSIGN(
+        auto merge_writer,
+        MergeTreeWriter::Create(/*last_sequence_number=*/9, primary_keys_, path_factory,
+                                key_comparator_, /*user_defined_seq_comparator=*/nullptr,
+                                merge_function_wrapper_, /*schema_id=*/0, value_schema_, options,
+                                noop_compact_manager_, io_manager, pool_));
     // batch1
     std::shared_ptr<arrow::Array> array1 =
         arrow::ipc::internal::json::ArrayFromJSON(value_type_, R"([
@@ -331,7 +340,7 @@ TEST_F(MergeTreeWriterTest, TestWriteMultiBatch) {
     ASSERT_EQ(expected_data_increment, commit_increment.GetNewFilesIncrement());
 }
 
-TEST_F(MergeTreeWriterTest, TestWriteWithDeleteRow) {
+TEST_P(MergeTreeWriterTest, TestWriteWithDeleteRow) {
     ASSERT_OK_AND_ASSIGN(
         CoreOptions options,
         CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"}, {Options::SEQUENCE_FIELD, "f1"}}));
@@ -346,10 +355,14 @@ TEST_F(MergeTreeWriterTest, TestWriteWithDeleteRow) {
                          FieldsComparator::Create({value_fields_[1]},
                                                   /*is_ascending_order=*/true));
     assert(user_defined_seq_comparator);
-    auto merge_writer = std::make_shared<MergeTreeWriter>(
-        /*last_sequence_number=*/9, primary_keys_, path_factory, key_comparator_,
-        user_defined_seq_comparator, merge_function_wrapper_, /*schema_id=*/0, value_schema_,
-        options, noop_compact_manager_, pool_);
+    std::shared_ptr<IOManager> io_manager =
+        GetParam() ? std::make_shared<IOManager>(dir->Str() + "/tmp", file_system_) : nullptr;
+    ASSERT_OK_AND_ASSIGN(
+        auto merge_writer,
+        MergeTreeWriter::Create(/*last_sequence_number=*/9, primary_keys_, path_factory,
+                                key_comparator_, user_defined_seq_comparator,
+                                merge_function_wrapper_, /*schema_id=*/0, value_schema_, options,
+                                noop_compact_manager_, io_manager, pool_));
     // batch1
     std::shared_ptr<arrow::Array> array1 =
         arrow::ipc::internal::json::ArrayFromJSON(value_type_, R"([
@@ -411,7 +424,7 @@ TEST_F(MergeTreeWriterTest, TestWriteWithDeleteRow) {
     ASSERT_EQ(expected_data_increment, commit_increment.GetNewFilesIncrement());
 }
 
-TEST_F(MergeTreeWriterTest, TestMultiplePrepareCommit) {
+TEST_P(MergeTreeWriterTest, TestMultiplePrepareCommit) {
     ASSERT_OK_AND_ASSIGN(CoreOptions options,
                          CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"},
                                                {"orc.write.enable-metrics", "true"}}));
@@ -422,10 +435,14 @@ TEST_F(MergeTreeWriterTest, TestMultiplePrepareCommit) {
     ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
     std::string uuid = path_factory->uuid_;
 
-    auto merge_writer = std::make_shared<MergeTreeWriter>(
-        /*last_sequence_number=*/9, primary_keys_, path_factory, key_comparator_,
-        /*user_defined_seq_comparator=*/nullptr, merge_function_wrapper_, /*schema_id=*/0,
-        value_schema_, options, noop_compact_manager_, pool_);
+    std::shared_ptr<IOManager> io_manager =
+        GetParam() ? std::make_shared<IOManager>(dir->Str() + "/tmp", file_system_) : nullptr;
+    ASSERT_OK_AND_ASSIGN(
+        auto merge_writer,
+        MergeTreeWriter::Create(/*last_sequence_number=*/9, primary_keys_, path_factory,
+                                key_comparator_, /*user_defined_seq_comparator=*/nullptr,
+                                merge_function_wrapper_, /*schema_id=*/0, value_schema_, options,
+                                noop_compact_manager_, io_manager, pool_));
     // batch1
     std::shared_ptr<arrow::Array> array1 =
         arrow::ipc::internal::json::ArrayFromJSON(value_type_, R"([
@@ -548,7 +565,7 @@ TEST_F(MergeTreeWriterTest, TestMultiplePrepareCommit) {
     ASSERT_EQ(expected_data_increment2, commit_increment2.GetNewFilesIncrement());
 }
 
-TEST_F(MergeTreeWriterTest, TestPrepareCommitForEmptyData) {
+TEST_P(MergeTreeWriterTest, TestPrepareCommitForEmptyData) {
     ASSERT_OK_AND_ASSIGN(CoreOptions options,
                          CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"}}));
 
@@ -558,10 +575,14 @@ TEST_F(MergeTreeWriterTest, TestPrepareCommitForEmptyData) {
     ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
     std::string uuid = path_factory->uuid_;
 
-    auto merge_writer = std::make_shared<MergeTreeWriter>(
-        /*last_sequence_number=*/-1, primary_keys_, path_factory, key_comparator_,
-        /*user_defined_seq_comparator=*/nullptr, merge_function_wrapper_, /*schema_id=*/0,
-        value_schema_, options, noop_compact_manager_, pool_);
+    std::shared_ptr<IOManager> io_manager =
+        GetParam() ? std::make_shared<IOManager>(dir->Str() + "/tmp", file_system_) : nullptr;
+    ASSERT_OK_AND_ASSIGN(
+        auto merge_writer,
+        MergeTreeWriter::Create(/*last_sequence_number=*/-1, primary_keys_, path_factory,
+                                key_comparator_, /*user_defined_seq_comparator=*/nullptr,
+                                merge_function_wrapper_, /*schema_id=*/0, value_schema_, options,
+                                noop_compact_manager_, io_manager, pool_));
 
     // prepare commit, without write
     ASSERT_OK_AND_ASSIGN(CommitIncrement commit_increment,
@@ -588,7 +609,7 @@ TEST_F(MergeTreeWriterTest, TestPrepareCommitForEmptyData) {
     ASSERT_FALSE(options.GetFileSystem()->Exists(expected_data_file_path).value());
 }
 
-TEST_F(MergeTreeWriterTest, TestCloseBeforePrepareCommit) {
+TEST_P(MergeTreeWriterTest, TestCloseBeforePrepareCommit) {
     ASSERT_OK_AND_ASSIGN(CoreOptions options,
                          CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"}}));
 
@@ -598,10 +619,14 @@ TEST_F(MergeTreeWriterTest, TestCloseBeforePrepareCommit) {
     ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
     std::string uuid = path_factory->uuid_;
 
-    auto merge_writer = std::make_shared<MergeTreeWriter>(
-        /*last_sequence_number=*/-1, primary_keys_, path_factory, key_comparator_,
-        /*user_defined_seq_comparator=*/nullptr, merge_function_wrapper_, /*schema_id=*/0,
-        value_schema_, options, noop_compact_manager_, pool_);
+    std::shared_ptr<IOManager> io_manager =
+        GetParam() ? std::make_shared<IOManager>(dir->Str() + "/tmp", file_system_) : nullptr;
+    ASSERT_OK_AND_ASSIGN(
+        auto merge_writer,
+        MergeTreeWriter::Create(/*last_sequence_number=*/-1, primary_keys_, path_factory,
+                                key_comparator_, /*user_defined_seq_comparator=*/nullptr,
+                                merge_function_wrapper_, /*schema_id=*/0, value_schema_, options,
+                                noop_compact_manager_, io_manager, pool_));
 
     // write batch
     std::shared_ptr<arrow::Array> array1 =
@@ -615,7 +640,7 @@ TEST_F(MergeTreeWriterTest, TestCloseBeforePrepareCommit) {
     ASSERT_OK(merge_writer->Close());
 }
 
-TEST_F(MergeTreeWriterTest, TestCloseDeletesUncommittedFiles) {
+TEST_P(MergeTreeWriterTest, TestCloseDeletesUncommittedFiles) {
     ASSERT_OK_AND_ASSIGN(CoreOptions options,
                          CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"}}));
 
@@ -625,10 +650,14 @@ TEST_F(MergeTreeWriterTest, TestCloseDeletesUncommittedFiles) {
     ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
     std::string uuid = path_factory->uuid_;
 
-    auto merge_writer = std::make_shared<MergeTreeWriter>(
-        /*last_sequence_number=*/-1, primary_keys_, path_factory, key_comparator_,
-        /*user_defined_seq_comparator=*/nullptr, merge_function_wrapper_, /*schema_id=*/0,
-        value_schema_, options, noop_compact_manager_, pool_);
+    std::shared_ptr<IOManager> io_manager =
+        GetParam() ? std::make_shared<IOManager>(dir->Str() + "/tmp", file_system_) : nullptr;
+    ASSERT_OK_AND_ASSIGN(
+        auto merge_writer,
+        MergeTreeWriter::Create(/*last_sequence_number=*/-1, primary_keys_, path_factory,
+                                key_comparator_, /*user_defined_seq_comparator=*/nullptr,
+                                merge_function_wrapper_, /*schema_id=*/0, value_schema_, options,
+                                noop_compact_manager_, io_manager, pool_));
 
     std::shared_ptr<arrow::Array> array1 =
         arrow::ipc::internal::json::ArrayFromJSON(value_type_, R"([
@@ -649,11 +678,12 @@ TEST_F(MergeTreeWriterTest, TestCloseDeletesUncommittedFiles) {
     ASSERT_FALSE(options.GetFileSystem()->Exists(expected_data_file_path).value());
 }
 
-TEST_F(MergeTreeWriterTest, TestAutoFlush) {
+TEST_P(MergeTreeWriterTest, TestAutoFlush) {
     // each batch is a file due to WRITE_BUFFER_SIZE
-    ASSERT_OK_AND_ASSIGN(
-        CoreOptions options,
-        CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"}, {Options::WRITE_BUFFER_SIZE, "1"}}));
+    ASSERT_OK_AND_ASSIGN(CoreOptions options,
+                         CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"},
+                                               {Options::WRITE_BUFFER_SIZE, "1"},
+                                               {Options::WRITE_BUFFER_SPILLABLE, "false"}}));
 
     auto dir = UniqueTestDirectory::Create();
     ASSERT_TRUE(dir);
@@ -661,10 +691,14 @@ TEST_F(MergeTreeWriterTest, TestAutoFlush) {
     ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
     std::string uuid = path_factory->uuid_;
 
-    auto merge_writer = std::make_shared<MergeTreeWriter>(
-        /*last_sequence_number=*/9, primary_keys_, path_factory, key_comparator_,
-        /*user_defined_seq_comparator=*/nullptr, merge_function_wrapper_, /*schema_id=*/0,
-        value_schema_, options, noop_compact_manager_, pool_);
+    std::shared_ptr<IOManager> io_manager =
+        GetParam() ? std::make_shared<IOManager>(dir->Str() + "/tmp", file_system_) : nullptr;
+    ASSERT_OK_AND_ASSIGN(
+        auto merge_writer,
+        MergeTreeWriter::Create(/*last_sequence_number=*/9, primary_keys_, path_factory,
+                                key_comparator_, /*user_defined_seq_comparator=*/nullptr,
+                                merge_function_wrapper_, /*schema_id=*/0, value_schema_, options,
+                                noop_compact_manager_, io_manager, pool_));
     // batch1
     std::shared_ptr<arrow::Array> array1 =
         arrow::ipc::internal::json::ArrayFromJSON(value_type_, R"([
@@ -768,7 +802,7 @@ TEST_F(MergeTreeWriterTest, TestAutoFlush) {
     ASSERT_EQ(expected_data_increment, commit_increment.GetNewFilesIncrement());
 }
 
-TEST_F(MergeTreeWriterTest, TestIOException) {
+TEST_P(MergeTreeWriterTest, TestIOException) {
     ASSERT_OK_AND_ASSIGN(CoreOptions options,
                          CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"}}));
 
@@ -783,10 +817,14 @@ TEST_F(MergeTreeWriterTest, TestIOException) {
         ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
         std::string uuid = path_factory->uuid_;
 
-        auto merge_writer = std::make_shared<MergeTreeWriter>(
+        std::shared_ptr<IOManager> io_manager =
+            GetParam() ? std::make_shared<IOManager>(dir->Str() + "/tmp", file_system_) : nullptr;
+        auto merge_writer_result = MergeTreeWriter::Create(
             /*last_sequence_number=*/-1, primary_keys_, path_factory, key_comparator_,
             /*user_defined_seq_comparator=*/nullptr, merge_function_wrapper_, /*schema_id=*/0,
-            value_schema_, options, noop_compact_manager_, pool_);
+            value_schema_, options, noop_compact_manager_, io_manager, pool_);
+        CHECK_HOOK_STATUS(merge_writer_result.status(), i);
+        auto merge_writer = std::move(merge_writer_result).value();
 
         // write batch
         std::shared_ptr<arrow::Array> array =
@@ -812,11 +850,12 @@ TEST_F(MergeTreeWriterTest, TestIOException) {
     ASSERT_TRUE(run_complete);
 }
 
-TEST_F(MergeTreeWriterTest, TestBulkData) {
+TEST_P(MergeTreeWriterTest, TestBulkData) {
     // each batch is a file due to WRITE_BUFFER_SIZE
-    ASSERT_OK_AND_ASSIGN(
-        CoreOptions options,
-        CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"}, {Options::WRITE_BUFFER_SIZE, "1"}}));
+    ASSERT_OK_AND_ASSIGN(CoreOptions options,
+                         CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"},
+                                               {Options::WRITE_BUFFER_SIZE, "1"},
+                                               {Options::WRITE_BUFFER_SPILLABLE, "false"}}));
 
     auto dir = UniqueTestDirectory::Create();
     ASSERT_TRUE(dir);
@@ -824,10 +863,14 @@ TEST_F(MergeTreeWriterTest, TestBulkData) {
     ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
     std::string uuid = path_factory->uuid_;
 
-    auto merge_writer = std::make_shared<MergeTreeWriter>(
-        /*last_sequence_number=*/-1, primary_keys_, path_factory, key_comparator_,
-        /*user_defined_seq_comparator=*/nullptr, merge_function_wrapper_, /*schema_id=*/0,
-        value_schema_, options, noop_compact_manager_, pool_);
+    std::shared_ptr<IOManager> io_manager =
+        GetParam() ? std::make_shared<IOManager>(dir->Str() + "/tmp", file_system_) : nullptr;
+    ASSERT_OK_AND_ASSIGN(
+        auto merge_writer,
+        MergeTreeWriter::Create(/*last_sequence_number=*/-1, primary_keys_, path_factory,
+                                key_comparator_, /*user_defined_seq_comparator=*/nullptr,
+                                merge_function_wrapper_, /*schema_id=*/0, value_schema_, options,
+                                noop_compact_manager_, io_manager, pool_));
     // multi batch
     size_t batch_size = 500;
     for (size_t i = 0; i < batch_size; ++i) {
@@ -889,10 +932,12 @@ TEST_F(MergeTreeWriterTest, TestShouldWait) {
     ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
 
     auto fake_compact_manager = std::make_shared<FakeCompactManager>();
-    auto merge_writer = std::make_shared<MergeTreeWriter>(
-        /*last_sequence_number=*/-1, primary_keys_, path_factory, key_comparator_,
-        /*user_defined_seq_comparator=*/nullptr, merge_function_wrapper_, /*schema_id=*/0,
-        value_schema_, options, fake_compact_manager, pool_);
+    ASSERT_OK_AND_ASSIGN(
+        auto merge_writer,
+        MergeTreeWriter::Create(/*last_sequence_number=*/-1, primary_keys_, path_factory,
+                                key_comparator_, /*user_defined_seq_comparator=*/nullptr,
+                                merge_function_wrapper_, /*schema_id=*/0, value_schema_, options,
+                                fake_compact_manager, /*io_manager=*/nullptr, pool_));
 
     std::shared_ptr<arrow::Array> array =
         arrow::ipc::internal::json::ArrayFromJSON(value_type_, R"([
@@ -922,10 +967,12 @@ TEST_F(MergeTreeWriterTest, TestUpdateCompactResultDeleteIntermediateFile) {
     ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
 
     auto fake_compact_manager = std::make_shared<FakeCompactManager>();
-    auto merge_writer = std::make_shared<MergeTreeWriter>(
-        /*last_sequence_number=*/-1, primary_keys_, path_factory, key_comparator_,
-        /*user_defined_seq_comparator=*/nullptr, merge_function_wrapper_, /*schema_id=*/0,
-        value_schema_, options, fake_compact_manager, pool_);
+    ASSERT_OK_AND_ASSIGN(
+        auto merge_writer,
+        MergeTreeWriter::Create(/*last_sequence_number=*/-1, primary_keys_, path_factory,
+                                key_comparator_, /*user_defined_seq_comparator=*/nullptr,
+                                merge_function_wrapper_, /*schema_id=*/0, value_schema_, options,
+                                fake_compact_manager, /*io_manager=*/nullptr, pool_));
 
     // Round 1: Before=[A], After=[X]  => compact_before_=[A], compact_after_=[X]
     // Round 2: Before=[X], After=[Y]  => X is in compact_after_, so it's an intermediate file
@@ -953,10 +1000,12 @@ TEST_F(MergeTreeWriterTest, TestUpdateCompactResultWithFileInCompactAfter) {
     ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
 
     auto fake_compact_manager = std::make_shared<FakeCompactManager>();
-    auto merge_writer = std::make_shared<MergeTreeWriter>(
-        /*last_sequence_number=*/-1, primary_keys_, path_factory, key_comparator_,
-        /*user_defined_seq_comparator=*/nullptr, merge_function_wrapper_, /*schema_id=*/0,
-        value_schema_, options, fake_compact_manager, pool_);
+    ASSERT_OK_AND_ASSIGN(
+        auto merge_writer,
+        MergeTreeWriter::Create(/*last_sequence_number=*/-1, primary_keys_, path_factory,
+                                key_comparator_, /*user_defined_seq_comparator=*/nullptr,
+                                merge_function_wrapper_, /*schema_id=*/0, value_schema_, options,
+                                fake_compact_manager, /*io_manager=*/nullptr, pool_));
 
     // Round 1: Before=[A], After=[X@level0] => compact_after_ = [X@level0]
     // Round 2 (upgrade): Before=[X@level0], After=[X@level1]
@@ -986,10 +1035,12 @@ TEST_F(MergeTreeWriterTest, TestUpdateCompactResultWithFileInCompactBefore) {
     ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
 
     auto fake_compact_manager = std::make_shared<FakeCompactManager>();
-    auto merge_writer = std::make_shared<MergeTreeWriter>(
-        /*last_sequence_number=*/-1, primary_keys_, path_factory, key_comparator_,
-        /*user_defined_seq_comparator=*/nullptr, merge_function_wrapper_, /*schema_id=*/0,
-        value_schema_, options, fake_compact_manager, pool_);
+    ASSERT_OK_AND_ASSIGN(
+        auto merge_writer,
+        MergeTreeWriter::Create(/*last_sequence_number=*/-1, primary_keys_, path_factory,
+                                key_comparator_, /*user_defined_seq_comparator=*/nullptr,
+                                merge_function_wrapper_, /*schema_id=*/0, value_schema_, options,
+                                fake_compact_manager, /*io_manager=*/nullptr, pool_));
 
     // Round 1 (upgrade): Before=[X@level0], After=[X@level1]
     // X is not in compact_after_ yet, so it goes to compact_before_ = [X].

--- a/src/paimon/core/mergetree/merge_tree_writer_test.cpp
+++ b/src/paimon/core/mergetree/merge_tree_writer_test.cpp
@@ -165,6 +165,22 @@ class MergeTreeWriterTest : public ::testing::TestWithParam<bool> {
             /*first_row_id=*/std::nullopt, /*write_cols=*/std::nullopt);
     }
 
+    Result<std::shared_ptr<MergeTreeWriter>> CreateMergeWriter(
+        int64_t last_sequence_number, const std::string& temp_dir,
+        const std::shared_ptr<DataFilePathFactory>& path_factory, int64_t schema_id,
+        const CoreOptions& options,
+        const std::shared_ptr<FieldsComparator>& user_defined_seq_comparator = nullptr,
+        const std::shared_ptr<CompactManager>& compact_manager = nullptr) const {
+        std::shared_ptr<CompactManager> writer_compact_manager =
+            compact_manager ? compact_manager : noop_compact_manager_;
+        std::shared_ptr<IOManager> io_manager =
+            GetParam() ? std::make_shared<IOManager>(temp_dir + "/tmp", file_system_) : nullptr;
+        return MergeTreeWriter::Create(last_sequence_number, primary_keys_, path_factory,
+                                       key_comparator_, user_defined_seq_comparator,
+                                       merge_function_wrapper_, schema_id, value_schema_, options,
+                                       writer_compact_manager, io_manager, pool_);
+    }
+
  private:
     std::shared_ptr<MemoryPool> pool_;
     std::shared_ptr<FileSystem> file_system_;
@@ -188,14 +204,9 @@ TEST_P(MergeTreeWriterTest, TestSimple) {
     ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
     std::string uuid = path_factory->uuid_;
 
-    std::shared_ptr<IOManager> io_manager =
-        GetParam() ? std::make_shared<IOManager>(dir->Str() + "/tmp", file_system_) : nullptr;
-    ASSERT_OK_AND_ASSIGN(
-        auto merge_writer,
-        MergeTreeWriter::Create(/*last_sequence_number=*/-1, primary_keys_, path_factory,
-                                key_comparator_, /*user_defined_seq_comparator=*/nullptr,
-                                merge_function_wrapper_, /*schema_id=*/1, value_schema_, options,
-                                noop_compact_manager_, io_manager, pool_));
+    ASSERT_OK_AND_ASSIGN(auto merge_writer,
+                         CreateMergeWriter(/*last_sequence_number=*/-1, dir->Str(), path_factory,
+                                           /*schema_id=*/1, options));
 
     // write batch
     std::shared_ptr<arrow::Array> array1 =
@@ -264,14 +275,9 @@ TEST_P(MergeTreeWriterTest, TestWriteMultiBatch) {
     ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
     std::string uuid = path_factory->uuid_;
 
-    std::shared_ptr<IOManager> io_manager =
-        GetParam() ? std::make_shared<IOManager>(dir->Str() + "/tmp", file_system_) : nullptr;
-    ASSERT_OK_AND_ASSIGN(
-        auto merge_writer,
-        MergeTreeWriter::Create(/*last_sequence_number=*/9, primary_keys_, path_factory,
-                                key_comparator_, /*user_defined_seq_comparator=*/nullptr,
-                                merge_function_wrapper_, /*schema_id=*/0, value_schema_, options,
-                                noop_compact_manager_, io_manager, pool_));
+    ASSERT_OK_AND_ASSIGN(auto merge_writer,
+                         CreateMergeWriter(/*last_sequence_number=*/9, dir->Str(), path_factory,
+                                           /*schema_id=*/0, options));
     // batch1
     std::shared_ptr<arrow::Array> array1 =
         arrow::ipc::internal::json::ArrayFromJSON(value_type_, R"([
@@ -355,14 +361,9 @@ TEST_P(MergeTreeWriterTest, TestWriteWithDeleteRow) {
                          FieldsComparator::Create({value_fields_[1]},
                                                   /*is_ascending_order=*/true));
     assert(user_defined_seq_comparator);
-    std::shared_ptr<IOManager> io_manager =
-        GetParam() ? std::make_shared<IOManager>(dir->Str() + "/tmp", file_system_) : nullptr;
-    ASSERT_OK_AND_ASSIGN(
-        auto merge_writer,
-        MergeTreeWriter::Create(/*last_sequence_number=*/9, primary_keys_, path_factory,
-                                key_comparator_, user_defined_seq_comparator,
-                                merge_function_wrapper_, /*schema_id=*/0, value_schema_, options,
-                                noop_compact_manager_, io_manager, pool_));
+    ASSERT_OK_AND_ASSIGN(auto merge_writer,
+                         CreateMergeWriter(/*last_sequence_number=*/9, dir->Str(), path_factory,
+                                           /*schema_id=*/0, options, user_defined_seq_comparator));
     // batch1
     std::shared_ptr<arrow::Array> array1 =
         arrow::ipc::internal::json::ArrayFromJSON(value_type_, R"([
@@ -435,14 +436,9 @@ TEST_P(MergeTreeWriterTest, TestMultiplePrepareCommit) {
     ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
     std::string uuid = path_factory->uuid_;
 
-    std::shared_ptr<IOManager> io_manager =
-        GetParam() ? std::make_shared<IOManager>(dir->Str() + "/tmp", file_system_) : nullptr;
-    ASSERT_OK_AND_ASSIGN(
-        auto merge_writer,
-        MergeTreeWriter::Create(/*last_sequence_number=*/9, primary_keys_, path_factory,
-                                key_comparator_, /*user_defined_seq_comparator=*/nullptr,
-                                merge_function_wrapper_, /*schema_id=*/0, value_schema_, options,
-                                noop_compact_manager_, io_manager, pool_));
+    ASSERT_OK_AND_ASSIGN(auto merge_writer,
+                         CreateMergeWriter(/*last_sequence_number=*/9, dir->Str(), path_factory,
+                                           /*schema_id=*/0, options));
     // batch1
     std::shared_ptr<arrow::Array> array1 =
         arrow::ipc::internal::json::ArrayFromJSON(value_type_, R"([
@@ -575,14 +571,9 @@ TEST_P(MergeTreeWriterTest, TestPrepareCommitForEmptyData) {
     ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
     std::string uuid = path_factory->uuid_;
 
-    std::shared_ptr<IOManager> io_manager =
-        GetParam() ? std::make_shared<IOManager>(dir->Str() + "/tmp", file_system_) : nullptr;
-    ASSERT_OK_AND_ASSIGN(
-        auto merge_writer,
-        MergeTreeWriter::Create(/*last_sequence_number=*/-1, primary_keys_, path_factory,
-                                key_comparator_, /*user_defined_seq_comparator=*/nullptr,
-                                merge_function_wrapper_, /*schema_id=*/0, value_schema_, options,
-                                noop_compact_manager_, io_manager, pool_));
+    ASSERT_OK_AND_ASSIGN(auto merge_writer,
+                         CreateMergeWriter(/*last_sequence_number=*/-1, dir->Str(), path_factory,
+                                           /*schema_id=*/0, options));
 
     // prepare commit, without write
     ASSERT_OK_AND_ASSIGN(CommitIncrement commit_increment,
@@ -619,14 +610,9 @@ TEST_P(MergeTreeWriterTest, TestCloseBeforePrepareCommit) {
     ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
     std::string uuid = path_factory->uuid_;
 
-    std::shared_ptr<IOManager> io_manager =
-        GetParam() ? std::make_shared<IOManager>(dir->Str() + "/tmp", file_system_) : nullptr;
-    ASSERT_OK_AND_ASSIGN(
-        auto merge_writer,
-        MergeTreeWriter::Create(/*last_sequence_number=*/-1, primary_keys_, path_factory,
-                                key_comparator_, /*user_defined_seq_comparator=*/nullptr,
-                                merge_function_wrapper_, /*schema_id=*/0, value_schema_, options,
-                                noop_compact_manager_, io_manager, pool_));
+    ASSERT_OK_AND_ASSIGN(auto merge_writer,
+                         CreateMergeWriter(/*last_sequence_number=*/-1, dir->Str(), path_factory,
+                                           /*schema_id=*/0, options));
 
     // write batch
     std::shared_ptr<arrow::Array> array1 =
@@ -650,14 +636,9 @@ TEST_P(MergeTreeWriterTest, TestCloseDeletesUncommittedFiles) {
     ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
     std::string uuid = path_factory->uuid_;
 
-    std::shared_ptr<IOManager> io_manager =
-        GetParam() ? std::make_shared<IOManager>(dir->Str() + "/tmp", file_system_) : nullptr;
-    ASSERT_OK_AND_ASSIGN(
-        auto merge_writer,
-        MergeTreeWriter::Create(/*last_sequence_number=*/-1, primary_keys_, path_factory,
-                                key_comparator_, /*user_defined_seq_comparator=*/nullptr,
-                                merge_function_wrapper_, /*schema_id=*/0, value_schema_, options,
-                                noop_compact_manager_, io_manager, pool_));
+    ASSERT_OK_AND_ASSIGN(auto merge_writer,
+                         CreateMergeWriter(/*last_sequence_number=*/-1, dir->Str(), path_factory,
+                                           /*schema_id=*/0, options));
 
     std::shared_ptr<arrow::Array> array1 =
         arrow::ipc::internal::json::ArrayFromJSON(value_type_, R"([
@@ -691,14 +672,9 @@ TEST_P(MergeTreeWriterTest, TestAutoFlush) {
     ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
     std::string uuid = path_factory->uuid_;
 
-    std::shared_ptr<IOManager> io_manager =
-        GetParam() ? std::make_shared<IOManager>(dir->Str() + "/tmp", file_system_) : nullptr;
-    ASSERT_OK_AND_ASSIGN(
-        auto merge_writer,
-        MergeTreeWriter::Create(/*last_sequence_number=*/9, primary_keys_, path_factory,
-                                key_comparator_, /*user_defined_seq_comparator=*/nullptr,
-                                merge_function_wrapper_, /*schema_id=*/0, value_schema_, options,
-                                noop_compact_manager_, io_manager, pool_));
+    ASSERT_OK_AND_ASSIGN(auto merge_writer,
+                         CreateMergeWriter(/*last_sequence_number=*/9, dir->Str(), path_factory,
+                                           /*schema_id=*/0, options));
     // batch1
     std::shared_ptr<arrow::Array> array1 =
         arrow::ipc::internal::json::ArrayFromJSON(value_type_, R"([
@@ -817,12 +793,8 @@ TEST_P(MergeTreeWriterTest, TestIOException) {
         ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
         std::string uuid = path_factory->uuid_;
 
-        std::shared_ptr<IOManager> io_manager =
-            GetParam() ? std::make_shared<IOManager>(dir->Str() + "/tmp", file_system_) : nullptr;
-        auto merge_writer_result = MergeTreeWriter::Create(
-            /*last_sequence_number=*/-1, primary_keys_, path_factory, key_comparator_,
-            /*user_defined_seq_comparator=*/nullptr, merge_function_wrapper_, /*schema_id=*/0,
-            value_schema_, options, noop_compact_manager_, io_manager, pool_);
+        auto merge_writer_result = CreateMergeWriter(
+            /*last_sequence_number=*/-1, dir->Str(), path_factory, /*schema_id=*/0, options);
         CHECK_HOOK_STATUS(merge_writer_result.status(), i);
         auto merge_writer = std::move(merge_writer_result).value();
 
@@ -863,14 +835,9 @@ TEST_P(MergeTreeWriterTest, TestBulkData) {
     ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
     std::string uuid = path_factory->uuid_;
 
-    std::shared_ptr<IOManager> io_manager =
-        GetParam() ? std::make_shared<IOManager>(dir->Str() + "/tmp", file_system_) : nullptr;
-    ASSERT_OK_AND_ASSIGN(
-        auto merge_writer,
-        MergeTreeWriter::Create(/*last_sequence_number=*/-1, primary_keys_, path_factory,
-                                key_comparator_, /*user_defined_seq_comparator=*/nullptr,
-                                merge_function_wrapper_, /*schema_id=*/0, value_schema_, options,
-                                noop_compact_manager_, io_manager, pool_));
+    ASSERT_OK_AND_ASSIGN(auto merge_writer,
+                         CreateMergeWriter(/*last_sequence_number=*/-1, dir->Str(), path_factory,
+                                           /*schema_id=*/0, options));
     // multi batch
     size_t batch_size = 500;
     for (size_t i = 0; i < batch_size; ++i) {
@@ -923,7 +890,7 @@ TEST_P(MergeTreeWriterTest, TestBulkData) {
     }
 }
 
-TEST_F(MergeTreeWriterTest, TestShouldWait) {
+TEST_P(MergeTreeWriterTest, TestShouldWait) {
     ASSERT_OK_AND_ASSIGN(CoreOptions options,
                          CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"}}));
     auto dir = UniqueTestDirectory::Create();
@@ -934,10 +901,8 @@ TEST_F(MergeTreeWriterTest, TestShouldWait) {
     auto fake_compact_manager = std::make_shared<FakeCompactManager>();
     ASSERT_OK_AND_ASSIGN(
         auto merge_writer,
-        MergeTreeWriter::Create(/*last_sequence_number=*/-1, primary_keys_, path_factory,
-                                key_comparator_, /*user_defined_seq_comparator=*/nullptr,
-                                merge_function_wrapper_, /*schema_id=*/0, value_schema_, options,
-                                fake_compact_manager, /*io_manager=*/nullptr, pool_));
+        CreateMergeWriter(/*last_sequence_number=*/-1, dir->Str(), path_factory, /*schema_id=*/0,
+                          options, /*user_defined_seq_comparator=*/nullptr, fake_compact_manager));
 
     std::shared_ptr<arrow::Array> array =
         arrow::ipc::internal::json::ArrayFromJSON(value_type_, R"([
@@ -957,7 +922,7 @@ TEST_F(MergeTreeWriterTest, TestShouldWait) {
     ASSERT_OK(merge_writer->Close());
 }
 
-TEST_F(MergeTreeWriterTest, TestUpdateCompactResultDeleteIntermediateFile) {
+TEST_P(MergeTreeWriterTest, TestUpdateCompactResultDeleteIntermediateFile) {
     // TODO(lisizhuo.lsz): test UpdateCompactResult in inte compaction test.
     ASSERT_OK_AND_ASSIGN(CoreOptions options,
                          CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"}}));
@@ -969,10 +934,8 @@ TEST_F(MergeTreeWriterTest, TestUpdateCompactResultDeleteIntermediateFile) {
     auto fake_compact_manager = std::make_shared<FakeCompactManager>();
     ASSERT_OK_AND_ASSIGN(
         auto merge_writer,
-        MergeTreeWriter::Create(/*last_sequence_number=*/-1, primary_keys_, path_factory,
-                                key_comparator_, /*user_defined_seq_comparator=*/nullptr,
-                                merge_function_wrapper_, /*schema_id=*/0, value_schema_, options,
-                                fake_compact_manager, /*io_manager=*/nullptr, pool_));
+        CreateMergeWriter(/*last_sequence_number=*/-1, dir->Str(), path_factory, /*schema_id=*/0,
+                          options, /*user_defined_seq_comparator=*/nullptr, fake_compact_manager));
 
     // Round 1: Before=[A], After=[X]  => compact_before_=[A], compact_after_=[X]
     // Round 2: Before=[X], After=[Y]  => X is in compact_after_, so it's an intermediate file
@@ -991,7 +954,7 @@ TEST_F(MergeTreeWriterTest, TestUpdateCompactResultDeleteIntermediateFile) {
     ASSERT_EQ(merge_writer->compact_after_, std::vector<std::shared_ptr<DataFileMeta>>({file_y}));
 }
 
-TEST_F(MergeTreeWriterTest, TestUpdateCompactResultWithFileInCompactAfter) {
+TEST_P(MergeTreeWriterTest, TestUpdateCompactResultWithFileInCompactAfter) {
     ASSERT_OK_AND_ASSIGN(CoreOptions options,
                          CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"}}));
     auto dir = UniqueTestDirectory::Create();
@@ -1002,10 +965,8 @@ TEST_F(MergeTreeWriterTest, TestUpdateCompactResultWithFileInCompactAfter) {
     auto fake_compact_manager = std::make_shared<FakeCompactManager>();
     ASSERT_OK_AND_ASSIGN(
         auto merge_writer,
-        MergeTreeWriter::Create(/*last_sequence_number=*/-1, primary_keys_, path_factory,
-                                key_comparator_, /*user_defined_seq_comparator=*/nullptr,
-                                merge_function_wrapper_, /*schema_id=*/0, value_schema_, options,
-                                fake_compact_manager, /*io_manager=*/nullptr, pool_));
+        CreateMergeWriter(/*last_sequence_number=*/-1, dir->Str(), path_factory, /*schema_id=*/0,
+                          options, /*user_defined_seq_comparator=*/nullptr, fake_compact_manager));
 
     // Round 1: Before=[A], After=[X@level0] => compact_after_ = [X@level0]
     // Round 2 (upgrade): Before=[X@level0], After=[X@level1]
@@ -1026,7 +987,7 @@ TEST_F(MergeTreeWriterTest, TestUpdateCompactResultWithFileInCompactAfter) {
               std::vector<std::shared_ptr<DataFileMeta>>({file_x_level1}));
 }
 
-TEST_F(MergeTreeWriterTest, TestUpdateCompactResultWithFileInCompactBefore) {
+TEST_P(MergeTreeWriterTest, TestUpdateCompactResultWithFileInCompactBefore) {
     ASSERT_OK_AND_ASSIGN(CoreOptions options,
                          CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"}}));
     auto dir = UniqueTestDirectory::Create();
@@ -1037,10 +998,8 @@ TEST_F(MergeTreeWriterTest, TestUpdateCompactResultWithFileInCompactBefore) {
     auto fake_compact_manager = std::make_shared<FakeCompactManager>();
     ASSERT_OK_AND_ASSIGN(
         auto merge_writer,
-        MergeTreeWriter::Create(/*last_sequence_number=*/-1, primary_keys_, path_factory,
-                                key_comparator_, /*user_defined_seq_comparator=*/nullptr,
-                                merge_function_wrapper_, /*schema_id=*/0, value_schema_, options,
-                                fake_compact_manager, /*io_manager=*/nullptr, pool_));
+        CreateMergeWriter(/*last_sequence_number=*/-1, dir->Str(), path_factory, /*schema_id=*/0,
+                          options, /*user_defined_seq_comparator=*/nullptr, fake_compact_manager));
 
     // Round 1 (upgrade): Before=[X@level0], After=[X@level1]
     // X is not in compact_after_ yet, so it goes to compact_before_ = [X].

--- a/src/paimon/core/mergetree/write_buffer.cpp
+++ b/src/paimon/core/mergetree/write_buffer.cpp
@@ -16,34 +16,56 @@
 
 #include "paimon/core/mergetree/write_buffer.h"
 
-#include <limits>
 #include <memory>
 #include <utility>
 
 #include "arrow/type.h"
+#include "paimon/core/disk/io_manager.h"
 #include "paimon/core/io/key_value_record_reader.h"
 #include "paimon/core/io/merged_key_value_record_reader.h"
+#include "paimon/core/mergetree/external_sort_buffer.h"
 #include "paimon/core/mergetree/in_memory_sort_buffer.h"
 
 namespace paimon {
 
-WriteBuffer::WriteBuffer(
-    int64_t last_sequence_number, const std::shared_ptr<arrow::DataType>& value_type,
+Result<std::unique_ptr<WriteBuffer>> WriteBuffer::Create(
+    int64_t last_sequence_number, const std::shared_ptr<arrow::Schema>& value_schema,
     const std::vector<std::string>& trimmed_primary_keys,
     const std::vector<std::string>& user_defined_sequence_fields,
     const std::shared_ptr<FieldsComparator>& key_comparator,
+    const std::shared_ptr<FieldsComparator>& user_defined_seq_comparator,
     const std::shared_ptr<MergeFunctionWrapper<KeyValue>>& merge_function_wrapper,
-    const std::shared_ptr<MemoryPool>& pool)
-    : key_comparator_(key_comparator), merge_function_wrapper_(merge_function_wrapper) {
-    // TODO(jinli.zjw): input sequence_fields_ascending as parameter
-    sort_buffer_ = std::make_unique<InMemorySortBuffer>(
+    const CoreOptions& options, const std::shared_ptr<IOManager>& io_manager,
+    const std::shared_ptr<MemoryPool>& pool) {
+    auto value_type = arrow::struct_(value_schema->fields());
+    auto in_memory_buffer = std::make_unique<InMemorySortBuffer>(
         last_sequence_number, value_type, trimmed_primary_keys, user_defined_sequence_fields,
-        /*sequence_fields_ascending=*/true, key_comparator,
-        /*write_buffer_size=*/std::numeric_limits<int64_t>::max(), pool);
+        options.SequenceFieldSortOrderIsAscending(), key_comparator, options.GetWriteBufferSize(),
+        pool);
+    std::unique_ptr<SortBuffer> sort_buffer;
+    if (!options.GetWriteBufferSpillable() || io_manager == nullptr) {
+        sort_buffer = std::move(in_memory_buffer);
+    } else {
+        PAIMON_ASSIGN_OR_RAISE(
+            sort_buffer,
+            ExternalSortBuffer::Create(std::move(in_memory_buffer), value_schema,
+                                       trimmed_primary_keys, key_comparator,
+                                       user_defined_seq_comparator, options, io_manager, pool));
+    }
+    return std::unique_ptr<WriteBuffer>(
+        new WriteBuffer(std::move(sort_buffer), key_comparator, merge_function_wrapper));
 }
 
-Status WriteBuffer::Write(std::unique_ptr<RecordBatch>&& batch) {
-    return sort_buffer_->Write(std::move(batch)).status();
+WriteBuffer::WriteBuffer(
+    std::unique_ptr<SortBuffer>&& sort_buffer,
+    const std::shared_ptr<FieldsComparator>& key_comparator,
+    const std::shared_ptr<MergeFunctionWrapper<KeyValue>>& merge_function_wrapper)
+    : sort_buffer_(std::move(sort_buffer)),
+      key_comparator_(key_comparator),
+      merge_function_wrapper_(merge_function_wrapper) {}
+
+Result<bool> WriteBuffer::Write(std::unique_ptr<RecordBatch>&& batch) {
+    return sort_buffer_->Write(std::move(batch));
 }
 
 Result<std::vector<std::unique_ptr<KeyValueRecordReader>>> WriteBuffer::CreateReaders() {
@@ -56,6 +78,10 @@ Result<std::vector<std::unique_ptr<KeyValueRecordReader>>> WriteBuffer::CreateRe
             std::move(reader), key_comparator_, merge_function_wrapper_));
     }
     return merged_readers;
+}
+
+Result<bool> WriteBuffer::FlushMemory() {
+    return sort_buffer_->FlushMemory();
 }
 
 void WriteBuffer::Clear() {

--- a/src/paimon/core/mergetree/write_buffer.h
+++ b/src/paimon/core/mergetree/write_buffer.h
@@ -46,8 +46,8 @@ template <typename T>
 class MergeFunctionWrapper;
 
 /// WriteBuffer manages the batch buffer for MergeTreeWriter.
-/// It delegates to a SortBuffer implementation (BinaryInMemorySortBuffer or
-/// BinaryExternalSortBuffer) based on the spillable configuration.
+/// It delegates to a SortBuffer implementation (InMemorySortBuffer or ExternalSortBuffer) based on
+/// the spillable configuration.
 class WriteBuffer {
  public:
     static Result<std::unique_ptr<WriteBuffer>> Create(

--- a/src/paimon/core/mergetree/write_buffer.h
+++ b/src/paimon/core/mergetree/write_buffer.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "arrow/type_fwd.h"
+#include "paimon/core/core_options.h"
 #include "paimon/core/mergetree/in_memory_sort_buffer.h"
 #include "paimon/core/mergetree/sort_buffer.h"
 #include "paimon/record_batch.h"
@@ -31,10 +32,12 @@
 namespace arrow {
 class Array;
 class DataType;
+class Schema;
 class StructArray;
 }  // namespace arrow
 
 namespace paimon {
+class IOManager;
 class KeyValueRecordReader;
 class FieldsComparator;
 class MemoryPool;
@@ -42,26 +45,34 @@ struct KeyValue;
 template <typename T>
 class MergeFunctionWrapper;
 
-/// WriteBuffer manages the in-memory batch buffer for MergeTreeWriter.
-/// It is responsible for importing Arrow data, estimating memory usage,
-/// and flushing buffered batches into KeyValueRecordReaders.
+/// WriteBuffer manages the batch buffer for MergeTreeWriter.
+/// It delegates to a SortBuffer implementation (BinaryInMemorySortBuffer or
+/// BinaryExternalSortBuffer) based on the spillable configuration.
 class WriteBuffer {
  public:
-    WriteBuffer(int64_t last_sequence_number, const std::shared_ptr<arrow::DataType>& value_type,
-                const std::vector<std::string>& trimmed_primary_keys,
-                const std::vector<std::string>& user_defined_sequence_fields,
-                const std::shared_ptr<FieldsComparator>& key_comparator,
-                const std::shared_ptr<MergeFunctionWrapper<KeyValue>>& merge_function_wrapper,
-                const std::shared_ptr<MemoryPool>& pool);
+    static Result<std::unique_ptr<WriteBuffer>> Create(
+        int64_t last_sequence_number, const std::shared_ptr<arrow::Schema>& value_schema,
+        const std::vector<std::string>& trimmed_primary_keys,
+        const std::vector<std::string>& user_defined_sequence_fields,
+        const std::shared_ptr<FieldsComparator>& key_comparator,
+        const std::shared_ptr<FieldsComparator>& user_defined_seq_comparator,
+        const std::shared_ptr<MergeFunctionWrapper<KeyValue>>& merge_function_wrapper,
+        const CoreOptions& options, const std::shared_ptr<IOManager>& io_manager,
+        const std::shared_ptr<MemoryPool>& pool);
 
     /// Import a RecordBatch into the buffer.
-    /// Does NOT check memory thresholds or trigger flush.
-    Status Write(std::unique_ptr<RecordBatch>&& batch);
+    /// Return false when the batch was accepted but the caller should fall back to
+    /// FlushWriteBuffer before buffering more data.
+    Result<bool> Write(std::unique_ptr<RecordBatch>&& batch);
 
     /// Create KeyValueRecordReaders from sort buffer without clearing the buffer.
     /// The caller should invoke Clear() after consuming the readers.
     /// @return list of KeyValueRecordReaders built from buffered data
     Result<std::vector<std::unique_ptr<KeyValueRecordReader>>> CreateReaders();
+
+    /// Try to spill current buffered data. Return false when the call completed normally but the
+    /// caller should fall back to FlushWriteBuffer before buffering more data.
+    Result<bool> FlushMemory();
 
     /// Return current memory usage in bytes.
     uint64_t GetMemoryUsage() const {
@@ -77,6 +88,10 @@ class WriteBuffer {
     void Clear();
 
  private:
+    WriteBuffer(std::unique_ptr<SortBuffer>&& sort_buffer,
+                const std::shared_ptr<FieldsComparator>& key_comparator,
+                const std::shared_ptr<MergeFunctionWrapper<KeyValue>>& merge_function_wrapper);
+
     std::unique_ptr<SortBuffer> sort_buffer_;
     std::shared_ptr<FieldsComparator> key_comparator_;
     std::shared_ptr<MergeFunctionWrapper<KeyValue>> merge_function_wrapper_;

--- a/src/paimon/core/mergetree/write_buffer_test.cpp
+++ b/src/paimon/core/mergetree/write_buffer_test.cpp
@@ -27,9 +27,12 @@
 #include "gtest/gtest.h"
 #include "paimon/common/types/data_field.h"
 #include "paimon/common/utils/fields_comparator.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/disk/io_manager.h"
 #include "paimon/core/io/key_value_record_reader.h"
 #include "paimon/core/mergetree/compact/deduplicate_merge_function.h"
 #include "paimon/core/mergetree/compact/reducer_merge_function_wrapper.h"
+#include "paimon/fs/file_system.h"
 #include "paimon/memory/memory_pool.h"
 #include "paimon/testing/utils/testharness.h"
 
@@ -48,10 +51,14 @@ class WriteBufferTest : public ::testing::Test {
  public:
     void SetUp() override {
         pool_ = GetDefaultPool();
+        tmp_dir_ = UniqueTestDirectory::Create();
+        ASSERT_TRUE(tmp_dir_);
+        io_manager_ = std::make_shared<IOManager>(tmp_dir_->Str(), tmp_dir_->GetFileSystem());
         value_fields_ = {DataField(0, arrow::field("f0", arrow::utf8())),
                          DataField(1, arrow::field("f1", arrow::int32())),
                          DataField(2, arrow::field("f2", arrow::int32())),
                          DataField(3, arrow::field("f3", arrow::float64()))};
+        value_schema_ = DataField::ConvertDataFieldsToArrowSchema(value_fields_);
         value_type_ = DataField::ConvertDataFieldsToArrowStructType(value_fields_);
         primary_keys_ = {"f0"};
         ASSERT_OK_AND_ASSIGN(key_comparator_,
@@ -61,6 +68,17 @@ class WriteBufferTest : public ::testing::Test {
         auto merge_function = std::make_unique<DeduplicateMergeFunction>(/*ignore_delete=*/false);
         merge_function_wrapper_ =
             std::make_shared<ReducerMergeFunctionWrapper>(std::move(merge_function));
+    }
+
+    std::unique_ptr<WriteBuffer> CreateWriteBuffer(int64_t last_sequence_number,
+                                                   const CoreOptions& options) const {
+        EXPECT_OK_AND_ASSIGN(
+            auto write_buffer,
+            WriteBuffer::Create(last_sequence_number, value_schema_, primary_keys_,
+                                /*user_defined_sequence_fields=*/{}, key_comparator_,
+                                /*user_defined_seq_comparator=*/nullptr, merge_function_wrapper_,
+                                options, io_manager_, pool_));
+        return write_buffer;
     }
 
     std::unique_ptr<RecordBatch> CreateBatch(
@@ -88,7 +106,10 @@ class WriteBufferTest : public ::testing::Test {
 
  protected:
     std::shared_ptr<MemoryPool> pool_;
+    std::unique_ptr<UniqueTestDirectory> tmp_dir_;
+    std::shared_ptr<IOManager> io_manager_;
     std::vector<DataField> value_fields_;
+    std::shared_ptr<arrow::Schema> value_schema_;
     std::shared_ptr<arrow::DataType> value_type_;
     std::vector<std::string> primary_keys_;
     std::shared_ptr<FieldsComparator> key_comparator_;
@@ -96,9 +117,8 @@ class WriteBufferTest : public ::testing::Test {
 };
 
 TEST_F(WriteBufferTest, TestFlushResetsStateAndAdvancesSequenceNumber) {
-    WriteBuffer write_buffer(/*last_sequence_number=*/9, value_type_, primary_keys_,
-                             /*user_defined_sequence_fields=*/{}, key_comparator_,
-                             merge_function_wrapper_, pool_);
+    ASSERT_OK_AND_ASSIGN(CoreOptions options, CoreOptions::FromMap(/*options_map=*/{}));
+    auto write_buffer = CreateWriteBuffer(/*last_sequence_number=*/9, options);
 
     std::shared_ptr<arrow::Array> array1 =
         arrow::ipc::internal::json::ArrayFromJSON(value_type_, R"([
@@ -112,17 +132,21 @@ TEST_F(WriteBufferTest, TestFlushResetsStateAndAdvancesSequenceNumber) {
     ])")
             .ValueOrDie();
 
-    ASSERT_OK(write_buffer.Write(CreateBatch(array1, /*row_kinds=*/{})));
-    ASSERT_OK(write_buffer.Write(CreateBatch(array2, /*row_kinds=*/{})));
-    ASSERT_FALSE(write_buffer.IsEmpty());
-    ASSERT_GT(write_buffer.GetMemoryUsage(), 0);
+    ASSERT_OK_AND_ASSIGN(bool buffered1,
+                         write_buffer->Write(CreateBatch(array1, /*row_kinds=*/{})));
+    ASSERT_TRUE(buffered1);
+    ASSERT_OK_AND_ASSIGN(bool buffered2,
+                         write_buffer->Write(CreateBatch(array2, /*row_kinds=*/{})));
+    ASSERT_TRUE(buffered2);
+    ASSERT_FALSE(write_buffer->IsEmpty());
+    ASSERT_GT(write_buffer->GetMemoryUsage(), 0);
 
-    ASSERT_OK_AND_ASSIGN(auto readers, write_buffer.CreateReaders());
+    ASSERT_OK_AND_ASSIGN(auto readers, write_buffer->CreateReaders());
 
     ASSERT_EQ(readers.size(), 2);
-    write_buffer.Clear();
-    ASSERT_TRUE(write_buffer.IsEmpty());
-    ASSERT_EQ(write_buffer.GetMemoryUsage(), 0);
+    write_buffer->Clear();
+    ASSERT_TRUE(write_buffer->IsEmpty());
+    ASSERT_EQ(write_buffer->GetMemoryUsage(), 0);
 
     ASSERT_OK_AND_ASSIGN(auto first_result, ReadReaderResult(readers[0].get()));
     ASSERT_EQ(first_result.sequence_numbers, (std::vector<int64_t>{10, 11}));
@@ -137,9 +161,8 @@ TEST_F(WriteBufferTest, TestFlushResetsStateAndAdvancesSequenceNumber) {
 }
 
 TEST_F(WriteBufferTest, TestFlushPreservesRowKinds) {
-    WriteBuffer write_buffer(/*last_sequence_number=*/-1, value_type_, primary_keys_,
-                             /*user_defined_sequence_fields=*/{}, key_comparator_,
-                             merge_function_wrapper_, pool_);
+    ASSERT_OK_AND_ASSIGN(CoreOptions options, CoreOptions::FromMap(/*options_map=*/{}));
+    auto write_buffer = CreateWriteBuffer(/*last_sequence_number=*/-1, options);
 
     std::shared_ptr<arrow::Array> array =
         arrow::ipc::internal::json::ArrayFromJSON(value_type_, R"([
@@ -156,9 +179,10 @@ TEST_F(WriteBufferTest, TestFlushPreservesRowKinds) {
         RecordBatch::RowKind::DELETE,
     };
 
-    ASSERT_OK(write_buffer.Write(CreateBatch(array, row_kinds)));
+    ASSERT_OK_AND_ASSIGN(bool buffered, write_buffer->Write(CreateBatch(array, row_kinds)));
+    ASSERT_TRUE(buffered);
 
-    ASSERT_OK_AND_ASSIGN(auto readers, write_buffer.CreateReaders());
+    ASSERT_OK_AND_ASSIGN(auto readers, write_buffer->CreateReaders());
     ASSERT_EQ(readers.size(), 1);
 
     ASSERT_OK_AND_ASSIGN(auto reader_result, ReadReaderResult(readers[0].get()));

--- a/src/paimon/core/operation/abstract_file_store_write.cpp
+++ b/src/paimon/core/operation/abstract_file_store_write.cpp
@@ -24,7 +24,6 @@
 #include "fmt/format.h"
 #include "paimon/common/data/binary_row.h"
 #include "paimon/common/metrics/metrics_impl.h"
-#include "paimon/core/memory/writer_memory_manager.h"
 #include "paimon/core/operation/file_store_scan.h"
 #include "paimon/core/operation/file_system_write_restore.h"
 #include "paimon/core/operation/metrics/compaction_metrics.h"
@@ -83,7 +82,7 @@ AbstractFileStoreWrite::AbstractFileStoreWrite(
       metrics_(std::make_shared<MetricsImpl>()),
       logger_(Logger::GetLogger("AbstractFileStoreWrite")) {
     writer_memory_manager_ =
-        std::make_shared<WriterMemoryManager>(static_cast<uint64_t>(options.GetWriteBufferSize()));
+        std::make_unique<WriterMemoryManager>(static_cast<uint64_t>(options.GetWriteBufferSize()));
     cache_manager_ = std::make_shared<CacheManager>(options.GetLookupCacheMaxMemory(),
                                                     options.GetLookupCacheHighPrioPoolRatio());
 }

--- a/src/paimon/core/operation/abstract_file_store_write.cpp
+++ b/src/paimon/core/operation/abstract_file_store_write.cpp
@@ -24,7 +24,7 @@
 #include "fmt/format.h"
 #include "paimon/common/data/binary_row.h"
 #include "paimon/common/metrics/metrics_impl.h"
-#include "paimon/core/manifest/manifest_entry.h"
+#include "paimon/core/memory/writer_memory_manager.h"
 #include "paimon/core/operation/file_store_scan.h"
 #include "paimon/core/operation/file_system_write_restore.h"
 #include "paimon/core/operation/metrics/compaction_metrics.h"
@@ -82,6 +82,8 @@ AbstractFileStoreWrite::AbstractFileStoreWrite(
       ignore_num_bucket_check_(ignore_num_bucket_check),
       metrics_(std::make_shared<MetricsImpl>()),
       logger_(Logger::GetLogger("AbstractFileStoreWrite")) {
+    writer_memory_manager_ =
+        std::make_shared<WriterMemoryManager>(static_cast<uint64_t>(options.GetWriteBufferSize()));
     cache_manager_ = std::make_shared<CacheManager>(options.GetLookupCacheMaxMemory(),
                                                     options.GetLookupCacheHighPrioPoolRatio());
 }
@@ -129,7 +131,9 @@ Status AbstractFileStoreWrite::Write(std::unique_ptr<RecordBatch>&& batch) {
     PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<BatchWriter> writer,
                            GetWriter(partition, batch->GetBucket()));
     assert(writer);
-    return writer->Write(std::move(batch));
+    PAIMON_RETURN_NOT_OK(writer->Write(std::move(batch)));
+    PAIMON_RETURN_NOT_OK(writer_memory_manager_->OnWriteCompleted(writer.get()));
+    return Status::OK();
 }
 
 Status AbstractFileStoreWrite::Compact(const std::map<std::string, std::string>& partition,
@@ -188,6 +192,7 @@ Result<std::vector<std::shared_ptr<CommitMessage>>> AbstractFileStoreWrite::Prep
             WriterContainer<BatchWriter>& writer_container = bucket_iter->second;
             PAIMON_ASSIGN_OR_RAISE(CommitIncrement increment,
                                    writer_container.writer->PrepareCommit(wait_compaction));
+            writer_memory_manager_->RefreshWriterMemory(writer_container.writer.get());
             auto compact_deletion_file = increment.GetCompactDeletionFile();
             auto& compact_increment = increment.GetCompactIncrement();
             if (compact_deletion_file) {
@@ -234,6 +239,7 @@ Result<std::vector<std::shared_ptr<CommitMessage>>> AbstractFileStoreWrite::Prep
                                      partition.ToString().c_str(), bucket,
                                      writer_container.last_modified_commit_identifier,
                                      latest_committed_identifier, commit_identifier);
+                    writer_memory_manager_->UnregisterWriter(writer_container.writer.get());
                     PAIMON_RETURN_NOT_OK(writer_container.writer->Close());
                     bucket_iter = buckets.erase(bucket_iter);
                     continue;
@@ -257,6 +263,7 @@ Result<std::vector<std::shared_ptr<CommitMessage>>> AbstractFileStoreWrite::Prep
 Status AbstractFileStoreWrite::Close() {
     for (auto& [_, bucket_writers] : writers_) {
         for (auto& [_, writer_container] : bucket_writers) {
+            writer_memory_manager_->UnregisterWriter(writer_container.writer.get());
             PAIMON_RETURN_NOT_OK(writer_container.writer->Close());
         }
     }
@@ -351,6 +358,7 @@ Result<std::shared_ptr<BatchWriter>> AbstractFileStoreWrite::GetWriter(const Bin
     } else {
         partition_iter->second.emplace(bucket, WriterContainer<BatchWriter>(writer, total_buckets));
     }
+    writer_memory_manager_->RegisterWriter(writer.get());
 
     return writer;
 }

--- a/src/paimon/core/operation/abstract_file_store_write.h
+++ b/src/paimon/core/operation/abstract_file_store_write.h
@@ -21,7 +21,6 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
-#include <utility>
 #include <vector>
 
 #include "arrow/type.h"
@@ -62,6 +61,7 @@ class MemoryPool;
 class RecordBatch;
 class RestoreFiles;
 class IOManager;
+class WriterMemoryManager;
 
 class AbstractFileStoreWrite : public FileStoreWrite {
  public:
@@ -132,6 +132,7 @@ class AbstractFileStoreWrite : public FileStoreWrite {
     std::shared_ptr<BucketedDvMaintainer::Factory> dv_maintainer_factory_;
     std::shared_ptr<IOManager> io_manager_;
     std::shared_ptr<CacheManager> cache_manager_;
+    std::shared_ptr<WriterMemoryManager> writer_memory_manager_;
 
     CoreOptions options_;
     std::shared_ptr<Executor> compact_executor_;

--- a/src/paimon/core/operation/abstract_file_store_write.h
+++ b/src/paimon/core/operation/abstract_file_store_write.h
@@ -29,6 +29,7 @@
 #include "paimon/common/io/cache/cache_manager.h"
 #include "paimon/core/core_options.h"
 #include "paimon/core/deletionvectors/bucketed_dv_maintainer.h"
+#include "paimon/core/memory/writer_memory_manager.h"
 #include "paimon/file_store_write.h"
 #include "paimon/logging.h"
 #include "paimon/metrics.h"
@@ -61,7 +62,6 @@ class MemoryPool;
 class RecordBatch;
 class RestoreFiles;
 class IOManager;
-class WriterMemoryManager;
 
 class AbstractFileStoreWrite : public FileStoreWrite {
  public:
@@ -132,7 +132,7 @@ class AbstractFileStoreWrite : public FileStoreWrite {
     std::shared_ptr<BucketedDvMaintainer::Factory> dv_maintainer_factory_;
     std::shared_ptr<IOManager> io_manager_;
     std::shared_ptr<CacheManager> cache_manager_;
-    std::shared_ptr<WriterMemoryManager> writer_memory_manager_;
+    std::unique_ptr<WriterMemoryManager> writer_memory_manager_;
 
     CoreOptions options_;
     std::shared_ptr<Executor> compact_executor_;

--- a/src/paimon/core/operation/key_value_file_store_write.cpp
+++ b/src/paimon/core/operation/key_value_file_store_write.cpp
@@ -16,9 +16,6 @@
 
 #include "paimon/core/operation/key_value_file_store_write.h"
 
-#include <limits>
-#include <map>
-#include <optional>
 #include <vector>
 
 #include "paimon/common/data/binary_row.h"
@@ -30,9 +27,7 @@
 #include "paimon/core/mergetree/merge_tree_writer.h"
 #include "paimon/core/operation/file_store_scan.h"
 #include "paimon/core/operation/key_value_file_store_scan.h"
-#include "paimon/core/operation/restore_files.h"
 #include "paimon/core/schema/table_schema.h"
-#include "paimon/core/snapshot.h"
 #include "paimon/core/utils/file_store_path_factory.h"
 #include "paimon/core/utils/primary_key_table_utils.h"
 #include "paimon/core/utils/snapshot_manager.h"
@@ -116,10 +111,12 @@ Result<std::shared_ptr<BatchWriter>> KeyValueFileStoreWrite::CreateWriter(
         compact_manager_factory_->CreateCompactManager(partition, bucket, compact_strategy,
                                                        compact_executor_, levels, dv_maintainer));
 
-    auto writer = std::make_shared<MergeTreeWriter>(
-        restore_max_seq_number, trimmed_primary_keys, data_file_path_factory, key_comparator_,
-        user_defined_seq_comparator_, merge_function_wrapper_, table_schema_->Id(), schema_,
-        options_, compact_manager, pool_);
+    PAIMON_ASSIGN_OR_RAISE(
+        std::shared_ptr<MergeTreeWriter> writer,
+        MergeTreeWriter::Create(
+            restore_max_seq_number, trimmed_primary_keys, data_file_path_factory, key_comparator_,
+            user_defined_seq_comparator_, merge_function_wrapper_, table_schema_->Id(), schema_,
+            options_, compact_manager, io_manager_, pool_));
     return std::shared_ptr<BatchWriter>(writer);
 }
 

--- a/src/paimon/core/operation/key_value_file_store_write.cpp
+++ b/src/paimon/core/operation/key_value_file_store_write.cpp
@@ -117,7 +117,7 @@ Result<std::shared_ptr<BatchWriter>> KeyValueFileStoreWrite::CreateWriter(
             restore_max_seq_number, trimmed_primary_keys, data_file_path_factory, key_comparator_,
             user_defined_seq_comparator_, merge_function_wrapper_, table_schema_->Id(), schema_,
             options_, compact_manager, io_manager_, pool_));
-    return std::shared_ptr<BatchWriter>(writer);
+    return writer;
 }
 
 Status KeyValueFileStoreWrite::Close() {

--- a/src/paimon/core/operation/key_value_file_store_write_test.cpp
+++ b/src/paimon/core/operation/key_value_file_store_write_test.cpp
@@ -218,8 +218,7 @@ TEST_F(KeyValueFileStoreWriteTest,
     ASSERT_EQ(commit_messages.size(), 1);
 }
 
-TEST_F(KeyValueFileStoreWriteTest,
-       TestWriteShouldSpillLargestWriterWhenGlobalMemoryLimitIsExceeded) {
+TEST_F(KeyValueFileStoreWriteTest, TestSpillSimple) {
     auto fields = {arrow::field("f0", arrow::utf8(), /*nullable=*/false)};
     arrow::Schema typed_schema(fields);
     ::ArrowSchema schema;
@@ -241,17 +240,38 @@ TEST_F(KeyValueFileStoreWriteTest,
 
     ASSERT_OK_AND_ASSIGN(std::unique_ptr<WriteContext> write_context, context_builder.Finish());
     ASSERT_OK_AND_ASSIGN(auto file_store_write, FileStoreWrite::Create(std::move(write_context)));
+    auto key_value_file_store_write = dynamic_cast<KeyValueFileStoreWrite*>(file_store_write.get());
+    auto get_writer = [&](int32_t bucket) -> std::shared_ptr<paimon::BatchWriter> {
+        auto partition_iter = key_value_file_store_write->writers_.find(BinaryRow::EmptyRow());
+        if (partition_iter != key_value_file_store_write->writers_.end()) {
+            auto& buckets = partition_iter->second;
+            auto bucket_iter = buckets.find(bucket);
+            if (PAIMON_LIKELY(bucket_iter != buckets.end())) {
+                return bucket_iter->second.writer;
+            }
+        }
+        assert(false);
+        return nullptr;
+    };
 
+    // write bucket 0, not trigger spill
     ASSERT_OK(WriteSingleStringRow(file_store_write.get(), /*bucket=*/0, std::string(48, 'a')));
     ASSERT_EQ(TestHelper::CountChannelFiles(dir->GetFileSystem(), dir->Str()), 0);
+    ASSERT_GT(get_writer(0)->GetMemoryUsage(), 0);
 
-    ASSERT_OK(WriteSingleStringRow(file_store_write.get(), /*bucket=*/1, std::string(48, 'b')));
+    // write bucket 1, spill bucket 0 (pick largest writer)
+    ASSERT_OK(WriteSingleStringRow(file_store_write.get(), /*bucket=*/1, std::string(32, 'b')));
     ASSERT_GT(TestHelper::CountChannelFiles(dir->GetFileSystem(), dir->Str()), 0);
+    ASSERT_EQ(get_writer(0)->GetMemoryUsage(), 0);
+    ASSERT_GT(get_writer(1)->GetMemoryUsage(), 0);
 
+    // prepare commit, clean all spill files and memory buffers
     ASSERT_OK_AND_ASSIGN(auto commit_messages,
                          file_store_write->PrepareCommit(/*wait_compaction=*/true));
     ASSERT_EQ(commit_messages.size(), 2);
     ASSERT_EQ(TestHelper::CountChannelFiles(dir->GetFileSystem(), dir->Str()), 0);
+    ASSERT_EQ(get_writer(0)->GetMemoryUsage(), 0);
+    ASSERT_EQ(get_writer(1)->GetMemoryUsage(), 0);
 }
 
 }  // namespace paimon::test

--- a/src/paimon/core/operation/key_value_file_store_write_test.cpp
+++ b/src/paimon/core/operation/key_value_file_store_write_test.cpp
@@ -261,7 +261,7 @@ TEST_F(KeyValueFileStoreWriteTest, TestSpillSimple) {
 
     // write bucket 1, spill bucket 0 (pick largest writer)
     ASSERT_OK(WriteSingleStringRow(file_store_write.get(), /*bucket=*/1, std::string(32, 'b')));
-    ASSERT_GT(TestHelper::CountChannelFiles(dir->GetFileSystem(), dir->Str()), 0);
+    ASSERT_EQ(TestHelper::CountChannelFiles(dir->GetFileSystem(), dir->Str()), 1);
     ASSERT_EQ(get_writer(0)->GetMemoryUsage(), 0);
     ASSERT_GT(get_writer(1)->GetMemoryUsage(), 0);
 

--- a/src/paimon/core/operation/key_value_file_store_write_test.cpp
+++ b/src/paimon/core/operation/key_value_file_store_write_test.cpp
@@ -25,7 +25,6 @@
 #include "arrow/array/array_base.h"
 #include "arrow/array/builder_binary.h"
 #include "arrow/array/builder_nested.h"
-#include "arrow/array/builder_primitive.h"
 #include "arrow/c/abi.h"
 #include "arrow/c/bridge.h"
 #include "arrow/c/helpers.h"
@@ -34,10 +33,10 @@
 #include "paimon/catalog/catalog.h"
 #include "paimon/catalog/identifier.h"
 #include "paimon/common/utils/path_util.h"
-#include "paimon/core/core_options.h"
 #include "paimon/file_store_write.h"
 #include "paimon/record_batch.h"
 #include "paimon/status.h"
+#include "paimon/testing/utils/test_helper.h"
 #include "paimon/testing/utils/testharness.h"
 #include "paimon/write_context.h"
 
@@ -217,6 +216,42 @@ TEST_F(KeyValueFileStoreWriteTest,
     ASSERT_OK_AND_ASSIGN(auto commit_messages,
                          file_store_write->PrepareCommit(/*wait_compaction=*/true));
     ASSERT_EQ(commit_messages.size(), 1);
+}
+
+TEST_F(KeyValueFileStoreWriteTest,
+       TestWriteShouldSpillLargestWriterWhenGlobalMemoryLimitIsExceeded) {
+    auto fields = {arrow::field("f0", arrow::utf8(), /*nullable=*/false)};
+    arrow::Schema typed_schema(fields);
+    ::ArrowSchema schema;
+    ASSERT_TRUE(arrow::ExportSchema(typed_schema, &schema).ok());
+
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+    ASSERT_OK_AND_ASSIGN(auto catalog, Catalog::Create(dir->Str(), {}));
+    ASSERT_OK(catalog->CreateDatabase("foo", {}, /*ignore_if_exists=*/false));
+    ASSERT_OK(catalog->CreateTable(Identifier("foo", "bar"), &schema,
+                                   /*partition_keys=*/{}, /*primary_keys=*/{"f0"},
+                                   {{Options::BUCKET, "2"},
+                                    {Options::WRITE_BUFFER_SIZE, "64"},
+                                    {Options::WRITE_BUFFER_SPILLABLE, "true"}},
+                                   /*ignore_if_exists=*/false));
+
+    WriteContextBuilder context_builder(PathUtil::JoinPath(dir->Str(), "foo.db/bar"), "test");
+    context_builder.WithTempDirectory(dir->Str());
+
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<WriteContext> write_context, context_builder.Finish());
+    ASSERT_OK_AND_ASSIGN(auto file_store_write, FileStoreWrite::Create(std::move(write_context)));
+
+    ASSERT_OK(WriteSingleStringRow(file_store_write.get(), /*bucket=*/0, std::string(48, 'a')));
+    ASSERT_EQ(TestHelper::CountChannelFiles(dir->GetFileSystem(), dir->Str()), 0);
+
+    ASSERT_OK(WriteSingleStringRow(file_store_write.get(), /*bucket=*/1, std::string(48, 'b')));
+    ASSERT_GT(TestHelper::CountChannelFiles(dir->GetFileSystem(), dir->Str()), 0);
+
+    ASSERT_OK_AND_ASSIGN(auto commit_messages,
+                         file_store_write->PrepareCommit(/*wait_compaction=*/true));
+    ASSERT_EQ(commit_messages.size(), 2);
+    ASSERT_EQ(TestHelper::CountChannelFiles(dir->GetFileSystem(), dir->Str()), 0);
 }
 
 }  // namespace paimon::test

--- a/src/paimon/testing/utils/test_helper.h
+++ b/src/paimon/testing/utils/test_helper.h
@@ -379,6 +379,25 @@ class TestHelper {
         }
     }
 
+    static int64_t CountChannelFiles(const std::shared_ptr<FileSystem>& file_system,
+                                     const std::string& tmp_path) {
+        std::vector<std::unique_ptr<BasicFileStatus>> file_statuses;
+        EXPECT_OK(file_system->ListDir(tmp_path, &file_statuses));
+
+        int64_t channel_file_count = 0;
+        for (const auto& file_status : file_statuses) {
+            const std::string path = file_status->GetPath();
+            if (file_status->IsDir() && path.find("paimon-io-") != std::string::npos) {
+                channel_file_count += CountChannelFiles(file_system, path);
+                continue;
+            }
+            if (StringUtils::EndsWith(path, ".channel")) {
+                ++channel_file_count;
+            }
+        }
+        return channel_file_count;
+    }
+
  private:
     void CheckExternalPath(const std::vector<std::shared_ptr<CommitMessage>>& actuals) {
         for (const auto& actual : actuals) {

--- a/src/paimon/testing/utils/test_helper.h
+++ b/src/paimon/testing/utils/test_helper.h
@@ -381,18 +381,21 @@ class TestHelper {
 
     static int64_t CountChannelFiles(const std::shared_ptr<FileSystem>& file_system,
                                      const std::string& tmp_path) {
-        std::vector<std::unique_ptr<BasicFileStatus>> file_statuses;
-        EXPECT_OK(file_system->ListDir(tmp_path, &file_statuses));
+        std::vector<std::unique_ptr<BasicFileStatus>> dir_statuses;
+        EXPECT_OK(file_system->ListDir(tmp_path, &dir_statuses));
 
         int64_t channel_file_count = 0;
-        for (const auto& file_status : file_statuses) {
-            const std::string path = file_status->GetPath();
-            if (file_status->IsDir() && path.find("paimon-io-") != std::string::npos) {
-                channel_file_count += CountChannelFiles(file_system, path);
-                continue;
-            }
-            if (StringUtils::EndsWith(path, ".channel")) {
-                ++channel_file_count;
+        for (const auto& dir_status : dir_statuses) {
+            const std::string dir_path = dir_status->GetPath();
+            if (dir_status->IsDir() && dir_path.find("paimon-io-") != std::string::npos) {
+                std::vector<std::unique_ptr<BasicFileStatus>> file_statuses;
+                EXPECT_OK(file_system->ListDir(dir_path, &file_statuses));
+
+                for (const auto& file_status : file_statuses) {
+                    if (StringUtils::EndsWith(file_status->GetPath(), ".channel")) {
+                        ++channel_file_count;
+                    }
+                }
             }
         }
         return channel_file_count;


### PR DESCRIPTION
### Purpose

Linked issue: #149 

Decide whether to create a spill-capable `ExternalSortBuffer` in `WriteBuffer` based on the `write-buffer-spillable` option and `IOManager`.

### Tests

KeyValueFileStoreWriteTest.TestSpillSimple

### API and Format

No storage format or protocol changes

### Documentation

No documentation changes needed.

### Generative AI tooling

Generated-by: Aone Copilot(Claude 4.6) and Github Copilot(GPT-5.4)