### PR TITLE
test(btree): add unit test for btree

### DIFF
--- a/src/paimon/common/global_index/btree/btree_global_index_integration_test.cpp
+++ b/src/paimon/common/global_index/btree/btree_global_index_integration_test.cpp
@@ -240,6 +240,11 @@ TEST_P(BTreeGlobalIndexIntegrationTest, WriteAndReadIntData) {
         Literal literal_5(5);
         ASSERT_OK_AND_ASSIGN(result, reader->VisitGreaterThan(literal_5));
         CheckResult(result, {});
+
+        // GreaterThan 1 (min_key) -> skip entries with value==1 via from_inclusive=false
+        Literal literal_1(1);
+        ASSERT_OK_AND_ASSIGN(result, reader->VisitGreaterThan(literal_1));
+        CheckResult(result, {3, 4, 6, 7, 8, 9, 10});
     }
 
     // --- VisitGreaterOrEqual ---
@@ -361,6 +366,10 @@ TEST_P(BTreeGlobalIndexIntegrationTest, WriteAndReadStringData) {
         Literal lit_cherry(FieldType::STRING, "cherry", 6);
         ASSERT_OK_AND_ASSIGN(auto result, reader->VisitGreaterThan(lit_cherry));
         CheckResult(result, {8});
+
+        Literal lit_apple(FieldType::STRING, "apple", 5);
+        ASSERT_OK_AND_ASSIGN(result, reader->VisitGreaterThan(lit_apple));
+        CheckResult(result, {1, 3, 4, 6, 7, 8});
     }
 
     // --- VisitGreaterOrEqual ---
@@ -401,6 +410,17 @@ TEST_P(BTreeGlobalIndexIntegrationTest, WriteAndReadStringData) {
         // StartsWith "z" -> no match
         Literal lit_z(FieldType::STRING, "z", 1);
         ASSERT_OK_AND_ASSIGN(result, reader->VisitStartsWith(lit_z));
+        CheckResult(result, {});
+
+        // StartsWith "" (empty prefix) -> all non-null rows
+        Literal lit_empty(FieldType::STRING, "", 0);
+        ASSERT_OK_AND_ASSIGN(result, reader->VisitStartsWith(lit_empty));
+        CheckResult(result, {0, 1, 3, 4, 6, 7, 8});
+
+        // StartsWith "\xFF\xFF" (all 0xFF bytes, overflow branch) -> no match
+        std::string xff_prefix = "\xFF\xFF";
+        Literal lit_xff(FieldType::STRING, xff_prefix.data(), xff_prefix.size());
+        ASSERT_OK_AND_ASSIGN(result, reader->VisitStartsWith(lit_xff));
         CheckResult(result, {});
     }
 
@@ -1448,6 +1468,27 @@ TEST_P(BTreeGlobalIndexIntegrationTest, WriteAndReadAllNull) {
         ASSERT_OK_AND_ASSIGN(auto result, reader->VisitNotIn(not_in_literals));
         CheckResult(result, {});
     }
+
+    // --- VisitGreaterThan -> empty (min_key_/max_key_ are nullopt) ---
+    {
+        Literal lit_1(1);
+        ASSERT_OK_AND_ASSIGN(auto result, reader->VisitGreaterThan(lit_1));
+        CheckResult(result, {});
+    }
+
+    // --- VisitGreaterOrEqual -> empty ---
+    {
+        Literal lit_1(1);
+        ASSERT_OK_AND_ASSIGN(auto result, reader->VisitGreaterOrEqual(lit_1));
+        CheckResult(result, {});
+    }
+
+    // --- VisitLessOrEqual -> empty ---
+    {
+        Literal lit_1(1);
+        ASSERT_OK_AND_ASSIGN(auto result, reader->VisitLessOrEqual(lit_1));
+        CheckResult(result, {});
+    }
 }
 
 TEST_P(BTreeGlobalIndexIntegrationTest, WriteAndReadLargeDataWithSmallBlocks) {
@@ -1985,6 +2026,101 @@ TEST_P(BTreeGlobalIndexIntegrationTest, WriteAndReadMultiFilesWithMetaSelector) 
         std::vector<Literal> literals = {Literal(1), Literal(12), Literal(20)};
         ASSERT_OK_AND_ASSIGN(auto result, reader->VisitNotIn(literals));
         CheckResult(result, {1, 3, 4, 6, 9});
+    }
+}
+
+// Test both-bounds RangeQuery branch.
+TEST_P(BTreeGlobalIndexIntegrationTest, TestRangeQuery) {
+    auto file_writer = std::make_shared<FakeGlobalIndexFileWriter>(fs_, base_path_);
+    auto field = arrow::field("str_field", arrow::utf8());
+    auto c_schema = CreateArrowSchema(field);
+
+    // Use very small block size to force data into multiple blocks
+    std::map<std::string, std::string> options = {{BtreeDefs::kBtreeIndexBlockSize, "64"},
+                                                  {BtreeDefs::kBtreeIndexCompression, GetParam()}};
+    ASSERT_OK_AND_ASSIGN(auto indexer, BTreeGlobalIndexer::Create(options));
+    ASSERT_OK_AND_ASSIGN(auto writer,
+                         indexer->CreateWriter("str_field", c_schema.get(), file_writer, pool_));
+    // Data layout
+    //   0->"aaa", 1->"aab", 2->"bba", 3->"bbb", 4->"bbc",
+    //   5->null, 6->"cca", 7->"ccb", 8->"ddd"
+    auto array = arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({field}), R"([
+        ["aaa"],
+        ["aab"],
+        ["bba"],
+        ["bbb"],
+        ["bbc"],
+        [null],
+        ["cca"],
+        ["ccb"],
+        ["ddd"]
+    ])")
+                     .ValueOrDie();
+
+    ArrowArray c_array;
+    ASSERT_TRUE(arrow::ExportArray(*array, &c_array).ok());
+    std::vector<int64_t> row_ids(array->length());
+    std::iota(row_ids.begin(), row_ids.end(), 0);
+    ASSERT_OK(writer->AddBatch(&c_array, std::move(row_ids)));
+    ASSERT_OK_AND_ASSIGN(auto metas, writer->Finish());
+    ASSERT_EQ(metas.size(), 1);
+
+    auto file_reader = std::make_shared<FakeGlobalIndexFileReader>(fs_, base_path_);
+    c_schema = CreateArrowSchema(field);
+    ASSERT_OK_AND_ASSIGN(auto reader,
+                         indexer->CreateReader(c_schema.get(), file_reader, metas, pool_));
+
+    // Non-null rows: {0,1,2,3,4,6,7,8}, Null rows: {5}
+
+    {
+        Literal lit_bb(FieldType::STRING, "bb", 2);
+        ASSERT_OK_AND_ASSIGN(auto result, reader->VisitStartsWith(lit_bb));
+        CheckResult(result, {2, 3, 4});
+    }
+
+    {
+        Literal lit_cc(FieldType::STRING, "cc", 2);
+        ASSERT_OK_AND_ASSIGN(auto result, reader->VisitStartsWith(lit_cc));
+        CheckResult(result, {6, 7});
+    }
+
+    {
+        Literal lit_aaa(FieldType::STRING, "aaa", 3);
+        ASSERT_OK_AND_ASSIGN(auto result, reader->VisitGreaterThan(lit_aaa));
+        CheckResult(result, {1, 2, 3, 4, 6, 7, 8});
+    }
+
+    {
+        Literal lit_ddd(FieldType::STRING, "ddd", 3);
+        ASSERT_OK_AND_ASSIGN(auto result, reader->VisitGreaterThan(lit_ddd));
+        CheckResult(result, {});
+    }
+
+    {
+        Literal lit_empty(FieldType::STRING, "", 0);
+        ASSERT_OK_AND_ASSIGN(auto result, reader->VisitStartsWith(lit_empty));
+        CheckResult(result, {0, 1, 2, 3, 4, 6, 7, 8});
+    }
+
+    // Raw RangeQuery call to cover both-bounds branch with from_inclusive=false and
+    // to_inclusive=false
+    {
+        ASSERT_FALSE(reader->IsThreadSafe());
+        ASSERT_EQ(reader->GetIndexType(), BtreeDefs::kIdentifier);
+        auto lazy_reader = std::dynamic_pointer_cast<LazyFilteredBTreeReader>(reader);
+        ASSERT_TRUE(lazy_reader);
+        ASSERT_OK_AND_ASSIGN(auto tmp_reader, lazy_reader->GetOrCreateReader(metas[0]));
+        auto btree_reader = std::dynamic_pointer_cast<BTreeGlobalIndexReader>(tmp_reader);
+        ASSERT_TRUE(btree_reader);
+        ASSERT_FALSE(btree_reader->IsThreadSafe());
+        ASSERT_EQ(btree_reader->GetIndexType(), BtreeDefs::kIdentifier);
+
+        Literal from_lit(FieldType::STRING, "bba", 3);
+        Literal to_lit(FieldType::STRING, "bbc", 3);
+        ASSERT_OK_AND_ASSIGN(RoaringBitmap64 range_result,
+                             btree_reader->RangeQuery(from_lit, to_lit, /*from_inclusive=*/false,
+                                                      /*to_inclusive=*/false));
+        ASSERT_EQ(range_result, RoaringBitmap64::From({3}));
     }
 }
 

--- a/src/paimon/common/global_index/btree/btree_global_index_reader.cpp
+++ b/src/paimon/common/global_index/btree/btree_global_index_reader.cpp
@@ -324,6 +324,7 @@ Result<RoaringBitmap64> BTreeGlobalIndexReader::RangeQuery(const std::optional<L
                                sst_file_reader_->GetNextBlock(index_iterator));
 
         if (!data_iterator || !data_iterator->HasNext()) {
+            assert(false);
             break;
         }
 

--- a/src/paimon/common/global_index/offset_global_index_reader_test.cpp
+++ b/src/paimon/common/global_index/offset_global_index_reader_test.cpp
@@ -350,4 +350,52 @@ TEST_F(OffsetGlobalIndexReaderTest, TestVisitVectorSearchNotSupported) {
                         "FakeGlobalIndexReader does not support vector search");
 }
 
+TEST_F(OffsetGlobalIndexReaderTest, TestVisitStartsWithWithOffset) {
+    auto fake_reader = std::make_shared<FakeGlobalIndexReader>();
+    fake_reader->SetDefaultResult({0, 1, 4});
+
+    auto offset_reader = std::make_shared<OffsetGlobalIndexReader>(fake_reader, 50);
+
+    Literal prefix(FieldType::STRING, "abc", 3);
+    ASSERT_OK_AND_ASSIGN(auto result, offset_reader->VisitStartsWith(prefix));
+    // row ids {0, 1, 4} + offset 50 -> {50, 51, 54}
+    CheckResult(result, {50, 51, 54});
+}
+
+TEST_F(OffsetGlobalIndexReaderTest, TestVisitEndsWithWithOffset) {
+    auto fake_reader = std::make_shared<FakeGlobalIndexReader>();
+    fake_reader->SetDefaultResult({2, 3});
+
+    auto offset_reader = std::make_shared<OffsetGlobalIndexReader>(fake_reader, 25);
+
+    Literal suffix(FieldType::STRING, "xyz", 3);
+    ASSERT_OK_AND_ASSIGN(auto result, offset_reader->VisitEndsWith(suffix));
+    // row ids {2, 3} + offset 25 -> {27, 28}
+    CheckResult(result, {27, 28});
+}
+
+TEST_F(OffsetGlobalIndexReaderTest, TestVisitContainsWithOffset) {
+    auto fake_reader = std::make_shared<FakeGlobalIndexReader>();
+    fake_reader->SetDefaultResult({1, 5, 6});
+
+    auto offset_reader = std::make_shared<OffsetGlobalIndexReader>(fake_reader, 300);
+
+    Literal literal(FieldType::STRING, "foo", 3);
+    ASSERT_OK_AND_ASSIGN(auto result, offset_reader->VisitContains(literal));
+    // row ids {1, 5, 6} + offset 300 -> {301, 305, 306}
+    CheckResult(result, {301, 305, 306});
+}
+
+TEST_F(OffsetGlobalIndexReaderTest, TestVisitLikeWithOffset) {
+    auto fake_reader = std::make_shared<FakeGlobalIndexReader>();
+    fake_reader->SetDefaultResult({0, 3, 7});
+
+    auto offset_reader = std::make_shared<OffsetGlobalIndexReader>(fake_reader, 40);
+
+    Literal pattern(FieldType::STRING, "ab%", 3);
+    ASSERT_OK_AND_ASSIGN(auto result, offset_reader->VisitLike(pattern));
+    // row ids {0, 3, 7} + offset 40 -> {40, 43, 47}
+    CheckResult(result, {40, 43, 47});
+}
+
 }  // namespace paimon::test

--- a/src/paimon/common/utils/roaring_bitmap64.cpp
+++ b/src/paimon/common/utils/roaring_bitmap64.cpp
@@ -184,6 +184,7 @@ void RoaringBitmap64::AddMany(size_t n, const int64_t* values) {
     struct Bucket {
         uint32_t high;
         std::vector<uint32_t> lows;
+        explicit Bucket(uint32_t high_val) : high(high_val) {}
     };
     std::vector<Bucket> buckets;
     buckets.reserve(4);
@@ -206,7 +207,7 @@ void RoaringBitmap64::AddMany(size_t n, const int64_t* values) {
                 }
             }
             if (target == nullptr) {
-                buckets.push_back({high, {}});
+                buckets.emplace_back(high);
                 // Reserve generously on first encounter; we may end up using
                 // more memory than necessary if K turns out to be > 1, but
                 // this avoids repeated grow-and-copy in the common K == 1 case.

--- a/src/paimon/core/table/source/data_split_test.cpp
+++ b/src/paimon/core/table/source/data_split_test.cpp
@@ -1096,6 +1096,26 @@ TEST(DataSplitTest, TestPartialMergedRowCount) {
                                                      .Build()
                                                      .value());
     ASSERT_EQ(0, expected_data_split->PartialMergedRowCount());
+
+    ASSERT_EQ(4, expected_data_split->RowCount());
+    ASSERT_OK_AND_ASSIGN(auto latest_epoch, expected_data_split->LatestFileCreationEpochMillis());
+    ASSERT_TRUE(latest_epoch.has_value());
+    ASSERT_EQ(file_meta2->CreationTimeEpochMillis().value(), latest_epoch.value());
+}
+
+TEST(DataSplitTest, TestRowCountAndLatestFileCreationEpochMillisEmpty) {
+    DataSplitImpl::Builder builder(
+        /*partition=*/BinaryRow::EmptyRow(),
+        /*bucket=*/0, /*bucket_path=*/
+        "fake_table/bucket-0", std::vector<std::shared_ptr<DataFileMeta>>({}));
+
+    auto data_split = std::dynamic_pointer_cast<DataSplitImpl>(
+        builder.WithSnapshot(1).IsStreaming(false).RawConvertible(true).Build().value());
+
+    // Empty data_files: RowCount should be 0, LatestFileCreationEpochMillis should be nullopt
+    ASSERT_EQ(0, data_split->RowCount());
+    ASSERT_OK_AND_ASSIGN(auto latest_epoch, data_split->LatestFileCreationEpochMillis());
+    ASSERT_FALSE(latest_epoch.has_value());
 }
 
 }  // namespace paimon::test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose
Add unit test for btree global index.
<!-- Linking this pull request to the issue -->
Linked issue: #38 

<!-- What is the purpose of the change -->

### Tests
BTreeGlobalIndexIntegrationTest.TestRangeQuery
OffsetGlobalIndexReaderTest
DataSplitTest.TestRowCountAndLatestFileCreationEpochMillisEmpty

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling
Generated-by: Claude-4.6-Opus
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
