### PR TITLE
feat(core): support null merge results in key-value readers

### DIFF
--- a/src/paimon/core/io/key_value_data_file_record_reader.cpp
+++ b/src/paimon/core/io/key_value_data_file_record_reader.cpp
@@ -48,7 +48,7 @@ KeyValueDataFileRecordReader::KeyValueDataFileRecordReader(
       value_schema_(value_schema),
       value_names_(value_schema_->field_names()) {}
 
-bool KeyValueDataFileRecordReader::Iterator::HasNext() const {
+Result<bool> KeyValueDataFileRecordReader::Iterator::HasNext() const {
     int64_t array_length = reader_->row_kind_array_->length();
     const auto& selection_bitmap = reader_->selection_bitmap_;
     if (selection_bitmap.Cardinality() == array_length) {
@@ -67,7 +67,6 @@ bool KeyValueDataFileRecordReader::Iterator::HasNext() const {
 }
 
 Result<KeyValue> KeyValueDataFileRecordReader::Iterator::Next() {
-    assert(HasNext());
     // key is only used in merge sort; key context does not hold parent struct array
     auto key = std::make_unique<ColumnarRowRef>(reader_->key_ctx_, cursor_);
     // value is used in merge sort and projection (maybe async and multi-thread), so value context

--- a/src/paimon/core/io/key_value_data_file_record_reader.h
+++ b/src/paimon/core/io/key_value_data_file_record_reader.h
@@ -56,7 +56,7 @@ class KeyValueDataFileRecordReader : public KeyValueRecordReader {
      public:
         Iterator(KeyValueDataFileRecordReader* reader, int64_t previous_batch_first_row_number)
             : previous_batch_first_row_number_(previous_batch_first_row_number), reader_(reader) {}
-        bool HasNext() const override;
+        Result<bool> HasNext() const override;
         Result<KeyValue> Next() override;
         Result<std::pair<int64_t, KeyValue>> NextWithFilePos();
 

--- a/src/paimon/core/io/key_value_data_file_record_reader_test.cpp
+++ b/src/paimon/core/io/key_value_data_file_record_reader_test.cpp
@@ -285,7 +285,11 @@ TEST_F(KeyValueDataFileRecordReaderTest, TestWithSelectedBitmapWithFilePos) {
         auto typed_iter = dynamic_cast<KeyValueDataFileRecordReader::Iterator*>(iter);
         ASSERT_TRUE(typed_iter);
         size_t pos_iter = 0;
-        while (iter->HasNext()) {
+        while (true) {
+            ASSERT_OK_AND_ASSIGN(bool has_next, iter->HasNext());
+            if (!has_next) {
+                break;
+            }
             ASSERT_OK_AND_ASSIGN(auto kv_and_pos, typed_iter->NextWithFilePos());
             const auto& [pos, kv] = kv_and_pos;
             ASSERT_EQ(pos, expected_pos_vector[pos_iter++]);

--- a/src/paimon/core/io/key_value_in_memory_record_reader.h
+++ b/src/paimon/core/io/key_value_in_memory_record_reader.h
@@ -55,7 +55,7 @@ class KeyValueInMemoryRecordReader : public KeyValueRecordReader {
     class Iterator : public KeyValueRecordReader::Iterator {
      public:
         explicit Iterator(KeyValueInMemoryRecordReader* reader) : reader_(reader) {}
-        bool HasNext() const override {
+        Result<bool> HasNext() const override {
             return cursor_ < reader_->value_struct_array_->length();
         }
         Result<KeyValue> Next() override;

--- a/src/paimon/core/io/key_value_record_reader.h
+++ b/src/paimon/core/io/key_value_record_reader.h
@@ -20,6 +20,7 @@
 
 #include "paimon/core/key_value.h"
 #include "paimon/metrics.h"
+#include "paimon/result.h"
 namespace paimon {
 class KeyValueRecordReader {
  public:
@@ -28,7 +29,7 @@ class KeyValueRecordReader {
     class Iterator {
      public:
         virtual ~Iterator() = default;
-        virtual bool HasNext() const = 0;
+        virtual Result<bool> HasNext() const = 0;
         virtual Result<KeyValue> Next() = 0;
     };
 

--- a/src/paimon/core/io/merged_key_value_record_reader.cpp
+++ b/src/paimon/core/io/merged_key_value_record_reader.cpp
@@ -92,7 +92,7 @@ Result<bool> MergedKeyValueRecordReader::Iterator::MergeNextKey() const {
 }
 
 Status MergedKeyValueRecordReader::Iterator::LoadNextRawKeyValue() const {
-    if (next_raw_key_value_.has_value() || eof_) {
+    if (next_raw_key_value_.has_value()) {
         return Status::OK();
     }
 
@@ -109,7 +109,6 @@ Status MergedKeyValueRecordReader::Iterator::LoadNextRawKeyValue() const {
         current_iterator_.reset();
         PAIMON_ASSIGN_OR_RAISE(current_iterator_, reader_->reader_->NextBatch());
         if (current_iterator_ == nullptr) {
-            eof_ = true;
             return Status::OK();
         }
     }

--- a/src/paimon/core/io/merged_key_value_record_reader.cpp
+++ b/src/paimon/core/io/merged_key_value_record_reader.cpp
@@ -17,6 +17,7 @@
 #include "paimon/core/io/merged_key_value_record_reader.h"
 
 #include <cassert>
+#include <memory>
 #include <optional>
 #include <utility>
 
@@ -36,56 +37,79 @@ MergedKeyValueRecordReader::MergedKeyValueRecordReader(
     assert(merge_function_wrapper_ != nullptr);
 }
 
-Result<std::unique_ptr<MergedKeyValueRecordReader::Iterator>>
-MergedKeyValueRecordReader::Iterator::Create(MergedKeyValueRecordReader* reader) {
-    std::unique_ptr<Iterator> iterator(new Iterator(reader));
-    PAIMON_RETURN_NOT_OK(iterator->LoadNextKeyValue());
-    return iterator;
+Result<bool> MergedKeyValueRecordReader::Iterator::HasNext() const {
+    if (merged_key_value_.has_value()) {
+        return true;
+    }
+    return PrepareNextMergedKeyValue();
 }
 
 Result<KeyValue> MergedKeyValueRecordReader::Iterator::Next() {
-    assert(next_key_value_.has_value());
-    reader_->merge_function_wrapper_->Reset();
-    auto current_key = next_key_value_->key;
-    PAIMON_RETURN_NOT_OK(reader_->merge_function_wrapper_->Add(std::move(*next_key_value_)));
-    next_key_value_.reset();
-
-    while (true) {
-        PAIMON_RETURN_NOT_OK(LoadNextKeyValue());
-        if (!next_key_value_.has_value()) {
-            break;
-        }
-        if (reader_->key_comparator_->CompareTo(*current_key, *next_key_value_->key) != 0) {
-            break;
-        }
-        PAIMON_RETURN_NOT_OK(reader_->merge_function_wrapper_->Add(std::move(*next_key_value_)));
-        next_key_value_.reset();
+    if (!merged_key_value_.has_value()) {
+        return Status::Invalid("No more merged key values in current iterator");
     }
+
+    KeyValue result = std::move(*merged_key_value_);
+    merged_key_value_.reset();
+    return result;
+}
+
+Result<bool> MergedKeyValueRecordReader::Iterator::PrepareNextMergedKeyValue() const {
+    while (true) {
+        PAIMON_ASSIGN_OR_RAISE(bool has_next, MergeNextKey());
+        if (!has_next) {
+            return false;
+        }
+        // if merged_key_value_ is empty(maybe all filtered out), continue to fetch next key and
+        // merge until we get a non-empty merged result or no more keys
+        if (merged_key_value_.has_value()) {
+            return true;
+        }
+    }
+}
+
+Result<bool> MergedKeyValueRecordReader::Iterator::MergeNextKey() const {
+    PAIMON_RETURN_NOT_OK(LoadNextRawKeyValue());
+    if (!next_raw_key_value_.has_value()) {
+        return false;
+    }
+
+    reader_->merge_function_wrapper_->Reset();
+    auto current_key = next_raw_key_value_->key;
+
+    do {
+        PAIMON_RETURN_NOT_OK(
+            reader_->merge_function_wrapper_->Add(std::move(*next_raw_key_value_)));
+        next_raw_key_value_.reset();
+        PAIMON_RETURN_NOT_OK(LoadNextRawKeyValue());
+    } while (next_raw_key_value_.has_value() &&
+             reader_->key_comparator_->CompareTo(*current_key, *next_raw_key_value_->key) == 0);
 
     PAIMON_ASSIGN_OR_RAISE(std::optional<KeyValue> result,
                            reader_->merge_function_wrapper_->GetResult());
-    // TODO(jinli.zjw): support merge function producing no result (e.g. all rows are filtered out)
-    if (result == std::nullopt) {
-        return Status::Invalid("merged key value reader produced empty result");
-    }
-    return std::move(result).value();
+    merged_key_value_ = std::move(result);
+    return true;
 }
 
-Status MergedKeyValueRecordReader::Iterator::LoadNextKeyValue() {
-    if (next_key_value_.has_value()) {
+Status MergedKeyValueRecordReader::Iterator::LoadNextRawKeyValue() const {
+    if (next_raw_key_value_.has_value() || eof_) {
         return Status::OK();
     }
 
     while (true) {
-        if (current_iterator_ != nullptr && current_iterator_->HasNext()) {
-            PAIMON_ASSIGN_OR_RAISE(KeyValue key_value, current_iterator_->Next());
-            next_key_value_.emplace(std::move(key_value));
-            return Status::OK();
+        if (current_iterator_ != nullptr) {
+            PAIMON_ASSIGN_OR_RAISE(bool has_next, current_iterator_->HasNext());
+            if (has_next) {
+                PAIMON_ASSIGN_OR_RAISE(KeyValue key_value, current_iterator_->Next());
+                next_raw_key_value_.emplace(std::move(key_value));
+                return Status::OK();
+            }
         }
 
         current_iterator_.reset();
         PAIMON_ASSIGN_OR_RAISE(current_iterator_, reader_->reader_->NextBatch());
         if (current_iterator_ == nullptr) {
+            eof_ = true;
             return Status::OK();
         }
     }
@@ -97,8 +121,9 @@ Result<std::unique_ptr<KeyValueRecordReader::Iterator>> MergedKeyValueRecordRead
     }
     visited_ = true;
 
-    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<Iterator> iterator, Iterator::Create(this));
-    if (!iterator->HasNext()) {
+    auto iterator = std::make_unique<Iterator>(this);
+    PAIMON_ASSIGN_OR_RAISE(bool has_next, iterator->HasNext());
+    if (!has_next) {
         return std::unique_ptr<KeyValueRecordReader::Iterator>();
     }
     return iterator;

--- a/src/paimon/core/io/merged_key_value_record_reader.h
+++ b/src/paimon/core/io/merged_key_value_record_reader.h
@@ -34,23 +34,25 @@ class MergedKeyValueRecordReader : public KeyValueRecordReader {
 
     class Iterator : public KeyValueRecordReader::Iterator {
      public:
-        static Result<std::unique_ptr<Iterator>> Create(MergedKeyValueRecordReader* reader);
+        explicit Iterator(MergedKeyValueRecordReader* reader) : reader_(reader) {}
 
-        bool HasNext() const override {
-            return next_key_value_.has_value();
-        }
+        Result<bool> HasNext() const override;
 
         Result<KeyValue> Next() override;
 
      private:
-        explicit Iterator(MergedKeyValueRecordReader* reader) : reader_(reader) {}
-
-        Status LoadNextKeyValue();
+        Result<bool> PrepareNextMergedKeyValue() const;
+        Result<bool> MergeNextKey() const;
+        Status LoadNextRawKeyValue() const;
 
      private:
         MergedKeyValueRecordReader* reader_;
-        std::unique_ptr<KeyValueRecordReader::Iterator> current_iterator_;
-        std::optional<KeyValue> next_key_value_;
+        mutable std::unique_ptr<KeyValueRecordReader::Iterator> current_iterator_;
+        // Lookahead raw kv used to detect the boundary between two keys.
+        mutable std::optional<KeyValue> next_raw_key_value_;
+        // Merged kv prepared by HasNext() and consumed by Next().
+        mutable std::optional<KeyValue> merged_key_value_;
+        mutable bool eof_ = false;
     };
 
     Result<std::unique_ptr<KeyValueRecordReader::Iterator>> NextBatch() override;

--- a/src/paimon/core/io/merged_key_value_record_reader.h
+++ b/src/paimon/core/io/merged_key_value_record_reader.h
@@ -25,6 +25,9 @@
 namespace paimon {
 class FieldsComparator;
 
+/// Merges consecutive key-value records with the same primary key from the wrapped reader.
+/// The wrapped reader must return records ordered by primary key, so all records for the same
+/// primary key are contiguous.
 class MergedKeyValueRecordReader : public KeyValueRecordReader {
  public:
     MergedKeyValueRecordReader(
@@ -52,7 +55,6 @@ class MergedKeyValueRecordReader : public KeyValueRecordReader {
         mutable std::optional<KeyValue> next_raw_key_value_;
         // Merged kv prepared by HasNext() and consumed by Next().
         mutable std::optional<KeyValue> merged_key_value_;
-        mutable bool eof_ = false;
     };
 
     Result<std::unique_ptr<KeyValueRecordReader::Iterator>> NextBatch() override;

--- a/src/paimon/core/io/merged_key_value_record_reader_test.cpp
+++ b/src/paimon/core/io/merged_key_value_record_reader_test.cpp
@@ -23,6 +23,7 @@
 #include "arrow/array/array_nested.h"
 #include "arrow/ipc/json_simple.h"
 #include "gtest/gtest.h"
+#include "paimon/common/table/special_fields.h"
 #include "paimon/common/types/data_field.h"
 #include "paimon/common/utils/fields_comparator.h"
 #include "paimon/core/mergetree/compact/deduplicate_merge_function.h"
@@ -55,14 +56,11 @@ TEST_F(MergedKeyValueRecordReaderTest, TestMergeAcrossUnderlyingBatches) {
                                      DataField(3, arrow::field("v1", arrow::int32())),
                                      DataField(4, arrow::field("v2", arrow::int32()))};
 
-    auto key_schema = arrow::schema({fields[0].ArrowField(), fields[1].ArrowField()});
-    auto value_schema =
-        arrow::schema({fields[0].ArrowField(), fields[1].ArrowField(), fields[2].ArrowField(),
-                       fields[3].ArrowField(), fields[4].ArrowField()});
-    std::shared_ptr<arrow::DataType> src_type = arrow::struct_(
-        {arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
-         arrow::field("_VALUE_KIND", arrow::int8()), fields[0].ArrowField(), fields[1].ArrowField(),
-         fields[2].ArrowField(), fields[3].ArrowField(), fields[4].ArrowField()});
+    auto value_schema = DataField::ConvertDataFieldsToArrowSchema(fields);
+    auto arrow_fields = value_schema->fields();
+    auto key_schema = arrow::schema({arrow_fields[0], arrow_fields[1]});
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_(SpecialFields::CompleteSequenceAndValueKindField(value_schema)->fields());
 
     auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
         arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
@@ -94,6 +92,52 @@ TEST_F(MergedKeyValueRecordReaderTest, TestMergeAcrossUnderlyingBatches) {
             (ReadResultCollector::CollectKeyValueResult<
                 MergedKeyValueRecordReader, KeyValueRecordReader::Iterator>(merged_reader.get())));
         KeyValueChecker::CheckResult(expected, results, /*key_arity=*/2, /*value_arity=*/5);
+    }
+}
+
+TEST_F(MergedKeyValueRecordReaderTest, TestSkipMergedNulloptResultInHasNext) {
+    auto mfunc = std::make_unique<DeduplicateMergeFunction>(/*ignore_delete=*/true);
+    auto merge_function_wrapper = std::make_shared<ReducerMergeFunctionWrapper>(std::move(mfunc));
+
+    std::vector<DataField> fields = {DataField(0, arrow::field("k0", arrow::int32())),
+                                     DataField(1, arrow::field("v0", arrow::int32()))};
+
+    auto value_schema = DataField::ConvertDataFieldsToArrowSchema(fields);
+    auto arrow_fields = value_schema->fields();
+    auto key_schema = arrow::schema({arrow_fields[0]});
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_(SpecialFields::CompleteSequenceAndValueKindField(value_schema)->fields());
+
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [0, 3, 1, 10],
+        [3, 3, 1, 11],
+        [2, 3, 2, 200],
+        [4, 3, 2, 240],
+        [1, 0, 3, 300],
+        [5, 3, 3, 30]
+    ])")
+            .ValueOrDie());
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FieldsComparator> key_comparator,
+                         FieldsComparator::Create({fields[0]}, /*is_ascending_order=*/true));
+
+    auto expected = KeyValueChecker::GenerateKeyValues(
+        /*seq_vec=*/{1}, /*key_vec=*/{{3}}, /*value_vec=*/{{3, 300}}, pool_);
+
+    for (auto batch_size : {1, 2, 3}) {
+        auto file_batch_reader =
+            std::make_unique<MockFileBatchReader>(src_array, src_type, /*batch_size=*/batch_size);
+        auto raw_reader = std::make_unique<MockKeyValueDataFileRecordReader>(
+            std::move(file_batch_reader), key_schema, value_schema, /*level=*/0, pool_);
+        auto merged_reader = std::make_unique<MergedKeyValueRecordReader>(
+            std::move(raw_reader), key_comparator, merge_function_wrapper);
+
+        ASSERT_OK_AND_ASSIGN(
+            auto results,
+            (ReadResultCollector::CollectKeyValueResult<
+                MergedKeyValueRecordReader, KeyValueRecordReader::Iterator>(merged_reader.get())));
+        KeyValueChecker::CheckResult(expected, results, /*key_arity=*/1, /*value_arity=*/2);
     }
 }
 

--- a/src/paimon/core/mergetree/compact/loser_tree.h
+++ b/src/paimon/core/mergetree/compact/loser_tree.h
@@ -116,7 +116,11 @@ class LoserTree {
         Status AdvanceIfAvailable() {
             first_same_key_index = -1;
             state = State::WINNER_WITH_NEW_KEY;
-            if (iterator == nullptr || !iterator->HasNext()) {
+            bool has_next = false;
+            if (iterator != nullptr) {
+                PAIMON_ASSIGN_OR_RAISE(has_next, iterator->HasNext());
+            }
+            if (iterator == nullptr || !has_next) {
                 while (!end_of_input) {
                     PAIMON_ASSIGN_OR_RAISE(iterator, reader->NextBatch());
                     if (!iterator) {
@@ -124,7 +128,11 @@ class LoserTree {
                         reader->Close();
                         end_of_input = true;
                         kv = std::nullopt;
-                    } else if (iterator->HasNext()) {
+                    } else {
+                        PAIMON_ASSIGN_OR_RAISE(has_next, iterator->HasNext());
+                        if (!has_next) {
+                            continue;
+                        }
                         PAIMON_ASSIGN_OR_RAISE(kv, iterator->Next());
                         break;
                     }

--- a/src/paimon/core/mergetree/compact/sort_merge_reader_test.cpp
+++ b/src/paimon/core/mergetree/compact/sort_merge_reader_test.cpp
@@ -71,15 +71,15 @@ class SortMergeReaderTest : public testing::Test {
                      const std::shared_ptr<FieldsComparator>& user_defined_seq_comparator,
                      const std::shared_ptr<arrow::Schema>& key_schema,
                      const std::shared_ptr<arrow::Schema>& value_schema,
-                     const std::vector<KeyValue>& expected) const {
+                     const std::vector<KeyValue>& expected, bool ignore_delete = false) const {
         CheckSortMergeResult<SortMergeReaderWithLoserTree>(src_array_vec, user_key_comparator,
                                                            user_defined_seq_comparator, key_schema,
                                                            value_schema, expected,
-                                                           /*need_merge=*/true);
+                                                           /*need_merge=*/true, ignore_delete);
         CheckSortMergeResult<SortMergeReaderWithMinHeap>(src_array_vec, user_key_comparator,
                                                          user_defined_seq_comparator, key_schema,
                                                          value_schema, expected,
-                                                         /*need_merge=*/true);
+                                                         /*need_merge=*/true, ignore_delete);
     }
 
  private:
@@ -89,9 +89,9 @@ class SortMergeReaderTest : public testing::Test {
         const std::shared_ptr<FieldsComparator>& user_key_comparator,
         const std::shared_ptr<FieldsComparator>& user_defined_seq_comparator,
         const std::shared_ptr<arrow::Schema>& key_schema,
-        const std::shared_ptr<arrow::Schema>& value_schema, int32_t batch_size,
-        bool need_merge) const {
-        auto mfunc = std::make_unique<DeduplicateMergeFunction>(/*ignore_delete=*/false);
+        const std::shared_ptr<arrow::Schema>& value_schema, int32_t batch_size, bool need_merge,
+        bool ignore_delete) const {
+        auto mfunc = std::make_unique<DeduplicateMergeFunction>(ignore_delete);
         auto merge_function_wrapper =
             std::make_shared<ReducerMergeFunctionWrapper>(std::move(mfunc));
         if (!need_merge) {
@@ -124,11 +124,12 @@ class SortMergeReaderTest : public testing::Test {
                               const std::shared_ptr<FieldsComparator>& user_defined_seq_comparator,
                               const std::shared_ptr<arrow::Schema>& key_schema,
                               const std::shared_ptr<arrow::Schema>& value_schema,
-                              const std::vector<KeyValue>& expected, bool need_merge) const {
+                              const std::vector<KeyValue>& expected, bool need_merge,
+                              bool ignore_delete = false) const {
         for (auto batch_size : {1, 2, 3, 4, 100}) {
             auto sort_merge_reader = CreateSortMergeReader<SortMergeReaderType>(
                 src_array_vec, user_key_comparator, user_defined_seq_comparator, key_schema,
-                value_schema, batch_size, need_merge);
+                value_schema, batch_size, need_merge, ignore_delete);
             ASSERT_OK_AND_ASSIGN(
                 std::vector<KeyValue> results,
                 (ReadResultCollector::CollectKeyValueResult<
@@ -415,6 +416,54 @@ TEST_F(SortMergeReaderTest, TestSortMergeIn3Ways) {
 
     CheckResult({src_array1, src_array2, src_array3}, user_key_comparator,
                 /*user_defined_seq_comparator=*/nullptr, key_schema, value_schema, expected);
+}
+
+TEST_F(SortMergeReaderTest, TestSortMergeWithDeleteMessages) {
+    arrow::FieldVector fields = {arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+                                 arrow::field("_VALUE_KIND", arrow::int8()),
+                                 arrow::field("k0", arrow::int32()),
+                                 arrow::field("v0", arrow::int32())};
+    auto data_fields = CreateDataField(fields);
+    std::shared_ptr<arrow::Schema> key_schema = arrow::schema(arrow::FieldVector({fields[2]}));
+    std::shared_ptr<arrow::Schema> value_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3]}));
+    std::shared_ptr<arrow::DataType> src_type = arrow::struct_(fields);
+
+    auto src_array1 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [0, 3, 1, 10],
+        [2, 3, 2, 200],
+        [1, 0, 3, 300]
+    ])")
+            .ValueOrDie());
+
+    auto src_array2 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [3, 3, 1, 11],
+        [4, 3, 2, 240],
+        [5, 3, 3, 30]
+    ])")
+            .ValueOrDie());
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FieldsComparator> user_key_comparator,
+                         FieldsComparator::Create({data_fields[2]}, std::vector<int32_t>({0}),
+                                                  /*is_ascending_order=*/true));
+
+    std::vector<RowKind*> delete_row_kinds = {const_cast<RowKind*>(RowKind::Delete()),
+                                              const_cast<RowKind*>(RowKind::Delete()),
+                                              const_cast<RowKind*>(RowKind::Delete())};
+    std::vector<KeyValue> expected_delete = KeyValueChecker::GenerateKeyValues(
+        delete_row_kinds, /*seq_vec=*/{3, 4, 5}, /*level_vec=*/{0, 0, 0},
+        /*key_vec=*/{{1}, {2}, {3}}, /*value_vec=*/{{1, 11}, {2, 240}, {3, 30}}, pool_);
+    CheckResult({src_array1, src_array2}, user_key_comparator,
+                /*user_defined_seq_comparator=*/nullptr, key_schema, value_schema, expected_delete,
+                /*ignore_delete=*/false);
+
+    std::vector<KeyValue> expected_ignore_delete = KeyValueChecker::GenerateKeyValues(
+        /*seq_vec=*/{1}, /*key_vec=*/{{3}}, /*value_vec=*/{{3, 300}}, pool_);
+    CheckResult({src_array1, src_array2}, user_key_comparator,
+                /*user_defined_seq_comparator=*/nullptr, key_schema, value_schema,
+                expected_ignore_delete, /*ignore_delete=*/true);
 }
 
 TEST_F(SortMergeReaderTest, TestSortMergeIn2WaysWithEmptyArray) {

--- a/src/paimon/core/mergetree/compact/sort_merge_reader_with_min_heap.cpp
+++ b/src/paimon/core/mergetree/compact/sort_merge_reader_with_min_heap.cpp
@@ -48,7 +48,8 @@ Result<std::unique_ptr<SortMergeReader::Iterator>> SortMergeReaderWithMinHeap::N
                 reader->Close();
                 break;
             }
-            if (iterator->HasNext()) {
+            PAIMON_ASSIGN_OR_RAISE(bool has_next, iterator->HasNext());
+            if (has_next) {
                 PAIMON_ASSIGN_OR_RAISE(KeyValue kv, iterator->Next());
                 min_heap_.emplace(std::move(kv), std::move(iterator), reader);
                 break;

--- a/src/paimon/core/mergetree/compact/sort_merge_reader_with_min_heap.h
+++ b/src/paimon/core/mergetree/compact/sort_merge_reader_with_min_heap.h
@@ -101,7 +101,8 @@ class SortMergeReaderWithMinHeap : public SortMergeReader {
         }
 
         Result<bool> Update() {
-            if (!iterator->HasNext()) {
+            PAIMON_ASSIGN_OR_RAISE(bool has_next, iterator->HasNext());
+            if (!has_next) {
                 return false;
             }
             PAIMON_ASSIGN_OR_RAISE(KeyValue tmp_kv, iterator->Next());

--- a/src/paimon/core/mergetree/lookup_levels.cpp
+++ b/src/paimon/core/mergetree/lookup_levels.cpp
@@ -380,7 +380,11 @@ Status LookupLevels<T>::CreateSstFileFromDataFile(const std::shared_ptr<DataFile
         }
         auto typed_iter = dynamic_cast<KeyValueDataFileRecordReader::Iterator*>(iter.get());
         assert(typed_iter);
-        while (typed_iter->HasNext()) {
+        while (true) {
+            PAIMON_ASSIGN_OR_RAISE(bool has_next, typed_iter->HasNext());
+            if (!has_next) {
+                break;
+            }
             std::pair<int64_t, KeyValue> kv_and_pos;
             PAIMON_ASSIGN_OR_RAISE(kv_and_pos, typed_iter->NextWithFilePos());
             const auto& [file_pos, kv] = kv_and_pos;

--- a/src/paimon/core/mergetree/sort_buffer_test.cpp
+++ b/src/paimon/core/mergetree/sort_buffer_test.cpp
@@ -115,7 +115,11 @@ class SortBufferTest : public ::testing::Test {
             if (iterator == nullptr) {
                 break;
             }
-            while (iterator->HasNext()) {
+            while (true) {
+                PAIMON_ASSIGN_OR_RAISE(bool has_next, iterator->HasNext());
+                if (!has_next) {
+                    break;
+                }
                 PAIMON_ASSIGN_OR_RAISE(KeyValue key_value, iterator->Next());
                 rows.push_back(ReaderResult{std::string(key_value.key->GetStringView(0)),
                                             key_value.value->GetInt(1), key_value.value->GetInt(2),

--- a/src/paimon/core/mergetree/spill_reader.cpp
+++ b/src/paimon/core/mergetree/spill_reader.cpp
@@ -62,7 +62,7 @@ Status SpillReader::Open(const FileIOChannel::ID& channel_id) {
 
 SpillReader::Iterator::Iterator(SpillReader* reader) : reader_(reader) {}
 
-bool SpillReader::Iterator::HasNext() const {
+Result<bool> SpillReader::Iterator::HasNext() const {
     return cursor_ < reader_->batch_length_;
 }
 

--- a/src/paimon/core/mergetree/spill_reader.h
+++ b/src/paimon/core/mergetree/spill_reader.h
@@ -49,7 +49,7 @@ class SpillReader : public KeyValueRecordReader {
     class Iterator : public KeyValueRecordReader::Iterator {
      public:
         explicit Iterator(SpillReader* reader);
-        bool HasNext() const override;
+        Result<bool> HasNext() const override;
         Result<KeyValue> Next() override;
 
      private:

--- a/src/paimon/core/mergetree/spill_reader_writer_test.cpp
+++ b/src/paimon/core/mergetree/spill_reader_writer_test.cpp
@@ -153,7 +153,11 @@ TEST_P(SpillReaderWriterTest, TestWriteBatch) {
                 break;
             }
             batch_count++;
-            while (iter->HasNext()) {
+            while (true) {
+                ASSERT_OK_AND_ASSIGN(bool has_next, iter->HasNext());
+                if (!has_next) {
+                    break;
+                }
                 ASSERT_OK_AND_ASSIGN(auto kv, iter->Next());
                 ASSERT_EQ(kv.key->GetStringView(0), expected_keys[total_rows]);
                 total_rows++;
@@ -176,7 +180,11 @@ TEST_P(SpillReaderWriterTest, TestWriteBatch) {
                 break;
             }
             batch_count++;
-            while (iter->HasNext()) {
+            while (true) {
+                ASSERT_OK_AND_ASSIGN(bool has_next, iter->HasNext());
+                if (!has_next) {
+                    break;
+                }
                 ASSERT_OK_AND_ASSIGN(auto kv, iter->Next());
                 ASSERT_EQ(kv.key->GetStringView(0), expected_keys[total_rows]);
                 total_rows++;
@@ -208,7 +216,11 @@ TEST_P(SpillReaderWriterTest, TestReadBatch) {
             ASSERT_OK_AND_ASSIGN(auto iter, reader->NextBatch());
             if (iter == nullptr) break;
             batch_count++;
-            while (iter->HasNext()) {
+            while (true) {
+                ASSERT_OK_AND_ASSIGN(bool has_next, iter->HasNext());
+                if (!has_next) {
+                    break;
+                }
                 ASSERT_OK_AND_ASSIGN(auto kv, iter->Next());
                 ASSERT_EQ(kv.key->GetStringView(0), expected_keys[total_rows]);
                 ASSERT_EQ(kv.value->GetStringView(0), expected_keys[total_rows]);
@@ -235,7 +247,8 @@ TEST_P(SpillReaderWriterTest, TestReadBatch) {
 
         ASSERT_OK_AND_ASSIGN(auto iter, reader->NextBatch());
         if (iter != nullptr) {
-            ASSERT_FALSE(iter->HasNext());
+            ASSERT_OK_AND_ASSIGN(bool has_next, iter->HasNext());
+            ASSERT_FALSE(has_next);
         }
         reader->Close();
     }

--- a/src/paimon/core/mergetree/write_buffer_test.cpp
+++ b/src/paimon/core/mergetree/write_buffer_test.cpp
@@ -78,7 +78,11 @@ class WriteBufferTest : public ::testing::Test {
         PAIMON_ASSIGN_OR_RAISE(auto iterator, reader->NextBatch());
 
         ReaderResult result;
-        while (iterator->HasNext()) {
+        while (true) {
+            PAIMON_ASSIGN_OR_RAISE(bool has_next, iterator->HasNext());
+            if (!has_next) {
+                break;
+            }
             PAIMON_ASSIGN_OR_RAISE(KeyValue key_value, iterator->Next());
             result.sequence_numbers.push_back(key_value.sequence_number);
             result.row_kind_values.push_back(key_value.value_kind->ToByteValue());

--- a/src/paimon/testing/utils/read_result_collector.h
+++ b/src/paimon/testing/utils/read_result_collector.h
@@ -49,7 +49,8 @@ class ReadResultCollector {
             }
             while (true) {
                 if constexpr (std::is_same_v<IteratorType, KeyValueRecordReader::Iterator>) {
-                    if (!iterator->HasNext()) {
+                    PAIMON_ASSIGN_OR_RAISE(bool has_next, iterator->HasNext());
+                    if (!has_next) {
                         break;
                     }
                     PAIMON_ASSIGN_OR_RAISE(KeyValue kv, iterator->Next());


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

Linked issue: N/A

Move calculate merged key-value operation into `MergedKeyValueRecordReader::Iterator::HasNext()` so merge functions that return `nullopt` can be skipped safely before `Next()` is called.

This fixes the iterator contract for delete-only groups when delete messages are ignored, and propagates the new `Result<bool>` `HasNext()` contract through key-value readers and related merge-tree call sites.

### Tests

TEST_F(MergedKeyValueRecordReaderTest, TestSkipMergedNulloptResultInHasNext)
TEST_F(SortMergeReaderTest, TestSortMergeWithDeleteMessages)

### API and Format

Changes the internal `KeyValueRecordReader::Iterator::HasNext()` contract to return `Result<bool>` so iterator prefetch errors can be returned directly. 

No public API, storage format and protocol change.

### Documentation

No user-facing documentation change.

### Generative AI tooling

Generated-by: Codex (GPT-5.5)
