### PR TITLE
fix: fix uuid.h to work on macOS

### DIFF
--- a/src/paimon/common/utils/uuid.h
+++ b/src/paimon/common/utils/uuid.h
@@ -31,20 +31,36 @@
 #include <fstream>
 #include <string>
 
+#if defined(__APPLE__)
+#include <uuid/uuid.h>
+
+#include <array>
+#endif
+
 namespace paimon {
 
 class UUID {
  public:
     static bool Generate(std::string* output) {
+#if defined(__APPLE__)
         output->clear();
-        std::ifstream f("/proc/sys/kernel/random/uuid");
-        std::getline(f, /*&*/ *output);
+        std::array<char, 37> buffer{};
+        uuid_t uuid;
+        uuid_generate_random(uuid);
+        uuid_unparse_lower(uuid, buffer.data());
+        *output = buffer.data();
         if (output->size() == 36) {
             return true;
-        } else {
-            output->clear();
-            return false;
         }
+#else
+        output->clear();
+        std::ifstream f("/proc/sys/kernel/random/uuid");
+        if (std::getline(f, /*&*/ *output) && output->size() == 36) {
+            return true;
+        }
+#endif
+        output->clear();
+        return false;
     }
 };
 


### PR DESCRIPTION
### Purpose

Currently `src/paimon/common/utils/uuid.h` blindly uses `/proc/sys/kernel/random/uuid` to generate uuid. This only works on Linux-based platforms. I just made it work on macOS. 

### Tests

N/A

### API and Format

N/A

### Documentation

N/A

### Generative AI tooling

Generated-by: Codex with GPT-5.5