### PR TITLE
test: add unit test for release-0.2

### DIFF
--- a/src/paimon/CMakeLists.txt
+++ b/src/paimon/CMakeLists.txt
@@ -532,6 +532,8 @@ if(PAIMON_BUILD_TESTS)
                     common/compression/block_compression_factory_test.cpp
                     common/sst/sst_file_io_test.cpp
                     common/sst/block_cache_test.cpp
+                    common/sst/block_meta_test.cpp
+                    common/sst/block_write_read_test.cpp
                     common/utils/crc32c_test.cpp
                     STATIC_LINK_LIBS
                     paimon_shared

--- a/src/paimon/common/predicate/predicate_test.cpp
+++ b/src/paimon/common/predicate/predicate_test.cpp
@@ -1410,6 +1410,115 @@ TEST_F(PredicateTest, TestLike) {
         StringStatsCheck(*predicate, 1ll, {StringFieldStats(std::nullopt, std::nullopt, 1ll)}));
 }
 
+TEST_F(PredicateTest, TestLikeConsecutivePercent) {
+    // consecutive '%' should be merged into one '%'
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", arrow::utf8())}));
+
+    // "%%" should behave the same as "%"
+    ASSERT_OK_AND_ASSIGN(auto predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "%%", 2)));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"anything"})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({""})).value());
+
+    // "a%%%b" should behave the same as "a%b"
+    ASSERT_OK_AND_ASSIGN(predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "a%%%b", 5)));
+    predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"axyzb"})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"ab"})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"axyzc"})).value());
+}
+
+TEST_F(PredicateTest, TestLikeEmptyField) {
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", arrow::utf8())}));
+
+    // empty field should match "%"
+    ASSERT_OK_AND_ASSIGN(auto predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "%", 1)));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({""})).value());
+
+    // empty field should NOT match "_"
+    ASSERT_OK_AND_ASSIGN(predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "_", 1)));
+    predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({""})).value());
+
+    // empty field should NOT match a fixed pattern "abc"
+    ASSERT_OK_AND_ASSIGN(predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "abc", 3)));
+    predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({""})).value());
+}
+
+TEST_F(PredicateTest, TestLikeMinLenExceedsField) {
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", arrow::utf8())}));
+
+    // pattern "abcdef" requires 6 literal chars, field "ab" has only 2
+    ASSERT_OK_AND_ASSIGN(auto predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "abcdef", 6)));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"ab"})).value());
+
+    // pattern "a_b_c" requires 3 literal chars, wildcards = min_len 3, field "ab" has 2
+    ASSERT_OK_AND_ASSIGN(predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "a_b_c", 5)));
+    predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"ab"})).value());
+
+    // field length equals min_len should still be possible to match
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"axbxc"})).value());
+}
+
+TEST_F(PredicateTest, TestLikeLongPatternHeapAlloc) {
+    // pattern length > STACK_LIMIT(128) uses heap allocation
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", arrow::utf8())}));
+
+    // Build a pattern with > 128 characters: "a" + 130 * "_" + "z"
+    std::string long_pattern = "a";
+    for (int i = 0; i < 130; ++i) {
+        long_pattern += '_';
+    }
+    long_pattern += 'z';
+
+    ASSERT_OK_AND_ASSIGN(auto predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, long_pattern.data(), long_pattern.size())));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+
+    // Build a matching field: "a" + 130 * "x" + "z"
+    std::string matching_field = "a";
+    for (int i = 0; i < 130; ++i) {
+        matching_field += 'x';
+    }
+    matching_field += 'z';
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({matching_field})).value());
+
+    // Non-matching: wrong ending
+    std::string non_matching_field = "a";
+    for (int i = 0; i < 130; ++i) {
+        non_matching_field += 'x';
+    }
+    non_matching_field += 'y';
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({non_matching_field})).value());
+}
+
 TEST_F(PredicateTest, TestCompound) {
     ASSERT_OK_AND_ASSIGN(
         const auto startswith_predicate,

--- a/src/paimon/common/reader/data_evolution_array_test.cpp
+++ b/src/paimon/common/reader/data_evolution_array_test.cpp
@@ -218,8 +218,8 @@ TEST(DataEvolutionArrayTest, TestAllFieldTypes) {
     // --- Row array (array index 13) ---
     BinaryArray row_array;
     {
-        BinaryRow row1 =
-            BinaryRowGenerator::GenerateRow({std::string("Alice"), int32_t(30)}, pool.get());
+        BinaryRow row1 = BinaryRowGenerator::GenerateRow(
+            {std::string("Alice"), static_cast<int32_t>(30)}, pool.get());
         BinaryArrayWriter writer(&row_array, 1, 8, pool.get());
         writer.WriteRow(0, row1);
         writer.Complete();

--- a/src/paimon/common/reader/data_evolution_array_test.cpp
+++ b/src/paimon/common/reader/data_evolution_array_test.cpp
@@ -16,7 +16,18 @@
 
 #include "paimon/common/reader/data_evolution_array.h"
 
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "gtest/gtest.h"
+#include "paimon/common/data/binary_array_writer.h"
+#include "paimon/common/data/binary_map.h"
+#include "paimon/common/data/binary_string.h"
+#include "paimon/data/decimal.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/memory/bytes.h"
 #include "paimon/memory/memory_pool.h"
 #include "paimon/testing/utils/binary_row_generator.h"
 #include "paimon/testing/utils/testharness.h"
@@ -72,6 +83,263 @@ TEST(DataEvolutionArrayTest, TestNullValue) {
     ASSERT_TRUE(data_evolution_array.IsNullAt(1));
     ASSERT_EQ(data_evolution_array.GetLong(2), 1);
     ASSERT_EQ(data_evolution_array.GetLong(3), -100);
+}
+
+TEST(DataEvolutionArrayTest, TestAllFieldTypes) {
+    auto pool = GetDefaultPool();
+
+    // We create separate BinaryArrays for each field type and use DataEvolutionArray
+    // to proxy access across them. Each array has 2 elements; the evolution array
+    // picks one element from each underlying array via array_offsets/field_offsets.
+
+    // --- Boolean array (array index 0) ---
+    BinaryArray bool_array;
+    {
+        BinaryArrayWriter writer(&bool_array, 2, sizeof(bool), pool.get());
+        writer.WriteBoolean(0, true);
+        writer.WriteBoolean(1, false);
+        writer.Complete();
+    }
+
+    // --- Byte array (array index 1) ---
+    BinaryArray byte_array;
+    {
+        BinaryArrayWriter writer(&byte_array, 2, sizeof(int8_t), pool.get());
+        writer.WriteByte(0, 42);
+        writer.WriteByte(1, -7);
+        writer.Complete();
+    }
+
+    // --- Short array (array index 2) ---
+    BinaryArray short_array;
+    {
+        BinaryArrayWriter writer(&short_array, 2, sizeof(int16_t), pool.get());
+        writer.WriteShort(0, 1024);
+        writer.WriteShort(1, -512);
+        writer.Complete();
+    }
+
+    // --- Int array (array index 3) ---
+    BinaryArray int_array;
+    {
+        BinaryArrayWriter writer(&int_array, 2, sizeof(int32_t), pool.get());
+        writer.WriteInt(0, 100000);
+        writer.WriteInt(1, -99999);
+        writer.Complete();
+    }
+
+    // --- Long array (array index 4) ---
+    BinaryArray long_array;
+    {
+        BinaryArrayWriter writer(&long_array, 2, sizeof(int64_t), pool.get());
+        writer.WriteLong(0, 1234567890LL);
+        writer.WriteLong(1, -987654321LL);
+        writer.Complete();
+    }
+
+    // --- Float array (array index 5) ---
+    BinaryArray float_array;
+    {
+        BinaryArrayWriter writer(&float_array, 2, sizeof(float), pool.get());
+        writer.WriteFloat(0, 3.14f);
+        writer.WriteFloat(1, -2.71f);
+        writer.Complete();
+    }
+
+    // --- Double array (array index 6) ---
+    BinaryArray double_array;
+    {
+        BinaryArrayWriter writer(&double_array, 2, sizeof(double), pool.get());
+        writer.WriteDouble(0, 1.23456789);
+        writer.WriteDouble(1, -9.87654321);
+        writer.Complete();
+    }
+
+    // --- String array (array index 7) ---
+    BinaryArray string_array;
+    {
+        BinaryArrayWriter writer(&string_array, 2, 8, pool.get());
+        writer.WriteString(0, BinaryString::FromString("hello", pool.get()));
+        writer.WriteString(1, BinaryString::FromString("world", pool.get()));
+        writer.Complete();
+    }
+
+    // --- Decimal array (array index 8), precision=10, scale=2 ---
+    BinaryArray decimal_array;
+    {
+        BinaryArrayWriter writer(&decimal_array, 2, 8, pool.get());
+        writer.WriteDecimal(0, Decimal(10, 2, 12345), 10);
+        writer.WriteDecimal(1, Decimal(10, 2, 67890), 10);
+        writer.Complete();
+    }
+
+    // --- Timestamp array (array index 9), precision=9 (non-compact) ---
+    BinaryArray timestamp_array;
+    {
+        BinaryArrayWriter writer(&timestamp_array, 2, 8, pool.get());
+        writer.WriteTimestamp(0, Timestamp(1000, 500), 9);
+        writer.WriteTimestamp(1, Timestamp(2000, 999), 9);
+        writer.Complete();
+    }
+
+    // --- Binary/Bytes array (array index 10) ---
+    BinaryArray binary_array;
+    {
+        Bytes bytes_val1("abcde", pool.get());
+        Bytes bytes_val2("fghij", pool.get());
+        BinaryArrayWriter writer(&binary_array, 2, 8, pool.get());
+        writer.WriteBinary(0, bytes_val1);
+        writer.WriteBinary(1, bytes_val2);
+        writer.Complete();
+    }
+
+    // --- Nested Array array (array index 11) ---
+    BinaryArray nested_array;
+    {
+        auto inner = BinaryArray::FromIntArray({10, 20}, pool.get());
+        auto inner2 = BinaryArray::FromIntArray({30, 40}, pool.get());
+        BinaryArrayWriter writer(&nested_array, 2, 8, pool.get());
+        writer.WriteArray(0, inner);
+        writer.WriteArray(1, inner2);
+        writer.Complete();
+    }
+
+    // --- Map array (array index 12) ---
+    BinaryArray map_array;
+    {
+        auto map_key = BinaryArray::FromIntArray({1, 2}, pool.get());
+        auto map_val = BinaryArray::FromLongArray({100LL, 200LL}, pool.get());
+        auto map_obj = BinaryMap::ValueOf(map_key, map_val, pool.get());
+        BinaryArrayWriter writer(&map_array, 1, 8, pool.get());
+        writer.WriteMap(0, *map_obj);
+        writer.Complete();
+    }
+
+    // --- Row array (array index 13) ---
+    BinaryArray row_array;
+    {
+        BinaryRow row1 =
+            BinaryRowGenerator::GenerateRow({std::string("Alice"), int32_t(30)}, pool.get());
+        BinaryArrayWriter writer(&row_array, 1, 8, pool.get());
+        writer.WriteRow(0, row1);
+        writer.Complete();
+    }
+
+    // --- Date array (array index 14), stored as int32 ---
+    BinaryArray date_array;
+    {
+        BinaryArrayWriter writer(&date_array, 2, sizeof(int32_t), pool.get());
+        writer.WriteInt(0, 19000);  // days since epoch
+        writer.WriteInt(1, 18500);
+        writer.Complete();
+    }
+
+    std::vector<BinaryArray> arrays = {
+        bool_array,       // 0
+        byte_array,       // 1
+        short_array,      // 2
+        int_array,        // 3
+        long_array,       // 4
+        float_array,      // 5
+        double_array,     // 6
+        string_array,     // 7
+        decimal_array,    // 8
+        timestamp_array,  // 9
+        binary_array,     // 10
+        nested_array,     // 11
+        map_array,        // 12
+        row_array,        // 13
+        date_array,       // 14
+    };
+
+    // Each evolution entry: (array_index, field_index_within_array)
+    // pos 0:  boolean   -> arrays[0][0]  = true
+    // pos 1:  byte      -> arrays[1][0]  = 42
+    // pos 2:  short     -> arrays[2][1]  = -512
+    // pos 3:  int       -> arrays[3][0]  = 100000
+    // pos 4:  long      -> arrays[4][1]  = -987654321
+    // pos 5:  float     -> arrays[5][0]  = 3.14f
+    // pos 6:  double    -> arrays[6][1]  = -9.87654321
+    // pos 7:  string    -> arrays[7][0]  = "hello"
+    // pos 8:  decimal   -> arrays[8][1]  = Decimal(10,2,67890)
+    // pos 9:  timestamp -> arrays[9][0]  = Timestamp(1000,500)
+    // pos 10: binary    -> arrays[10][1] = "fghij"
+    // pos 11: array     -> arrays[11][0] = [10,20]
+    // pos 12: map       -> arrays[12][0]
+    // pos 13: row       -> arrays[13][0] = ("Alice", 30)
+    // pos 14: date      -> arrays[14][0] = 19000
+    // pos 15: string    -> arrays[7][1]  = "world"
+    std::vector<int32_t> array_offsets = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 7};
+    std::vector<int32_t> field_offsets = {0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 1};
+
+    DataEvolutionArray evolution(arrays, array_offsets, field_offsets);
+
+    ASSERT_EQ(evolution.Size(), 16);
+
+    // Boolean
+    ASSERT_FALSE(evolution.IsNullAt(0));
+    ASSERT_EQ(evolution.GetBoolean(0), true);
+
+    // Byte
+    ASSERT_EQ(evolution.GetByte(1), 42);
+
+    // Short
+    ASSERT_EQ(evolution.GetShort(2), -512);
+
+    // Int
+    ASSERT_EQ(evolution.GetInt(3), 100000);
+
+    // Long
+    ASSERT_EQ(evolution.GetLong(4), -987654321LL);
+
+    // Float
+    ASSERT_FLOAT_EQ(evolution.GetFloat(5), 3.14f);
+
+    // Double
+    ASSERT_DOUBLE_EQ(evolution.GetDouble(6), -9.87654321);
+
+    // String
+    ASSERT_EQ(evolution.GetString(7).ToString(), "hello");
+
+    // StringView
+    ASSERT_EQ(evolution.GetStringView(15), "world");
+
+    // Decimal
+    ASSERT_EQ(evolution.GetDecimal(8, 10, 2), Decimal(10, 2, 67890));
+
+    // Timestamp
+    ASSERT_EQ(evolution.GetTimestamp(9, 9), Timestamp(1000, 500));
+
+    // Binary
+    auto retrieved_binary = evolution.GetBinary(10);
+    Bytes expected_binary("fghij", pool.get());
+    ASSERT_EQ(*retrieved_binary, expected_binary);
+
+    // Nested Array
+    auto retrieved_array = evolution.GetArray(11);
+    ASSERT_OK_AND_ASSIGN(auto inner_values, retrieved_array->ToIntArray());
+    ASSERT_EQ(inner_values, std::vector<int32_t>({10, 20}));
+
+    // Map
+    auto retrieved_map = evolution.GetMap(12);
+    ASSERT_EQ(retrieved_map->Size(), 2);
+
+    // Row
+    auto retrieved_row = evolution.GetRow(13, 2);
+    ASSERT_EQ(retrieved_row->GetString(0).ToString(), "Alice");
+    ASSERT_EQ(retrieved_row->GetInt(1), 30);
+
+    // Date
+    ASSERT_EQ(evolution.GetDate(14), 19000);
+
+    // Verify unsupported ToXxxArray methods
+    ASSERT_NOK_WITH_MSG(evolution.ToBooleanArray(),
+                        "DataEvolutionArray not support ToBooleanArray");
+    ASSERT_NOK_WITH_MSG(evolution.ToByteArray(), "DataEvolutionArray not support ToByteArray");
+    ASSERT_NOK_WITH_MSG(evolution.ToShortArray(), "DataEvolutionArray not support ToShortArray");
+    ASSERT_NOK_WITH_MSG(evolution.ToIntArray(), "DataEvolutionArray not support ToIntArray");
+    ASSERT_NOK_WITH_MSG(evolution.ToFloatArray(), "DataEvolutionArray not support ToFloatArray");
+    ASSERT_NOK_WITH_MSG(evolution.ToDoubleArray(), "DataEvolutionArray not support ToDoubleArray");
 }
 
 }  // namespace paimon::test

--- a/src/paimon/common/reader/data_evolution_row_test.cpp
+++ b/src/paimon/common/reader/data_evolution_row_test.cpp
@@ -144,8 +144,8 @@ TEST(DataEvolutionRowTest, TestAllFieldTypes) {
         writer.WriteMap(1, *map_obj);
 
         // field 2: row ("Alice", 30)
-        BinaryRow inner_row =
-            BinaryRowGenerator::GenerateRow({std::string("Alice"), int32_t(30)}, pool.get());
+        BinaryRow inner_row = BinaryRowGenerator::GenerateRow(
+            {std::string("Alice"), static_cast<int32_t>(30)}, pool.get());
         writer.WriteRow(2, inner_row);
 
         writer.Complete();

--- a/src/paimon/common/reader/data_evolution_row_test.cpp
+++ b/src/paimon/common/reader/data_evolution_row_test.cpp
@@ -16,11 +16,21 @@
 
 #include "paimon/common/reader/data_evolution_row.h"
 
+#include <cstdint>
+#include <memory>
+#include <string>
 #include <variant>
+#include <vector>
 
 #include "gtest/gtest.h"
+#include "paimon/common/data/binary_array_writer.h"
+#include "paimon/common/data/binary_map.h"
+#include "paimon/common/data/binary_row_writer.h"
 #include "paimon/common/data/data_define.h"
 #include "paimon/common/types/row_kind.h"
+#include "paimon/data/decimal.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/memory/bytes.h"
 #include "paimon/memory/memory_pool.h"
 #include "paimon/status.h"
 #include "paimon/testing/utils/binary_row_generator.h"
@@ -88,6 +98,138 @@ TEST(DataEvolutionRowTest, TestNull) {
     ASSERT_EQ(row.GetInt(5), 10);
     ASSERT_TRUE(row.IsNullAt(6));
     ASSERT_TRUE(row.IsNullAt(7));
+}
+
+TEST(DataEvolutionRowTest, TestAllFieldTypes) {
+    auto pool = GetDefaultPool();
+
+    // Row0: boolean(true), byte(42), short(1024), int(100000), date(19000)
+    BinaryRow row0 = BinaryRowGenerator::GenerateRow(
+        {true, int8_t(42), int16_t(1024), int32_t(100000), int32_t(19000)}, pool.get());
+
+    // Row1: long(-987654321), float(3.14f), double(-9.87654321)
+    BinaryRow row1 = BinaryRowGenerator::GenerateRow(
+        {int64_t(-987654321LL), float(3.14f), double(-9.87654321)}, pool.get());
+
+    // Row2: string("hello"), string("world")
+    BinaryRow row2 =
+        BinaryRowGenerator::GenerateRow({std::string("hello"), std::string("world")}, pool.get());
+
+    // Row3: decimal(10,2,67890), timestamp(1000,500) with precision 9
+    BinaryRow row3 = BinaryRowGenerator::GenerateRow(
+        {Decimal(10, 2, 67890), TimestampType(Timestamp(1000, 500), 9)}, pool.get());
+
+    // Row4: binary("fghij")
+    auto bytes_val = std::make_shared<Bytes>("fghij", pool.get());
+    BinaryRow row4 = BinaryRowGenerator::GenerateRow({bytes_val}, pool.get());
+
+    // Row5: nested array [10,20], nested map {1:100, 2:200}, nested row ("Alice", 30)
+    // Built manually via BinaryRowWriter since BinaryRowGenerator doesn't support nested types
+    BinaryRow row5(3);
+    {
+        BinaryRowWriter writer(&row5, 0, pool.get());
+
+        // field 0: array [10, 20]
+        auto inner_array = BinaryArray::FromIntArray({10, 20}, pool.get());
+        writer.WriteArray(0, inner_array);
+
+        // field 1: map {1->100, 2->200}
+        auto map_key = BinaryArray::FromIntArray({1, 2}, pool.get());
+        auto map_val = BinaryArray::FromLongArray({100LL, 200LL}, pool.get());
+        auto map_obj = BinaryMap::ValueOf(map_key, map_val, pool.get());
+        writer.WriteMap(1, *map_obj);
+
+        // field 2: row ("Alice", 30)
+        BinaryRow inner_row =
+            BinaryRowGenerator::GenerateRow({std::string("Alice"), int32_t(30)}, pool.get());
+        writer.WriteRow(2, inner_row);
+
+        writer.Complete();
+    }
+
+    // Build the DataEvolutionRow that picks specific fields from each row.
+    // evolution field -> (row_index, field_index_within_row)
+    // pos 0:  boolean   -> row0[0]  = true
+    // pos 1:  byte      -> row0[1]  = 42
+    // pos 2:  short     -> row0[2]  = 1024
+    // pos 3:  int       -> row0[3]  = 100000
+    // pos 4:  date      -> row0[4]  = 19000
+    // pos 5:  long      -> row1[0]  = -987654321
+    // pos 6:  float     -> row1[1]  = 3.14f
+    // pos 7:  double    -> row1[2]  = -9.87654321
+    // pos 8:  string    -> row2[0]  = "hello"
+    // pos 9:  stringview-> row2[1]  = "world"
+    // pos 10: decimal   -> row3[0]  = Decimal(10,2,67890)
+    // pos 11: timestamp -> row3[1]  = Timestamp(1000,500)
+    // pos 12: binary    -> row4[0]  = "fghij"
+    // pos 13: array     -> row5[0]  = [10,20]
+    // pos 14: map       -> row5[1]  = {1:100, 2:200}
+    // pos 15: row       -> row5[2]  = ("Alice", 30)
+    std::vector<int32_t> row_offsets = {0, 0, 0, 0, 0, 1, 1, 1, 2, 2, 3, 3, 4, 5, 5, 5};
+    std::vector<int32_t> field_offsets = {0, 1, 2, 3, 4, 0, 1, 2, 0, 1, 0, 1, 0, 0, 1, 2};
+
+    DataEvolutionRow evolution({row0, row1, row2, row3, row4, row5}, row_offsets, field_offsets);
+
+    ASSERT_EQ(evolution.GetFieldCount(), 16);
+
+    // Boolean
+    ASSERT_FALSE(evolution.IsNullAt(0));
+    ASSERT_EQ(evolution.GetBoolean(0), true);
+
+    // Byte
+    ASSERT_EQ(evolution.GetByte(1), 42);
+
+    // Short
+    ASSERT_EQ(evolution.GetShort(2), 1024);
+
+    // Int
+    ASSERT_EQ(evolution.GetInt(3), 100000);
+
+    // Date
+    ASSERT_EQ(evolution.GetDate(4), 19000);
+
+    // Long
+    ASSERT_EQ(evolution.GetLong(5), -987654321LL);
+
+    // Float
+    ASSERT_FLOAT_EQ(evolution.GetFloat(6), 3.14f);
+
+    // Double
+    ASSERT_DOUBLE_EQ(evolution.GetDouble(7), -9.87654321);
+
+    // String
+    ASSERT_EQ(evolution.GetString(8).ToString(), "hello");
+
+    // StringView
+    ASSERT_EQ(evolution.GetStringView(9), "world");
+
+    // Decimal
+    ASSERT_EQ(evolution.GetDecimal(10, 10, 2), Decimal(10, 2, 67890));
+
+    // Timestamp
+    ASSERT_EQ(evolution.GetTimestamp(11, 9), Timestamp(1000, 500));
+
+    // Binary
+    auto retrieved_binary = evolution.GetBinary(12);
+    Bytes expected_binary("fghij", pool.get());
+    ASSERT_EQ(*retrieved_binary, expected_binary);
+
+    // Nested Array
+    auto retrieved_array = evolution.GetArray(13);
+    ASSERT_OK_AND_ASSIGN(auto inner_values, retrieved_array->ToIntArray());
+    ASSERT_EQ(inner_values, std::vector<int32_t>({10, 20}));
+
+    // Map
+    auto retrieved_map = evolution.GetMap(14);
+    ASSERT_EQ(retrieved_map->Size(), 2);
+
+    // Nested Row
+    auto retrieved_row = evolution.GetRow(15, 2);
+    ASSERT_EQ(retrieved_row->GetString(0).ToString(), "Alice");
+    ASSERT_EQ(retrieved_row->GetInt(1), 30);
+
+    // ToString
+    ASSERT_EQ(evolution.ToString(), "DataEvolutionRow");
 }
 
 }  // namespace paimon::test

--- a/src/paimon/common/reader/data_evolution_row_test.cpp
+++ b/src/paimon/common/reader/data_evolution_row_test.cpp
@@ -104,12 +104,16 @@ TEST(DataEvolutionRowTest, TestAllFieldTypes) {
     auto pool = GetDefaultPool();
 
     // Row0: boolean(true), byte(42), short(1024), int(100000), date(19000)
-    BinaryRow row0 = BinaryRowGenerator::GenerateRow(
-        {true, int8_t(42), int16_t(1024), int32_t(100000), int32_t(19000)}, pool.get());
+    BinaryRow row0 =
+        BinaryRowGenerator::GenerateRow({true, static_cast<int8_t>(42), static_cast<int16_t>(1024),
+                                         static_cast<int32_t>(100000), static_cast<int32_t>(19000)},
+                                        pool.get());
 
     // Row1: long(-987654321), float(3.14f), double(-9.87654321)
     BinaryRow row1 = BinaryRowGenerator::GenerateRow(
-        {int64_t(-987654321LL), float(3.14f), double(-9.87654321)}, pool.get());
+        {static_cast<int64_t>(-987654321LL), static_cast<float>(3.14f),
+         static_cast<double>(-9.87654321)},
+        pool.get());
 
     // Row2: string("hello"), string("world")
     BinaryRow row2 =

--- a/src/paimon/common/sst/block_meta_test.cpp
+++ b/src/paimon/common/sst/block_meta_test.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026-present Alibaba Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdint>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "paimon/common/sst/block_handle.h"
+#include "paimon/common/sst/block_trailer.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+class BlockMetaTest : public ::testing::Test {
+ protected:
+    void SetUp() override {
+        pool_ = GetDefaultPool();
+    }
+
+    std::shared_ptr<MemoryPool> pool_;
+};
+
+TEST_F(BlockMetaTest, TestBlockHandleSimple) {
+    int64_t offset = 1024;
+    int32_t size = 256;
+    BlockHandle handle(offset, size);
+
+    // Test Offset and Size
+    ASSERT_EQ(handle.Offset(), offset);
+    ASSERT_EQ(handle.Size(), size);
+
+    // Test GetFullBlockSize
+    ASSERT_EQ(handle.GetFullBlockSize(), size + BlockHandle::MAX_ENCODED_LENGTH);
+
+    // Test ToString
+    ASSERT_EQ(handle.ToString(), "BlockHandle{offset=1024, size=256}");
+
+    // Test WriteBlockHandle and ReadBlockHandle (round-trip serialization)
+    ASSERT_OK_AND_ASSIGN(MemorySlice slice, handle.WriteBlockHandle(pool_.get()));
+    MemorySliceInput input(slice);
+    ASSERT_OK_AND_ASSIGN(BlockHandle restored, BlockHandle::ReadBlockHandle(&input));
+    ASSERT_EQ(restored.Offset(), offset);
+    ASSERT_EQ(restored.Size(), size);
+    ASSERT_EQ(restored.GetFullBlockSize(), handle.GetFullBlockSize());
+    ASSERT_EQ(restored.ToString(), handle.ToString());
+
+    // Test with zero values
+    BlockHandle zero_handle(0, 0);
+    ASSERT_EQ(zero_handle.Offset(), 0);
+    ASSERT_EQ(zero_handle.Size(), 0);
+    ASSERT_EQ(zero_handle.GetFullBlockSize(), BlockHandle::MAX_ENCODED_LENGTH);
+    ASSERT_EQ(zero_handle.ToString(), "BlockHandle{offset=0, size=0}");
+
+    // Test with large values
+    int64_t large_offset = 9999999999ll;
+    int32_t large_size = 2147483647;
+    BlockHandle large_handle(large_offset, large_size);
+    ASSERT_EQ(large_handle.Offset(), large_offset);
+    ASSERT_EQ(large_handle.Size(), large_size);
+    ASSERT_EQ(large_handle.ToString(), "BlockHandle{offset=9999999999, size=2147483647}");
+
+    // Round-trip for large values
+    ASSERT_OK_AND_ASSIGN(MemorySlice large_slice, large_handle.WriteBlockHandle(pool_.get()));
+    MemorySliceInput large_input(large_slice);
+    ASSERT_OK_AND_ASSIGN(BlockHandle large_restored, BlockHandle::ReadBlockHandle(&large_input));
+    ASSERT_EQ(large_restored.Offset(), large_offset);
+    ASSERT_EQ(large_restored.Size(), large_size);
+}
+
+TEST_F(BlockMetaTest, TestBlockTrailerSimple) {
+    int8_t compression_type = 2;
+    int32_t crc32c = 0x12345678;
+    BlockTrailer trailer(compression_type, crc32c);
+
+    // Test CompressionType and Crc32c
+    ASSERT_EQ(trailer.CompressionType(), compression_type);
+    ASSERT_EQ(trailer.Crc32c(), crc32c);
+
+    // Test ToString
+    std::string str = trailer.ToString();
+    ASSERT_NE(str.find("compression_type=2"), std::string::npos);
+    ASSERT_NE(str.find("0x12345678"), std::string::npos);
+
+    // Test ENCODED_LENGTH constant
+    ASSERT_EQ(BlockTrailer::ENCODED_LENGTH, 5);
+
+    // Test WriteBlockTrailer and ReadBlockTrailer (round-trip serialization)
+    MemorySlice slice = trailer.WriteBlockTrailer(pool_.get());
+    ASSERT_EQ(slice.Length(), BlockTrailer::ENCODED_LENGTH);
+    MemorySliceInput input(slice);
+    auto restored = BlockTrailer::ReadBlockTrailer(&input);
+    ASSERT_NE(restored, nullptr);
+    ASSERT_EQ(restored->CompressionType(), compression_type);
+    ASSERT_EQ(restored->Crc32c(), crc32c);
+    ASSERT_EQ(restored->ToString(), trailer.ToString());
+
+    // Test with zero values
+    BlockTrailer zero_trailer(0, 0);
+    ASSERT_EQ(zero_trailer.CompressionType(), 0);
+    ASSERT_EQ(zero_trailer.Crc32c(), 0);
+
+    MemorySlice zero_slice = zero_trailer.WriteBlockTrailer(pool_.get());
+    MemorySliceInput zero_input(zero_slice);
+    auto zero_restored = BlockTrailer::ReadBlockTrailer(&zero_input);
+    ASSERT_EQ(zero_restored->CompressionType(), 0);
+    ASSERT_EQ(zero_restored->Crc32c(), 0);
+
+    // Test with negative crc32c (valid signed int32)
+    int32_t negative_crc = -1;
+    BlockTrailer neg_trailer(/*compression_type=*/1, negative_crc);
+    ASSERT_EQ(neg_trailer.Crc32c(), negative_crc);
+    ASSERT_EQ(neg_trailer.CompressionType(), 1);
+
+    MemorySlice neg_slice = neg_trailer.WriteBlockTrailer(pool_.get());
+    MemorySliceInput neg_input(neg_slice);
+    auto neg_restored = BlockTrailer::ReadBlockTrailer(&neg_input);
+    ASSERT_EQ(neg_restored->CompressionType(), 1);
+    ASSERT_EQ(neg_restored->Crc32c(), negative_crc);
+}
+
+}  // namespace paimon::test

--- a/src/paimon/common/sst/block_write_read_test.cpp
+++ b/src/paimon/common/sst/block_write_read_test.cpp
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2026-present Alibaba Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "paimon/common/sst/block_iterator.h"
+#include "paimon/common/sst/block_reader.h"
+#include "paimon/common/sst/block_writer.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+class BlockWriteReadTest : public ::testing::Test {
+ protected:
+    void SetUp() override {
+        pool_ = GetDefaultPool();
+        comparator_ = [](const MemorySlice& a, const MemorySlice& b) -> Result<int32_t> {
+            std::string_view va = a.ReadStringView();
+            std::string_view vb = b.ReadStringView();
+            if (va < vb) return -1;
+            if (va > vb) return 1;
+            return 0;
+        };
+    }
+
+    std::shared_ptr<Bytes> MakeBytes(const std::string& str) {
+        return std::make_shared<Bytes>(str, pool_.get());
+    }
+
+    /// Build a block with the given key-value pairs via BlockWriter.
+    /// BlockWriter::Finish() produces a slice whose tail is [int32 size | char aligned_type],
+    /// which is exactly the layout that BlockReader::Create expects.
+    MemorySlice BuildBlock(BlockWriter& writer,
+                           const std::vector<std::pair<std::string, std::string>>& pairs) {
+        for (const auto& [k, v] : pairs) {
+            auto key = MakeBytes(k);
+            auto value = MakeBytes(v);
+            EXPECT_OK(writer.Write(key, value));
+        }
+        EXPECT_OK_AND_ASSIGN(auto result, writer.Finish());
+        return result;
+    }
+
+    std::shared_ptr<MemoryPool> pool_;
+    MemorySlice::SliceComparator comparator_;
+};
+
+TEST_F(BlockWriteReadTest, AlignedWriteAndRead) {
+    BlockWriter writer(1024, pool_);
+    ASSERT_EQ(writer.Size(), 0);
+
+    auto key1 = MakeBytes("aaaa");
+    auto val1 = MakeBytes("1111");
+    ASSERT_OK(writer.Write(key1, val1));
+    ASSERT_EQ(writer.Size(), 1);
+    ASSERT_GT(writer.Memory(), 0);
+
+    auto key2 = MakeBytes("bbbb");
+    auto val2 = MakeBytes("2222");
+    auto key3 = MakeBytes("cccc");
+    auto val3 = MakeBytes("3333");
+    ASSERT_OK(writer.Write(key2, val2));
+    ASSERT_OK(writer.Write(key3, val3));
+    ASSERT_EQ(writer.Size(), 3);
+
+    auto block = BuildBlock(writer, {});
+    ASSERT_GT(block.Length(), 0);
+    // Last byte should be ALIGNED (0) because all kv pairs are same-size
+    ASSERT_EQ(block.ReadByte(block.Length() - 1), static_cast<int8_t>(BlockAlignedType::ALIGNED));
+
+    // Read back
+    ASSERT_OK_AND_ASSIGN(auto reader, BlockReader::Create(block, comparator_));
+    ASSERT_EQ(reader->RecordCount(), 3);
+    ASSERT_NE(reader->Comparator(), nullptr);
+
+    // SeekTo returns byte positions, should be increasing
+    ASSERT_EQ(reader->SeekTo(0), 0);
+    ASSERT_GT(reader->SeekTo(1), 0);
+    ASSERT_GT(reader->SeekTo(2), reader->SeekTo(1));
+
+    // BlockInput should be readable
+    ASSERT_TRUE(reader->BlockInput().IsReadable());
+
+    // Iterate and verify all entries
+    auto iter = reader->Iterator();
+    ASSERT_TRUE(iter->HasNext());
+    ASSERT_OK_AND_ASSIGN(auto entry1, iter->Next());
+    ASSERT_EQ(entry1.key.ReadStringView(), "aaaa");
+    ASSERT_EQ(entry1.value.ReadStringView(), "1111");
+
+    ASSERT_OK_AND_ASSIGN(auto entry2, iter->Next());
+    ASSERT_EQ(entry2.key.ReadStringView(), "bbbb");
+    ASSERT_EQ(entry2.value.ReadStringView(), "2222");
+
+    ASSERT_OK_AND_ASSIGN(auto entry3, iter->Next());
+    ASSERT_EQ(entry3.key.ReadStringView(), "cccc");
+    ASSERT_EQ(entry3.value.ReadStringView(), "3333");
+
+    ASSERT_FALSE(iter->HasNext());
+}
+
+TEST_F(BlockWriteReadTest, UnalignedWriteAndRead) {
+    BlockWriter writer(1024, pool_, /*aligned=*/false);
+    auto block = BuildBlock(writer, {{"a", "short"}, {"bb", "a_longer_value"}});
+    ASSERT_GT(block.Length(), 0);
+    // Last byte should be UNALIGNED (1)
+    ASSERT_EQ(block.ReadByte(block.Length() - 1), static_cast<int8_t>(BlockAlignedType::UNALIGNED));
+
+    ASSERT_OK_AND_ASSIGN(auto reader, BlockReader::Create(block, comparator_));
+    ASSERT_EQ(reader->RecordCount(), 2);
+
+    auto iter = reader->Iterator();
+    ASSERT_OK_AND_ASSIGN(auto entry1, iter->Next());
+    ASSERT_EQ(entry1.key.ReadStringView(), "a");
+    ASSERT_EQ(entry1.value.ReadStringView(), "short");
+
+    ASSERT_OK_AND_ASSIGN(auto entry2, iter->Next());
+    ASSERT_EQ(entry2.key.ReadStringView(), "bb");
+    ASSERT_EQ(entry2.value.ReadStringView(), "a_longer_value");
+
+    ASSERT_FALSE(iter->HasNext());
+}
+
+TEST_F(BlockWriteReadTest, EmptyBlockWriteAndRead) {
+    BlockWriter writer(1024, pool_);
+
+    ASSERT_OK_AND_ASSIGN(auto block, writer.Finish());
+    ASSERT_GT(block.Length(), 0);
+    // Empty block must be UNALIGNED (1)
+    ASSERT_EQ(block.ReadByte(block.Length() - 1), static_cast<int8_t>(BlockAlignedType::UNALIGNED));
+
+    // Reader should see 0 records
+    ASSERT_OK_AND_ASSIGN(auto reader, BlockReader::Create(block, comparator_));
+    ASSERT_EQ(reader->RecordCount(), 0);
+
+    auto iter = reader->Iterator();
+    ASSERT_FALSE(iter->HasNext());
+}
+
+TEST_F(BlockWriteReadTest, ResetAndRewrite) {
+    BlockWriter writer(1024, pool_);
+
+    auto key = MakeBytes("old_key");
+    auto val = MakeBytes("old_val");
+    ASSERT_OK(writer.Write(key, val));
+    ASSERT_EQ(writer.Size(), 1);
+
+    writer.Reset();
+    ASSERT_EQ(writer.Size(), 0);
+
+    // Write new data and read back
+    auto block = BuildBlock(writer, {{"new_key", "new_val"}});
+    ASSERT_OK_AND_ASSIGN(auto reader, BlockReader::Create(block, comparator_));
+    ASSERT_EQ(reader->RecordCount(), 1);
+
+    auto iter = reader->Iterator();
+    ASSERT_OK_AND_ASSIGN(auto entry, iter->Next());
+    ASSERT_EQ(entry.key.ReadStringView(), "new_key");
+    ASSERT_EQ(entry.value.ReadStringView(), "new_val");
+}
+
+TEST_F(BlockWriteReadTest, MemoryAlignedVsUnaligned) {
+    BlockWriter aligned_writer(1024, pool_);
+    auto k1 = MakeBytes("aaaa");
+    auto v1 = MakeBytes("1111");
+    auto k2 = MakeBytes("bbbb");
+    auto v2 = MakeBytes("2222");
+    ASSERT_OK(aligned_writer.Write(k1, v1));
+    ASSERT_OK(aligned_writer.Write(k2, v2));
+
+    BlockWriter unaligned_writer(1024, pool_, /*aligned=*/false);
+    auto k3 = MakeBytes("aaaa");
+    auto v3 = MakeBytes("1111");
+    auto k4 = MakeBytes("bbbb");
+    auto v4 = MakeBytes("2222");
+    ASSERT_OK(unaligned_writer.Write(k3, v3));
+    ASSERT_OK(unaligned_writer.Write(k4, v4));
+
+    // Unaligned memory should be larger due to position index overhead
+    ASSERT_GT(unaligned_writer.Memory(), aligned_writer.Memory());
+}
+
+TEST_F(BlockWriteReadTest, SkipKeyAndReadValue) {
+    BlockWriter writer(1024, pool_);
+    auto block = BuildBlock(writer, {{"key1", "val1"}, {"key2", "val2"}});
+
+    ASSERT_OK_AND_ASSIGN(auto reader, BlockReader::Create(block, comparator_));
+    auto iter = reader->Iterator();
+
+    ASSERT_TRUE(iter->HasNext());
+    ASSERT_OK_AND_ASSIGN(auto value1, iter->SkipKeyAndReadValue());
+    ASSERT_EQ(value1.ReadStringView(), "val1");
+
+    ASSERT_TRUE(iter->HasNext());
+    ASSERT_OK_AND_ASSIGN(auto value2, iter->SkipKeyAndReadValue());
+    ASSERT_EQ(value2.ReadStringView(), "val2");
+
+    ASSERT_FALSE(iter->HasNext());
+}
+
+TEST_F(BlockWriteReadTest, IteratorSeekTo) {
+    BlockWriter writer(1024, pool_);
+    auto block =
+        BuildBlock(writer, {{"apple", "1"}, {"banana", "2"}, {"cherry", "3"}, {"date", "4"}});
+
+    ASSERT_OK_AND_ASSIGN(auto reader, BlockReader::Create(block, comparator_));
+
+    // Exact match
+    {
+        auto iter = reader->Iterator();
+        auto target = MemorySlice::Wrap(MakeBytes("cherry"));
+        ASSERT_OK_AND_ASSIGN(bool found, iter->SeekTo(target));
+        ASSERT_TRUE(found);
+        ASSERT_TRUE(iter->HasNext());
+        ASSERT_OK_AND_ASSIGN(auto entry, iter->Next());
+        ASSERT_EQ(entry.key.ReadStringView(), "cherry");
+        ASSERT_EQ(entry.value.ReadStringView(), "3");
+    }
+
+    // No exact match: "blueberry" should land on "cherry" (first key >= target)
+    {
+        auto iter = reader->Iterator();
+        auto target = MemorySlice::Wrap(MakeBytes("blueberry"));
+        ASSERT_OK_AND_ASSIGN(bool found, iter->SeekTo(target));
+        ASSERT_FALSE(found);
+        ASSERT_TRUE(iter->HasNext());
+        ASSERT_OK_AND_ASSIGN(auto entry, iter->Next());
+        ASSERT_EQ(entry.key.ReadStringView(), "cherry");
+    }
+}
+
+}  // namespace paimon::test

--- a/src/paimon/common/sst/block_write_read_test.cpp
+++ b/src/paimon/common/sst/block_write_read_test.cpp
@@ -35,27 +35,29 @@ class BlockWriteReadTest : public ::testing::Test {
         comparator_ = [](const MemorySlice& a, const MemorySlice& b) -> Result<int32_t> {
             std::string_view va = a.ReadStringView();
             std::string_view vb = b.ReadStringView();
-            if (va < vb) return -1;
-            if (va > vb) return 1;
+            if (va < vb) {
+                return -1;
+            }
+            if (va > vb) {
+                return 1;
+            }
             return 0;
         };
     }
 
-    std::shared_ptr<Bytes> MakeBytes(const std::string& str) {
+    std::shared_ptr<Bytes> MakeBytes(const std::string& str) const {
         return std::make_shared<Bytes>(str, pool_.get());
     }
 
     /// Build a block with the given key-value pairs via BlockWriter.
-    /// BlockWriter::Finish() produces a slice whose tail is [int32 size | char aligned_type],
-    /// which is exactly the layout that BlockReader::Create expects.
-    MemorySlice BuildBlock(BlockWriter& writer,
-                           const std::vector<std::pair<std::string, std::string>>& pairs) {
+    MemorySlice BuildBlock(const std::vector<std::pair<std::string, std::string>>& pairs,
+                           BlockWriter* writer) const {
         for (const auto& [k, v] : pairs) {
             auto key = MakeBytes(k);
             auto value = MakeBytes(v);
-            EXPECT_OK(writer.Write(key, value));
+            EXPECT_OK(writer->Write(key, value));
         }
-        EXPECT_OK_AND_ASSIGN(auto result, writer.Finish());
+        EXPECT_OK_AND_ASSIGN(auto result, writer->Finish());
         return result;
     }
 
@@ -81,7 +83,7 @@ TEST_F(BlockWriteReadTest, AlignedWriteAndRead) {
     ASSERT_OK(writer.Write(key3, val3));
     ASSERT_EQ(writer.Size(), 3);
 
-    auto block = BuildBlock(writer, {});
+    auto block = BuildBlock({}, &writer);
     ASSERT_GT(block.Length(), 0);
     // Last byte should be ALIGNED (0) because all kv pairs are same-size
     ASSERT_EQ(block.ReadByte(block.Length() - 1), static_cast<int8_t>(BlockAlignedType::ALIGNED));
@@ -119,7 +121,7 @@ TEST_F(BlockWriteReadTest, AlignedWriteAndRead) {
 
 TEST_F(BlockWriteReadTest, UnalignedWriteAndRead) {
     BlockWriter writer(1024, pool_, /*aligned=*/false);
-    auto block = BuildBlock(writer, {{"a", "short"}, {"bb", "a_longer_value"}});
+    auto block = BuildBlock({{"a", "short"}, {"bb", "a_longer_value"}}, &writer);
     ASSERT_GT(block.Length(), 0);
     // Last byte should be UNALIGNED (1)
     ASSERT_EQ(block.ReadByte(block.Length() - 1), static_cast<int8_t>(BlockAlignedType::UNALIGNED));
@@ -167,7 +169,7 @@ TEST_F(BlockWriteReadTest, ResetAndRewrite) {
     ASSERT_EQ(writer.Size(), 0);
 
     // Write new data and read back
-    auto block = BuildBlock(writer, {{"new_key", "new_val"}});
+    auto block = BuildBlock({{"new_key", "new_val"}}, &writer);
     ASSERT_OK_AND_ASSIGN(auto reader, BlockReader::Create(block, comparator_));
     ASSERT_EQ(reader->RecordCount(), 1);
 
@@ -200,7 +202,7 @@ TEST_F(BlockWriteReadTest, MemoryAlignedVsUnaligned) {
 
 TEST_F(BlockWriteReadTest, SkipKeyAndReadValue) {
     BlockWriter writer(1024, pool_);
-    auto block = BuildBlock(writer, {{"key1", "val1"}, {"key2", "val2"}});
+    auto block = BuildBlock({{"key1", "val1"}, {"key2", "val2"}}, &writer);
 
     ASSERT_OK_AND_ASSIGN(auto reader, BlockReader::Create(block, comparator_));
     auto iter = reader->Iterator();
@@ -219,7 +221,7 @@ TEST_F(BlockWriteReadTest, SkipKeyAndReadValue) {
 TEST_F(BlockWriteReadTest, IteratorSeekTo) {
     BlockWriter writer(1024, pool_);
     auto block =
-        BuildBlock(writer, {{"apple", "1"}, {"banana", "2"}, {"cherry", "3"}, {"date", "4"}});
+        BuildBlock({{"apple", "1"}, {"banana", "2"}, {"cherry", "3"}, {"date", "4"}}, &writer);
 
     ASSERT_OK_AND_ASSIGN(auto reader, BlockReader::Create(block, comparator_));
 

--- a/src/paimon/common/sst/block_writer.cpp
+++ b/src/paimon/common/sst/block_writer.cpp
@@ -55,7 +55,7 @@ Result<MemorySlice> BlockWriter::Finish() {
     if (aligned_) {
         block_->WriteValue(aligned_size_);
     } else {
-        for (auto& position : positions_) {
+        for (const auto& position : positions_) {
             block_->WriteValue(position);
         }
         block_->WriteValue(static_cast<int32_t>(positions_.size()));

--- a/src/paimon/common/utils/arrow/mem_utils.cpp
+++ b/src/paimon/common/utils/arrow/mem_utils.cpp
@@ -28,8 +28,6 @@ namespace paimon {
 
 class ArrowMemPoolAdaptor : public arrow::MemoryPool {
  public:
-    explicit ArrowMemPoolAdaptor(paimon::MemoryPool& pool) : pool_(pool) {}
-
     explicit ArrowMemPoolAdaptor(const std::shared_ptr<paimon::MemoryPool>& pool)
         : pool_(*pool), life_holder_(pool) {}
 
@@ -78,10 +76,6 @@ class ArrowMemPoolAdaptor : public arrow::MemoryPool {
     std::shared_ptr<paimon::MemoryPool> life_holder_;
     arrow::internal::MemoryPoolStats stats_;
 };
-
-std::unique_ptr<arrow::MemoryPool> GetArrowPool(MemoryPool& pool) {
-    return std::make_unique<ArrowMemPoolAdaptor>(pool);
-}
 
 std::unique_ptr<arrow::MemoryPool> GetArrowPool(const std::shared_ptr<MemoryPool>& pool) {
     return std::make_unique<ArrowMemPoolAdaptor>(pool);

--- a/src/paimon/common/utils/bit_set_test.cpp
+++ b/src/paimon/common/utils/bit_set_test.cpp
@@ -47,4 +47,60 @@ TEST(BitSetTest, TestBitSet) {
     }
 }
 
+TEST(BitSetTest, TestGetOutOfBound) {
+    auto pool = GetDefaultPool();
+    // 2 bytes = 16 bits
+    auto bit_set = std::make_shared<BitSet>(2);
+    auto seg = MemorySegment::AllocateHeapMemory(2, pool.get());
+    ASSERT_OK(bit_set->SetMemorySegment(seg));
+
+    ASSERT_OK(bit_set->Set(0));
+    ASSERT_OK(bit_set->Set(15));
+    ASSERT_TRUE(bit_set->Get(0));
+    ASSERT_TRUE(bit_set->Get(15));
+
+    // Out-of-bound access should return false (bit_size_ = 16)
+    ASSERT_FALSE(bit_set->Get(16));
+    ASSERT_FALSE(bit_set->Get(100));
+    ASSERT_FALSE(bit_set->Get(std::numeric_limits<uint32_t>::max()));
+
+    // Set out-of-bound should return error
+    ASSERT_NOK_WITH_MSG(bit_set->Set(16), "Index out of bound");
+}
+
+TEST(BitSetTest, TestClearNonAligned) {
+    auto pool = GetDefaultPool();
+    // 5 bytes = 40 bits, not a multiple of 8 bytes,
+    // exercises both the 8-byte loop (never enters) and the tail byte-by-byte loop
+    auto bit_set = std::make_shared<BitSet>(5);
+    auto seg = MemorySegment::AllocateHeapMemory(8, pool.get());
+    ASSERT_OK(bit_set->SetMemorySegment(seg));
+
+    // Set every bit
+    for (uint32_t i = 0; i < 40; i++) {
+        ASSERT_OK(bit_set->Set(i));
+    }
+    for (uint32_t i = 0; i < 40; i++) {
+        ASSERT_TRUE(bit_set->Get(i));
+    }
+
+    // Clear and verify all bits are unset
+    bit_set->Clear();
+    for (uint32_t i = 0; i < 40; i++) {
+        ASSERT_FALSE(bit_set->Get(i));
+    }
+
+    // 16 bytes = 128 bits, exact multiple of 8 bytes, exercises the 8-byte loop + tail loop
+    auto bit_set_aligned = std::make_shared<BitSet>(16);
+    auto seg2 = MemorySegment::AllocateHeapMemory(16, pool.get());
+    ASSERT_OK(bit_set_aligned->SetMemorySegment(seg2));
+
+    for (uint32_t i = 0; i < 128; i++) {
+        ASSERT_OK(bit_set_aligned->Set(i));
+    }
+    bit_set_aligned->Clear();
+    for (uint32_t i = 0; i < 128; i++) {
+        ASSERT_FALSE(bit_set_aligned->Get(i));
+    }
+}
 }  // namespace paimon::test

--- a/src/paimon/common/utils/date_time_utils_test.cpp
+++ b/src/paimon/common/utils/date_time_utils_test.cpp
@@ -309,4 +309,11 @@ TEST(DateTimeUtilsTest, TestToUTCTimestamp) {
         ASSERT_EQ(utc_ts, Timestamp(-28800000l, 0));
     }
 }
+TEST(DateTimeUtilsTest, TestGetArrowTimeUnitStr) {
+    ASSERT_EQ(DateTimeUtils::GetArrowTimeUnitStr(arrow::TimeUnit::SECOND), "SECOND");
+    ASSERT_EQ(DateTimeUtils::GetArrowTimeUnitStr(arrow::TimeUnit::MILLI), "MILLISECOND");
+    ASSERT_EQ(DateTimeUtils::GetArrowTimeUnitStr(arrow::TimeUnit::MICRO), "MICROSECOND");
+    ASSERT_EQ(DateTimeUtils::GetArrowTimeUnitStr(arrow::TimeUnit::NANO), "NANOSECOND");
+}
+
 }  // namespace paimon::test

--- a/src/paimon/common/utils/projected_array_test.cpp
+++ b/src/paimon/common/utils/projected_array_test.cpp
@@ -23,8 +23,11 @@
 #include "gtest/gtest.h"
 #include "paimon/common/data/binary_array.h"
 #include "paimon/common/data/binary_array_writer.h"
+#include "paimon/common/data/binary_map.h"
+#include "paimon/common/data/binary_row.h"
 #include "paimon/memory/bytes.h"
 #include "paimon/memory/memory_pool.h"
+#include "paimon/testing/utils/binary_row_generator.h"
 
 namespace paimon::test {
 TEST(ProjectedArrayTest, TestSimple) {
@@ -279,4 +282,86 @@ TEST(ProjectedArrayTest, TestSimple) {
         ASSERT_TRUE(projected_array.IsNullAt(2));
     }
 }
+
+TEST(ProjectedArrayTest, TestGetStringView) {
+    auto pool = GetDefaultPool();
+    std::vector<BinaryString> arr;
+    arr.push_back(BinaryString::FromString("hello", pool.get()));
+    arr.push_back(BinaryString::FromString("world", pool.get()));
+    auto array = std::make_shared<BinaryArray>();
+    BinaryArrayWriter writer =
+        BinaryArrayWriter(array.get(), arr.size(), /*element_size=*/8, pool.get());
+    for (size_t i = 0; i < arr.size(); i++) {
+        writer.WriteString(i, arr[i]);
+    }
+    writer.Complete();
+
+    std::vector<int32_t> mapping = {1, 0, -1};
+    ProjectedArray projected_array(array, mapping);
+    ASSERT_EQ(projected_array.GetStringView(0), "world");
+    ASSERT_EQ(projected_array.GetStringView(1), "hello");
+    ASSERT_TRUE(projected_array.IsNullAt(2));
+}
+
+TEST(ProjectedArrayTest, TestGetMap) {
+    auto pool = GetDefaultPool();
+    auto key = BinaryArray::FromIntArray({1, 2, 3}, pool.get());
+    auto value = BinaryArray::FromLongArray({100ll, 200ll, 300ll}, pool.get());
+    auto map1 = BinaryMap::ValueOf(key, value, pool.get());
+
+    auto key2 = BinaryArray::FromIntArray({10, 20}, pool.get());
+    auto value2 = BinaryArray::FromLongArray({1000ll, 2000ll}, pool.get());
+    auto map2 = BinaryMap::ValueOf(key2, value2, pool.get());
+
+    auto array = std::make_shared<BinaryArray>();
+    BinaryArrayWriter writer =
+        BinaryArrayWriter(array.get(), /*num_elements=*/2, /*element_size=*/8, pool.get());
+    writer.WriteMap(0, *map1);
+    writer.WriteMap(1, *map2);
+    writer.Complete();
+
+    std::vector<int32_t> mapping = {1, 0, -1};
+    ProjectedArray projected_array(array, mapping);
+
+    // mapping[0] -> original index 1 -> map2
+    auto result0 = projected_array.GetMap(0);
+    ASSERT_EQ(result0->Size(), 2);
+    ASSERT_EQ(result0->KeyArray()->ToIntArray().value(), (std::vector<int32_t>{10, 20}));
+
+    // mapping[1] -> original index 0 -> map1
+    auto result1 = projected_array.GetMap(1);
+    ASSERT_EQ(result1->Size(), 3);
+    ASSERT_EQ(result1->KeyArray()->ToIntArray().value(), (std::vector<int32_t>{1, 2, 3}));
+
+    ASSERT_TRUE(projected_array.IsNullAt(2));
+}
+
+TEST(ProjectedArrayTest, TestGetRow) {
+    auto pool = GetDefaultPool();
+    BinaryRow row1 = BinaryRowGenerator::GenerateRow({std::string("Alice"), 30}, pool.get());
+    BinaryRow row2 = BinaryRowGenerator::GenerateRow({std::string("Bob"), 40}, pool.get());
+
+    auto array = std::make_shared<BinaryArray>();
+    BinaryArrayWriter writer =
+        BinaryArrayWriter(array.get(), /*num_elements=*/2, /*element_size=*/8, pool.get());
+    writer.WriteRow(0, row1);
+    writer.WriteRow(1, row2);
+    writer.Complete();
+
+    std::vector<int32_t> mapping = {1, 0, -1};
+    ProjectedArray projected_array(array, mapping);
+
+    // mapping[0] -> original index 1 -> row2
+    auto result0 = std::dynamic_pointer_cast<BinaryRow>(projected_array.GetRow(0, 2));
+    ASSERT_TRUE(result0);
+    ASSERT_EQ(*result0, row2);
+
+    // mapping[1] -> original index 0 -> row1
+    auto result1 = std::dynamic_pointer_cast<BinaryRow>(projected_array.GetRow(1, 2));
+    ASSERT_TRUE(result1);
+    ASSERT_EQ(*result1, row1);
+
+    ASSERT_TRUE(projected_array.IsNullAt(2));
+}
+
 }  // namespace paimon::test

--- a/src/paimon/common/utils/projected_row_test.cpp
+++ b/src/paimon/common/utils/projected_row_test.cpp
@@ -76,8 +76,14 @@ TEST(ProjectedRowTest, TestSimple) {
                                     5,  4,  3,  2,  1,  0,  -1, -1, -1, -1};
 
     ProjectedRow projected_row(row, mapping);
-    ASSERT_EQ(projected_row.GetFieldCount(), 20);
+
+    // test row kind
     ASSERT_EQ(projected_row.GetRowKind().value(), RowKind::Insert());
+    projected_row.SetRowKind(RowKind::Delete());
+    ASSERT_EQ(projected_row.GetRowKind().value(), RowKind::Delete());
+    ASSERT_EQ(row->GetRowKind().value(), RowKind::Delete());
+
+    ASSERT_EQ(projected_row.GetFieldCount(), 20);
 
     ASSERT_TRUE(projected_row.IsNullAt(19));
     ASSERT_TRUE(projected_row.IsNullAt(18));
@@ -111,7 +117,7 @@ TEST(ProjectedRowTest, TestSimple) {
     ASSERT_TRUE(projected_row.IsNullAt(0));
 
     ASSERT_EQ(
-        "+I { indexMapping=15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -1, -1, -1, "
+        "-D { indexMapping=15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -1, -1, -1, "
         "mutableRow=(true,1,2,3,4,5.100000,6.120000,abcd,efgh,apple,1970-01-01 "
         "00:00:00.100000020,123.45678998765432145678,array,row,map,null) }",
         projected_row.ToString());

--- a/src/paimon/core/append/append_only_writer_test.cpp
+++ b/src/paimon/core/append/append_only_writer_test.cpp
@@ -533,6 +533,37 @@ TEST_F(AppendOnlyWriterTest, TestCloseDeletesCompactAfterFiles) {
     ASSERT_TRUE(compact_manager->close_called);
 }
 
+TEST_F(AppendOnlyWriterTest, TestCloseCleansDeletionFile) {
+    auto options = CreateOptions();
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+    auto path_factory = CreatePathFactory(dir->Str(), "mock_format", options);
+    auto compact_manager = std::make_shared<FakeCompactManager>();
+
+    auto deletion_file = std::make_shared<FakeCompactDeletionFile>("del-close");
+    auto before = NewAppendFile("before-close", 5, 0, 4);
+    auto after = NewAppendFile("after-close", 5, 5, 9);
+    auto result =
+        std::make_shared<CompactResult>(std::vector<std::shared_ptr<DataFileMeta>>{before},
+                                        std::vector<std::shared_ptr<DataFileMeta>>{after});
+    result->SetDeletionFile(deletion_file);
+    compact_manager->queued_results.push_back(
+        std::optional<std::shared_ptr<CompactResult>>(result));
+
+    arrow::FieldVector fields = {arrow::field("f0", arrow::utf8())};
+    auto schema = arrow::schema(fields);
+    AppendOnlyWriter writer(options, /*schema_id=*/0, schema, /*write_cols=*/std::nullopt,
+                            /*max_sequence_number=*/-1, path_factory, compact_manager,
+                            memory_pool_);
+
+    // Sync to consume the compaction result and populate compact_deletion_file_.
+    ASSERT_OK(writer.Sync());
+    ASSERT_FALSE(deletion_file->Cleaned());
+
+    ASSERT_OK(writer.Close());
+    ASSERT_TRUE(deletion_file->Cleaned());
+}
+
 TEST_F(AppendOnlyWriterTest, TestCompactNotCompletedTriggersCompaction) {
     auto options = CreateOptions();
     auto dir = UniqueTestDirectory::Create();

--- a/src/paimon/core/core_options_test.cpp
+++ b/src/paimon/core/core_options_test.cpp
@@ -664,4 +664,209 @@ TEST(CoreOptionsTest, TestScanTimestampMillisAndStringMutuallyExclusive) {
 TEST(CoreOptionsTest, TestScanTimestampInvalidString) {
     ASSERT_NOK(CoreOptions::FromMap({{Options::SCAN_TIMESTAMP, "not-a-date"}}));
 }
+
+TEST(CoreOptionsTest, TestOverflowProtection) {
+    std::string max_val = std::to_string(std::numeric_limits<int32_t>::max());
+    ASSERT_OK_AND_ASSIGN(
+        CoreOptions options,
+        CoreOptions::FromMap({{Options::NUM_SORTED_RUNS_COMPACTION_TRIGGER, max_val}}));
+
+    ASSERT_EQ(options.GetNumSortedRunsStopTrigger(), std::numeric_limits<int32_t>::max());
+    ASSERT_EQ(options.GetNumLevels(), std::numeric_limits<int32_t>::max());
+    ASSERT_EQ(options.GetLookupCompactMaxInterval(), std::numeric_limits<int32_t>::max());
+}
+
+TEST(CoreOptionsTest, TestExplicitNumLevels) {
+    ASSERT_OK_AND_ASSIGN(CoreOptions options, CoreOptions::FromMap({{Options::NUM_LEVELS, "10"}}));
+    ASSERT_EQ(options.GetNumLevels(), 10);
+}
+
+TEST(CoreOptionsTest, TestParseChangelogProducer) {
+    {
+        ASSERT_OK_AND_ASSIGN(CoreOptions options,
+                             CoreOptions::FromMap({{Options::CHANGELOG_PRODUCER, "none"}}));
+        ASSERT_EQ(options.GetChangelogProducer(), ChangelogProducer::NONE);
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(CoreOptions options,
+                             CoreOptions::FromMap({{Options::CHANGELOG_PRODUCER, "input"}}));
+        ASSERT_EQ(options.GetChangelogProducer(), ChangelogProducer::INPUT);
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(
+            CoreOptions options,
+            CoreOptions::FromMap({{Options::CHANGELOG_PRODUCER, "full-compaction"}}));
+        ASSERT_EQ(options.GetChangelogProducer(), ChangelogProducer::FULL_COMPACTION);
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(CoreOptions options,
+                             CoreOptions::FromMap({{Options::CHANGELOG_PRODUCER, "lookup"}}));
+        ASSERT_EQ(options.GetChangelogProducer(), ChangelogProducer::LOOKUP);
+    }
+    {
+        // case insensitive
+        ASSERT_OK_AND_ASSIGN(CoreOptions options,
+                             CoreOptions::FromMap({{Options::CHANGELOG_PRODUCER, "LOOKUP"}}));
+        ASSERT_EQ(options.GetChangelogProducer(), ChangelogProducer::LOOKUP);
+    }
+    { ASSERT_NOK(CoreOptions::FromMap({{Options::CHANGELOG_PRODUCER, "invalid"}})); }
+}
+
+TEST(CoreOptionsTest, TestParseExternalPathStrategy) {
+    {
+        ASSERT_OK_AND_ASSIGN(
+            CoreOptions options,
+            CoreOptions::FromMap({{Options::DATA_FILE_EXTERNAL_PATHS_STRATEGY, "none"}}));
+        ASSERT_EQ(options.GetExternalPathStrategy(), ExternalPathStrategy::NONE);
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(
+            CoreOptions options,
+            CoreOptions::FromMap({{Options::DATA_FILE_EXTERNAL_PATHS_STRATEGY, "specific-fs"}}));
+        ASSERT_EQ(options.GetExternalPathStrategy(), ExternalPathStrategy::SPECIFIC_FS);
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(
+            CoreOptions options,
+            CoreOptions::FromMap({{Options::DATA_FILE_EXTERNAL_PATHS_STRATEGY, "round-robin"}}));
+        ASSERT_EQ(options.GetExternalPathStrategy(), ExternalPathStrategy::ROUND_ROBIN);
+    }
+    {
+        // case insensitive
+        ASSERT_OK_AND_ASSIGN(
+            CoreOptions options,
+            CoreOptions::FromMap({{Options::DATA_FILE_EXTERNAL_PATHS_STRATEGY, "ROUND-ROBIN"}}));
+        ASSERT_EQ(options.GetExternalPathStrategy(), ExternalPathStrategy::ROUND_ROBIN);
+    }
+    { ASSERT_NOK(CoreOptions::FromMap({{Options::DATA_FILE_EXTERNAL_PATHS_STRATEGY, "invalid"}})); }
+}
+
+TEST(CoreOptionsTest, TestCopyAssignmentOperator) {
+    // Build a CoreOptions with non-default values
+    std::map<std::string, std::string> options = {
+        {Options::BUCKET, "3"},
+        {Options::PAGE_SIZE, "128 kb"},
+        {Options::TARGET_FILE_SIZE, "512MB"},
+        {Options::FILE_FORMAT, "ORC"},
+        {Options::FILE_COMPRESSION, "lz4"},
+        {Options::FILE_COMPRESSION_ZSTD_LEVEL, "5"},
+        {Options::PARTITION_DEFAULT_NAME, "foo"},
+        {Options::MANIFEST_MERGE_MIN_COUNT, "2"},
+        {Options::READ_BATCH_SIZE, "2048"},
+        {Options::WRITE_BATCH_SIZE, "1234"},
+        {Options::WRITE_BUFFER_SIZE, "16MB"},
+        {Options::WRITE_BUFFER_SPILLABLE, "false"},
+        {Options::COMMIT_FORCE_COMPACT, "true"},
+        {Options::COMMIT_MAX_RETRIES, "20"},
+        {Options::SEQUENCE_FIELD, "f1,f2"},
+        {Options::MERGE_ENGINE, "first-row"},
+        {Options::SORT_ENGINE, "min-heap"},
+        {Options::CHANGELOG_PRODUCER, "lookup"},
+        {Options::DELETION_VECTORS_ENABLED, "true"},
+        {Options::FORCE_LOOKUP, "true"},
+        {Options::IGNORE_DELETE, "true"},
+        {Options::WRITE_ONLY, "true"},
+        {Options::COMPACTION_MIN_FILE_NUM, "10"},
+        {Options::COMPACTION_FORCE_REWRITE_ALL_FILES, "true"},
+        {Options::NUM_SORTED_RUNS_COMPACTION_TRIGGER, "11"},
+        {Options::NUM_SORTED_RUNS_STOP_TRIGGER, "17"},
+        {Options::NUM_LEVELS, "9"},
+        {Options::LOOKUP_COMPACT, "gentle"},
+        {Options::DATA_FILE_PREFIX, "test-data-"},
+        {Options::ROW_TRACKING_ENABLED, "true"},
+        {Options::DATA_EVOLUTION_ENABLED, "true"},
+        {Options::BUCKET_FUNCTION_TYPE, "mod"},
+    };
+    ASSERT_OK_AND_ASSIGN(CoreOptions source, CoreOptions::FromMap(options));
+
+    // Default-constructed target with different values
+    CoreOptions target;
+
+    // Perform copy assignment
+    target = source;
+
+    // Verify all fields are correctly copied
+    ASSERT_EQ(3, target.GetBucket());
+    ASSERT_EQ(128 * 1024L, target.GetPageSize());
+    ASSERT_EQ("orc", target.GetFileFormat()->Identifier());
+    ASSERT_EQ("lz4", target.GetFileCompression());
+    ASSERT_EQ(5, target.GetFileCompressionZstdLevel());
+    ASSERT_EQ("foo", target.GetPartitionDefaultName());
+    ASSERT_EQ(2, target.GetManifestMergeMinCount());
+    ASSERT_EQ(2048, target.GetReadBatchSize());
+    ASSERT_EQ(1234, target.GetWriteBatchSize());
+    ASSERT_EQ(16 * 1024 * 1024L, target.GetWriteBufferSize());
+    ASSERT_FALSE(target.GetWriteBufferSpillable());
+    ASSERT_TRUE(target.CommitForceCompact());
+    ASSERT_EQ(20, target.GetCommitMaxRetries());
+    ASSERT_EQ(std::vector<std::string>({"f1", "f2"}), target.GetSequenceField());
+    ASSERT_EQ(MergeEngine::FIRST_ROW, target.GetMergeEngine());
+    ASSERT_EQ(SortEngine::MIN_HEAP, target.GetSortEngine());
+    ASSERT_EQ(ChangelogProducer::LOOKUP, target.GetChangelogProducer());
+    ASSERT_TRUE(target.DeletionVectorsEnabled());
+    ASSERT_TRUE(target.NeedLookup());
+    ASSERT_TRUE(target.IgnoreDelete());
+    ASSERT_TRUE(target.WriteOnly());
+    ASSERT_EQ(10, target.GetCompactionMinFileNum());
+    ASSERT_TRUE(target.CompactionForceRewriteAllFiles());
+    ASSERT_EQ(11, target.GetNumSortedRunsCompactionTrigger());
+    ASSERT_EQ(17, target.GetNumSortedRunsStopTrigger());
+    ASSERT_EQ(9, target.GetNumLevels());
+    ASSERT_EQ(LookupCompactMode::GENTLE, target.GetLookupCompactMode());
+    ASSERT_EQ("test-data-", target.DataFilePrefix());
+    ASSERT_TRUE(target.RowTrackingEnabled());
+    ASSERT_TRUE(target.DataEvolutionEnabled());
+    ASSERT_EQ(BucketFunctionType::MOD, target.GetBucketFunctionType());
+
+    // Verify the target's ToMap matches the source's ToMap
+    ASSERT_EQ(source.ToMap(), target.ToMap());
+}
+
+TEST(CoreOptionsTest, TestSelfAssignment) {
+    std::map<std::string, std::string> options = {
+        {Options::BUCKET, "7"},
+        {Options::MERGE_ENGINE, "first-row"},
+        {Options::CHANGELOG_PRODUCER, "lookup"},
+    };
+    ASSERT_OK_AND_ASSIGN(CoreOptions core_options, CoreOptions::FromMap(options));
+
+    // Self-assignment should be safe
+    core_options = core_options;
+
+    // Values should be preserved after self-assignment
+    ASSERT_EQ(7, core_options.GetBucket());
+    ASSERT_EQ(MergeEngine::FIRST_ROW, core_options.GetMergeEngine());
+    ASSERT_EQ(ChangelogProducer::LOOKUP, core_options.GetChangelogProducer());
+}
+
+TEST(CoreOptionsTest, TestAssignmentIndependence) {
+    std::map<std::string, std::string> options = {
+        {Options::BUCKET, "5"},
+        {Options::MERGE_ENGINE, "first-row"},
+    };
+    ASSERT_OK_AND_ASSIGN(CoreOptions source, CoreOptions::FromMap(options));
+
+    CoreOptions target;
+    target = source;
+
+    // Verify target matches source
+    ASSERT_EQ(5, target.GetBucket());
+    ASSERT_EQ(MergeEngine::FIRST_ROW, target.GetMergeEngine());
+
+    // Modify source by reassigning a different config
+    std::map<std::string, std::string> new_options = {
+        {Options::BUCKET, "99"},
+        {Options::MERGE_ENGINE, "deduplicate"},
+    };
+    ASSERT_OK_AND_ASSIGN(source, CoreOptions::FromMap(new_options));
+
+    // Target should be unaffected (deep copy)
+    ASSERT_EQ(5, target.GetBucket());
+    ASSERT_EQ(MergeEngine::FIRST_ROW, target.GetMergeEngine());
+
+    // Source should have new values
+    ASSERT_EQ(99, source.GetBucket());
+    ASSERT_EQ(MergeEngine::DEDUPLICATE, source.GetMergeEngine());
+}
+
 }  // namespace paimon::test

--- a/src/paimon/core/core_options_test.cpp
+++ b/src/paimon/core/core_options_test.cpp
@@ -709,7 +709,8 @@ TEST(CoreOptionsTest, TestParseChangelogProducer) {
                              CoreOptions::FromMap({{Options::CHANGELOG_PRODUCER, "LOOKUP"}}));
         ASSERT_EQ(options.GetChangelogProducer(), ChangelogProducer::LOOKUP);
     }
-    { ASSERT_NOK(CoreOptions::FromMap({{Options::CHANGELOG_PRODUCER, "invalid"}})); }
+    ASSERT_NOK_WITH_MSG(CoreOptions::FromMap({{Options::CHANGELOG_PRODUCER, "invalid"}}),
+                        "invalid changelog producer: invalid");
 }
 
 TEST(CoreOptionsTest, TestParseExternalPathStrategy) {
@@ -738,7 +739,9 @@ TEST(CoreOptionsTest, TestParseExternalPathStrategy) {
             CoreOptions::FromMap({{Options::DATA_FILE_EXTERNAL_PATHS_STRATEGY, "ROUND-ROBIN"}}));
         ASSERT_EQ(options.GetExternalPathStrategy(), ExternalPathStrategy::ROUND_ROBIN);
     }
-    { ASSERT_NOK(CoreOptions::FromMap({{Options::DATA_FILE_EXTERNAL_PATHS_STRATEGY, "invalid"}})); }
+    ASSERT_NOK_WITH_MSG(
+        CoreOptions::FromMap({{Options::DATA_FILE_EXTERNAL_PATHS_STRATEGY, "invalid"}}),
+        "invalid external path strategy: invalid");
 }
 
 TEST(CoreOptionsTest, TestCopyAssignmentOperator) {

--- a/src/paimon/core/core_options_test.cpp
+++ b/src/paimon/core/core_options_test.cpp
@@ -823,23 +823,9 @@ TEST(CoreOptionsTest, TestCopyAssignmentOperator) {
 
     // Verify the target's ToMap matches the source's ToMap
     ASSERT_EQ(source.ToMap(), target.ToMap());
-}
 
-TEST(CoreOptionsTest, TestSelfAssignment) {
-    std::map<std::string, std::string> options = {
-        {Options::BUCKET, "7"},
-        {Options::MERGE_ENGINE, "first-row"},
-        {Options::CHANGELOG_PRODUCER, "lookup"},
-    };
-    ASSERT_OK_AND_ASSIGN(CoreOptions core_options, CoreOptions::FromMap(options));
-
-    // Self-assignment should be safe
-    core_options = core_options;
-
-    // Values should be preserved after self-assignment
-    ASSERT_EQ(7, core_options.GetBucket());
-    ASSERT_EQ(MergeEngine::FIRST_ROW, core_options.GetMergeEngine());
-    ASSERT_EQ(ChangelogProducer::LOOKUP, core_options.GetChangelogProducer());
+    CoreOptions target2 = source;
+    ASSERT_EQ(source.ToMap(), target2.ToMap());
 }
 
 TEST(CoreOptionsTest, TestAssignmentIndependence) {

--- a/src/paimon/core/snapshot_test.cpp
+++ b/src/paimon/core/snapshot_test.cpp
@@ -20,6 +20,7 @@
 #include "paimon/common/utils/string_utils.h"
 #include "paimon/fs/local/local_file_system.h"
 #include "paimon/result.h"
+#include "paimon/snapshot/snapshot_info.h"
 #include "paimon/status.h"
 #include "paimon/testing/utils/testharness.h"
 
@@ -242,4 +243,162 @@ TEST_F(SnapshotTest, TestSerializeAndDeserialize) {
         se_and_de_from_str(json_str);
     }
 }
+TEST_F(SnapshotTest, TestCommitKindAnalyze) {
+    // Test constructing a Snapshot with CommitKind::Analyze
+    Snapshot snapshot(
+        /*version=*/3, /*id=*/20, /*schema_id=*/5,
+        /*base_manifest_list=*/"base-manifest-analyze",
+        /*base_manifest_list_size=*/100,
+        /*delta_manifest_list=*/"delta-manifest-analyze",
+        /*delta_manifest_list_size=*/200,
+        /*changelog_manifest_list=*/std::nullopt,
+        /*changelog_manifest_list_size=*/std::nullopt,
+        /*index_manifest=*/std::nullopt,
+        /*commit_user=*/"analyze-user",
+        /*commit_identifier=*/42,
+        /*commit_kind=*/Snapshot::CommitKind::Analyze(),
+        /*time_millis=*/1700000000000ll,
+        /*log_offsets=*/std::map<int32_t, int64_t>(),
+        /*total_record_count=*/0,
+        /*delta_record_count=*/0,
+        /*changelog_record_count=*/0,
+        /*watermark=*/std::nullopt,
+        /*statistics=*/"test-statistics",
+        /*properties=*/std::nullopt,
+        /*next_row_id=*/std::nullopt);
+
+    ASSERT_EQ(Snapshot::CommitKind::Analyze(), snapshot.GetCommitKind());
+    ASSERT_EQ("ANALYZE", Snapshot::CommitKind::ToString(snapshot.GetCommitKind()));
+}
+
+TEST_F(SnapshotTest, TestCommitKindAnalyzeSerializeAndDeserialize) {
+    std::string json_str = R"({
+        "version" : 3,
+        "id" : 20,
+        "schemaId" : 5,
+        "baseManifestList" : "base-manifest-analyze",
+        "baseManifestListSize" : 100,
+        "deltaManifestList" : "delta-manifest-analyze",
+        "deltaManifestListSize" : 200,
+        "changelogManifestList" : null,
+        "commitUser" : "analyze-user",
+        "commitIdentifier" : 42,
+        "commitKind" : "ANALYZE",
+        "timeMillis" : 1700000000000,
+        "logOffsets" : { },
+        "totalRecordCount" : 0,
+        "deltaRecordCount" : 0,
+        "changelogRecordCount" : 0,
+        "statistics" : "test-statistics"
+    })";
+
+    ASSERT_OK_AND_ASSIGN(Snapshot snapshot, Snapshot::FromJsonString(json_str));
+
+    // Verify deserialization
+    ASSERT_EQ(20, snapshot.Id());
+    ASSERT_EQ(5, snapshot.SchemaId());
+    ASSERT_EQ(Snapshot::CommitKind::Analyze(), snapshot.GetCommitKind());
+    ASSERT_EQ("test-statistics", snapshot.Statistics().value());
+
+    // Verify round-trip serialization
+    ASSERT_OK_AND_ASSIGN(std::string serialized, snapshot.ToJsonString());
+    ASSERT_EQ(ReplaceAll(json_str), ReplaceAll(serialized));
+
+    // Verify re-deserialization produces equal snapshot
+    ASSERT_OK_AND_ASSIGN(Snapshot deserialized, Snapshot::FromJsonString(serialized));
+    ASSERT_EQ(snapshot, deserialized);
+}
+
+TEST_F(SnapshotTest, TestCommitKindToStringAndFromString) {
+    // Verify all CommitKind values round-trip through ToString/FromString
+    ASSERT_EQ("APPEND", Snapshot::CommitKind::ToString(Snapshot::CommitKind::Append()));
+    ASSERT_EQ("COMPACT", Snapshot::CommitKind::ToString(Snapshot::CommitKind::Compact()));
+    ASSERT_EQ("OVERWRITE", Snapshot::CommitKind::ToString(Snapshot::CommitKind::Overwrite()));
+    ASSERT_EQ("ANALYZE", Snapshot::CommitKind::ToString(Snapshot::CommitKind::Analyze()));
+
+    ASSERT_EQ(Snapshot::CommitKind::Append(), Snapshot::CommitKind::FromString("APPEND"));
+    ASSERT_EQ(Snapshot::CommitKind::Compact(), Snapshot::CommitKind::FromString("COMPACT"));
+    ASSERT_EQ(Snapshot::CommitKind::Overwrite(), Snapshot::CommitKind::FromString("OVERWRITE"));
+    ASSERT_EQ(Snapshot::CommitKind::Analyze(), Snapshot::CommitKind::FromString("ANALYZE"));
+
+    // Verify equality/inequality
+    ASSERT_FALSE(Snapshot::CommitKind::Analyze() == Snapshot::CommitKind::Append());
+    ASSERT_FALSE(Snapshot::CommitKind::Analyze() == Snapshot::CommitKind::Compact());
+    ASSERT_FALSE(Snapshot::CommitKind::Analyze() == Snapshot::CommitKind::Overwrite());
+    ASSERT_TRUE(Snapshot::CommitKind::Analyze() == Snapshot::CommitKind::Analyze());
+}
+
+TEST_F(SnapshotTest, TestSnapshotInfoCommitKindToString) {
+    ASSERT_EQ("APPEND", SnapshotInfo::CommitKindToString(SnapshotInfo::CommitKind::APPEND));
+    ASSERT_EQ("COMPACT", SnapshotInfo::CommitKindToString(SnapshotInfo::CommitKind::COMPACT));
+    ASSERT_EQ("OVERWRITE", SnapshotInfo::CommitKindToString(SnapshotInfo::CommitKind::OVERWRITE));
+    ASSERT_EQ("ANALYZE", SnapshotInfo::CommitKindToString(SnapshotInfo::CommitKind::ANALYZE));
+    ASSERT_EQ("UNKNOWN", SnapshotInfo::CommitKindToString(SnapshotInfo::CommitKind::UNKNOWN));
+}
+
+TEST_F(SnapshotTest, TestChangelogManifestListSerialization) {
+    // Test with changelog_manifest_list set to a non-null value
+    {
+        std::string json_str = R"({
+            "version" : 3,
+            "id" : 1,
+            "schemaId" : 0,
+            "baseManifestList" : "base-manifest-list",
+            "deltaManifestList" : "delta-manifest-list",
+            "changelogManifestList" : "changelog-manifest-list",
+            "changelogManifestListSize" : 42,
+            "commitUser" : "user-01",
+            "commitIdentifier" : 100,
+            "commitKind" : "APPEND",
+            "timeMillis" : 1700000000000,
+            "logOffsets" : { },
+            "totalRecordCount" : 10,
+            "deltaRecordCount" : 5,
+            "changelogRecordCount" : 3
+        })";
+
+        ASSERT_OK_AND_ASSIGN(Snapshot snapshot, Snapshot::FromJsonString(json_str));
+        ASSERT_EQ("changelog-manifest-list", snapshot.ChangelogManifestList().value());
+        ASSERT_EQ(42, snapshot.ChangelogManifestListSize().value());
+
+        ASSERT_OK_AND_ASSIGN(std::string serialized, snapshot.ToJsonString());
+        ASSERT_EQ(ReplaceAll(json_str), ReplaceAll(serialized));
+
+        // Verify round-trip
+        ASSERT_OK_AND_ASSIGN(Snapshot deserialized, Snapshot::FromJsonString(serialized));
+        ASSERT_EQ(snapshot, deserialized);
+    }
+
+    // Test with changelog_manifest_list set to null
+    {
+        std::string json_str = R"({
+            "version" : 3,
+            "id" : 2,
+            "schemaId" : 0,
+            "baseManifestList" : "base-manifest-list",
+            "deltaManifestList" : "delta-manifest-list",
+            "changelogManifestList" : null,
+            "commitUser" : "user-02",
+            "commitIdentifier" : 200,
+            "commitKind" : "COMPACT",
+            "timeMillis" : 1700000001000,
+            "logOffsets" : { },
+            "totalRecordCount" : 20,
+            "deltaRecordCount" : 10,
+            "changelogRecordCount" : 0
+        })";
+
+        ASSERT_OK_AND_ASSIGN(Snapshot snapshot, Snapshot::FromJsonString(json_str));
+        ASSERT_EQ(std::nullopt, snapshot.ChangelogManifestList());
+        ASSERT_EQ(std::nullopt, snapshot.ChangelogManifestListSize());
+
+        ASSERT_OK_AND_ASSIGN(std::string serialized, snapshot.ToJsonString());
+        ASSERT_EQ(ReplaceAll(json_str), ReplaceAll(serialized));
+
+        // Verify round-trip
+        ASSERT_OK_AND_ASSIGN(Snapshot deserialized, Snapshot::FromJsonString(serialized));
+        ASSERT_EQ(snapshot, deserialized);
+    }
+}
+
 }  // namespace paimon::test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
No Linked issue

<!-- What is the purpose of the change -->

### Tests
PredicateTest, TestLikeConsecutivePercent
PredicateTest, TestLikeEmptyField
PredicateTest, TestLikeMinLenExceedsField
PredicateTest, TestLikeLongPatternHeapAlloc
DataEvolutionArrayTest, TestAllFieldTypes
DataEvolutionRowTest, TestAllFieldTypes
BlockMetaTest
BlockWriteReadTest
BitSetTest, TestGetOutOfBound
BitSetTest, TestClearNonAligned
DateTimeUtilsTest, TestGetArrowTimeUnitStr
ProjectedArrayTest, TestGetStringView
ProjectedArrayTest, TestGetMap
ProjectedArrayTest, TestGetRow
AppendOnlyWriterTest, TestCloseCleansDeletionFile
CoreOptionsTest, TestOverflowProtection
CoreOptionsTest, TestExplicitNumLevels
CoreOptionsTest, TestParseChangelogProducer
CoreOptionsTest, TestParseExternalPathStrategy
CoreOptionsTest, TestCopyAssignmentOperator
CoreOptionsTest, TestSelfAssignment
CoreOptionsTest, TestAssignmentIndependence
SnapshotTest, TestCommitKindAnalyze
SnapshotTest, TestCommitKindAnalyzeSerializeAndDeserialize
SnapshotTest, TestCommitKindToStringAndFromString
SnapshotTest, TestSnapshotInfoCommitKindToString
SnapshotTest, TestChangelogManifestListSerialization
<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude-4.6-Opus