### PR TITLE
refactor(btree): optimize BTreeFileMetaSelector with zero-copy comparator

### DIFF
--- a/src/paimon/common/global_index/btree/btree_file_meta_selector.cpp
+++ b/src/paimon/common/global_index/btree/btree_file_meta_selector.cpp
@@ -22,7 +22,9 @@ namespace paimon {
 BTreeFileMetaSelector::BTreeFileMetaSelector(const std::vector<GlobalIndexIOMeta>& files,
                                              const std::shared_ptr<arrow::DataType>& key_type,
                                              const std::shared_ptr<MemoryPool>& pool)
-    : key_type_(key_type), pool_(pool) {
+    : key_type_(key_type),
+      pool_(pool),
+      comparator_(KeySerializer::CreateComparator(key_type, pool)) {
     files_.reserve(files.size());
     for (const auto& file : files) {
         auto index_meta = BTreeIndexMeta::Deserialize(file.metadata, pool.get());
@@ -39,14 +41,15 @@ Result<std::vector<GlobalIndexIOMeta>> BTreeFileMetaSelector::VisitIsNull() {
 }
 
 Result<std::vector<GlobalIndexIOMeta>> BTreeFileMetaSelector::VisitEqual(const Literal& literal) {
-    return Filter([this, &literal](const BTreeIndexMeta& meta) -> Result<bool> {
+    PAIMON_ASSIGN_OR_RAISE(MemorySlice literal_slice, SerializeLiteral(literal));
+    return Filter([this, &literal_slice](const BTreeIndexMeta& meta) -> Result<bool> {
         if (meta.OnlyNulls()) {
             return false;
         }
-        PAIMON_ASSIGN_OR_RAISE(Literal min_key, DeserializeKey(meta.FirstKey()));
-        PAIMON_ASSIGN_OR_RAISE(Literal max_key, DeserializeKey(meta.LastKey()));
-        PAIMON_ASSIGN_OR_RAISE(int32_t cmp_min, literal.CompareTo(min_key));
-        PAIMON_ASSIGN_OR_RAISE(int32_t cmp_max, literal.CompareTo(max_key));
+        MemorySlice min_key_slice = WrapKeySlice(meta.FirstKey());
+        MemorySlice max_key_slice = WrapKeySlice(meta.LastKey());
+        PAIMON_ASSIGN_OR_RAISE(int32_t cmp_min, comparator_(literal_slice, min_key_slice));
+        PAIMON_ASSIGN_OR_RAISE(int32_t cmp_max, comparator_(literal_slice, max_key_slice));
         return cmp_min >= 0 && cmp_max <= 0;
     });
 }
@@ -59,12 +62,13 @@ Result<std::vector<GlobalIndexIOMeta>> BTreeFileMetaSelector::VisitNotEqual(
 Result<std::vector<GlobalIndexIOMeta>> BTreeFileMetaSelector::VisitLessThan(
     const Literal& literal) {
     // file.minKey < literal
-    return Filter([this, &literal](const BTreeIndexMeta& meta) -> Result<bool> {
+    PAIMON_ASSIGN_OR_RAISE(MemorySlice literal_slice, SerializeLiteral(literal));
+    return Filter([this, &literal_slice](const BTreeIndexMeta& meta) -> Result<bool> {
         if (meta.OnlyNulls()) {
             return false;
         }
-        PAIMON_ASSIGN_OR_RAISE(Literal min_key, DeserializeKey(meta.FirstKey()));
-        PAIMON_ASSIGN_OR_RAISE(int32_t cmp, min_key.CompareTo(literal));
+        MemorySlice min_key_slice = WrapKeySlice(meta.FirstKey());
+        PAIMON_ASSIGN_OR_RAISE(int32_t cmp, comparator_(min_key_slice, literal_slice));
         return cmp < 0;
     });
 }
@@ -72,12 +76,13 @@ Result<std::vector<GlobalIndexIOMeta>> BTreeFileMetaSelector::VisitLessThan(
 Result<std::vector<GlobalIndexIOMeta>> BTreeFileMetaSelector::VisitLessOrEqual(
     const Literal& literal) {
     // file.minKey <= literal
-    return Filter([this, &literal](const BTreeIndexMeta& meta) -> Result<bool> {
+    PAIMON_ASSIGN_OR_RAISE(MemorySlice literal_slice, SerializeLiteral(literal));
+    return Filter([this, &literal_slice](const BTreeIndexMeta& meta) -> Result<bool> {
         if (meta.OnlyNulls()) {
             return false;
         }
-        PAIMON_ASSIGN_OR_RAISE(Literal min_key, DeserializeKey(meta.FirstKey()));
-        PAIMON_ASSIGN_OR_RAISE(int32_t cmp, min_key.CompareTo(literal));
+        MemorySlice min_key_slice = WrapKeySlice(meta.FirstKey());
+        PAIMON_ASSIGN_OR_RAISE(int32_t cmp, comparator_(min_key_slice, literal_slice));
         return cmp <= 0;
     });
 }
@@ -85,12 +90,13 @@ Result<std::vector<GlobalIndexIOMeta>> BTreeFileMetaSelector::VisitLessOrEqual(
 Result<std::vector<GlobalIndexIOMeta>> BTreeFileMetaSelector::VisitGreaterThan(
     const Literal& literal) {
     // file.maxKey > literal
-    return Filter([this, &literal](const BTreeIndexMeta& meta) -> Result<bool> {
+    PAIMON_ASSIGN_OR_RAISE(MemorySlice literal_slice, SerializeLiteral(literal));
+    return Filter([this, &literal_slice](const BTreeIndexMeta& meta) -> Result<bool> {
         if (meta.OnlyNulls()) {
             return false;
         }
-        PAIMON_ASSIGN_OR_RAISE(Literal max_key, DeserializeKey(meta.LastKey()));
-        PAIMON_ASSIGN_OR_RAISE(int32_t cmp, max_key.CompareTo(literal));
+        MemorySlice max_key_slice = WrapKeySlice(meta.LastKey());
+        PAIMON_ASSIGN_OR_RAISE(int32_t cmp, comparator_(max_key_slice, literal_slice));
         return cmp > 0;
     });
 }
@@ -98,27 +104,34 @@ Result<std::vector<GlobalIndexIOMeta>> BTreeFileMetaSelector::VisitGreaterThan(
 Result<std::vector<GlobalIndexIOMeta>> BTreeFileMetaSelector::VisitGreaterOrEqual(
     const Literal& literal) {
     // file.maxKey >= literal
-    return Filter([this, &literal](const BTreeIndexMeta& meta) -> Result<bool> {
+    PAIMON_ASSIGN_OR_RAISE(MemorySlice literal_slice, SerializeLiteral(literal));
+    return Filter([this, &literal_slice](const BTreeIndexMeta& meta) -> Result<bool> {
         if (meta.OnlyNulls()) {
             return false;
         }
-        PAIMON_ASSIGN_OR_RAISE(Literal max_key, DeserializeKey(meta.LastKey()));
-        PAIMON_ASSIGN_OR_RAISE(int32_t cmp, max_key.CompareTo(literal));
+        MemorySlice max_key_slice = WrapKeySlice(meta.LastKey());
+        PAIMON_ASSIGN_OR_RAISE(int32_t cmp, comparator_(max_key_slice, literal_slice));
         return cmp >= 0;
     });
 }
 
 Result<std::vector<GlobalIndexIOMeta>> BTreeFileMetaSelector::VisitIn(
     const std::vector<Literal>& literals) {
-    return Filter([this, &literals](const BTreeIndexMeta& meta) -> Result<bool> {
+    std::vector<MemorySlice> literal_slices;
+    literal_slices.reserve(literals.size());
+    for (const auto& literal : literals) {
+        PAIMON_ASSIGN_OR_RAISE(MemorySlice slice, SerializeLiteral(literal));
+        literal_slices.push_back(std::move(slice));
+    }
+    return Filter([this, &literal_slices](const BTreeIndexMeta& meta) -> Result<bool> {
         if (meta.OnlyNulls()) {
             return false;
         }
-        PAIMON_ASSIGN_OR_RAISE(Literal min_key, DeserializeKey(meta.FirstKey()));
-        PAIMON_ASSIGN_OR_RAISE(Literal max_key, DeserializeKey(meta.LastKey()));
-        for (const auto& literal : literals) {
-            PAIMON_ASSIGN_OR_RAISE(int32_t cmp_min, literal.CompareTo(min_key));
-            PAIMON_ASSIGN_OR_RAISE(int32_t cmp_max, literal.CompareTo(max_key));
+        MemorySlice min_key_slice = WrapKeySlice(meta.FirstKey());
+        MemorySlice max_key_slice = WrapKeySlice(meta.LastKey());
+        for (const auto& literal_slice : literal_slices) {
+            PAIMON_ASSIGN_OR_RAISE(int32_t cmp_min, comparator_(literal_slice, min_key_slice));
+            PAIMON_ASSIGN_OR_RAISE(int32_t cmp_max, comparator_(literal_slice, max_key_slice));
             if (cmp_min >= 0 && cmp_max <= 0) {
                 return true;
             }
@@ -163,10 +176,14 @@ Result<std::vector<GlobalIndexIOMeta>> BTreeFileMetaSelector::Filter(
     return result;
 }
 
-Result<Literal> BTreeFileMetaSelector::DeserializeKey(
-    const std::shared_ptr<Bytes>& key_bytes) const {
-    MemorySlice slice = MemorySlice::Wrap(key_bytes);
-    return KeySerializer::DeserializeKey(slice, key_type_, pool_.get());
+MemorySlice BTreeFileMetaSelector::WrapKeySlice(const std::shared_ptr<Bytes>& key) {
+    return MemorySlice::Wrap(MemorySegment::WrapView(key->data(), key->size()));
+}
+
+Result<MemorySlice> BTreeFileMetaSelector::SerializeLiteral(const Literal& literal) const {
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<Bytes> bytes,
+                           KeySerializer::SerializeKey(literal, key_type_, pool_.get()));
+    return MemorySlice::Wrap(bytes);
 }
 
 }  // namespace paimon

--- a/src/paimon/common/global_index/btree/btree_file_meta_selector.h
+++ b/src/paimon/common/global_index/btree/btree_file_meta_selector.h
@@ -22,6 +22,7 @@
 
 #include "paimon/common/global_index/btree/btree_index_meta.h"
 #include "paimon/common/global_index/btree/key_serializer.h"
+#include "paimon/common/memory/memory_slice.h"
 #include "paimon/global_index/global_index_io_meta.h"
 #include "paimon/predicate/function_visitor.h"
 
@@ -55,11 +56,16 @@ class BTreeFileMetaSelector : public FunctionVisitor<std::vector<GlobalIndexIOMe
 
     Result<std::vector<GlobalIndexIOMeta>> Filter(const MetaPredicate& predicate) const;
 
-    Result<Literal> DeserializeKey(const std::shared_ptr<Bytes>& key_bytes) const;
+    Result<MemorySlice> SerializeLiteral(const Literal& literal) const;
+
+    /// Create a non-owning MemorySlice view over the raw bytes of a key,
+    /// avoiding shared_ptr reference-count overhead.
+    static MemorySlice WrapKeySlice(const std::shared_ptr<Bytes>& key);
 
     std::vector<std::pair<GlobalIndexIOMeta, std::shared_ptr<BTreeIndexMeta>>> files_;
     std::shared_ptr<arrow::DataType> key_type_;
     std::shared_ptr<MemoryPool> pool_;
+    MemorySlice::SliceComparator comparator_;
 };
 
 }  // namespace paimon


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: #38 

<!-- What is the purpose of the change -->
Optimize `BTreeFileMetaSelector` key comparison to use zero-copy `MemorySlice` comparator,
consistent with `BTreeGlobalIndexReader`.

- Replace `DeserializeKey` + `Literal::CompareTo` with `MemorySlice::SliceComparator`
- Use `MemorySegment::WrapView` for non-copying key slices

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling
Generated-by: Claude-4.6-Opus

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
