### PR TITLE
fix: Fix MemorySegment::Compare to use big-endian byte-order comparison semantics

### DIFF
--- a/src/paimon/common/memory/memory_segment.cpp
+++ b/src/paimon/common/memory/memory_segment.cpp
@@ -23,11 +23,8 @@ namespace paimon {
 int32_t MemorySegment::Compare(const MemorySegment& seg2, int32_t offset1, int32_t offset2,
                                int32_t len) const {
     while (len >= 8) {
-        // TODO(yonghao.fyh): support big endian, decide SmallEndian or BigEndian
-        // long l1 = GetLongBigEndian(offset1);
-        // long l2 = seg2.getLongBigEndian(offset2);
-        uint64_t l1 = GetValue<int64_t>(offset1);
-        uint64_t l2 = seg2.GetValue<int64_t>(offset2);
+        uint64_t l1 = GetLongBigEndian(offset1);
+        uint64_t l2 = seg2.GetLongBigEndian(offset2);
 
         if (l1 != l2) {
             return (l1 < l2) ? -1 : 1;

--- a/src/paimon/common/memory/memory_segment.h
+++ b/src/paimon/common/memory/memory_segment.h
@@ -135,7 +135,7 @@ class PAIMON_EXPORT MemorySegment {
     }
 
     inline uint64_t GetLongBigEndian(int32_t index) const {
-        uint64_t value = GetValue<uint64_t>(index);
+        auto value = GetValue<uint64_t>(index);
         if constexpr (SystemByteOrder() == ByteOrder::PAIMON_LITTLE_ENDIAN) {
             return EndianSwapValue(value);
         }

--- a/src/paimon/common/memory/memory_segment.h
+++ b/src/paimon/common/memory/memory_segment.h
@@ -134,8 +134,8 @@ class PAIMON_EXPORT MemorySegment {
     }
 
     inline uint64_t GetLongBigEndian(int32_t index) const {
-        uint64_t native_value = GetValue<uint64_t>(index);
-        return static_cast<uint64_t>(EndianSwapValue(native_value));
+        auto native_value = GetValue<uint64_t>(index);
+        return EndianSwapValue(native_value);
     }
 
     void CopyTo(int32_t offset, MemorySegment* target, int32_t target_offset,

--- a/src/paimon/common/memory/memory_segment.h
+++ b/src/paimon/common/memory/memory_segment.h
@@ -23,6 +23,7 @@
 #include <type_traits>
 
 #include "paimon/common/utils/math.h"
+#include "paimon/io/byte_order.h"
 #include "paimon/memory/bytes.h"
 #include "paimon/visibility.h"
 
@@ -133,7 +134,7 @@ class PAIMON_EXPORT MemorySegment {
         std::memcpy(MutableData() + index, &value, sizeof(T));
     }
 
-inline uint64_t GetLongBigEndian(int32_t index) const {
+    inline uint64_t GetLongBigEndian(int32_t index) const {
         uint64_t value = GetValue<uint64_t>(index);
         if constexpr (SystemByteOrder() == ByteOrder::PAIMON_LITTLE_ENDIAN) {
             return EndianSwapValue(value);

--- a/src/paimon/common/memory/memory_segment.h
+++ b/src/paimon/common/memory/memory_segment.h
@@ -22,6 +22,7 @@
 #include <memory>
 #include <type_traits>
 
+#include "paimon/common/utils/math.h"
 #include "paimon/memory/bytes.h"
 #include "paimon/visibility.h"
 
@@ -130,6 +131,11 @@ class PAIMON_EXPORT MemorySegment {
         static_assert(std::is_trivially_copyable_v<T>, "T must be trivially copyable");
 
         std::memcpy(MutableData() + index, &value, sizeof(T));
+    }
+
+    inline uint64_t GetLongBigEndian(int32_t index) const {
+        uint64_t native_value = GetValue<uint64_t>(index);
+        return static_cast<uint64_t>(EndianSwapValue(native_value));
     }
 
     void CopyTo(int32_t offset, MemorySegment* target, int32_t target_offset,

--- a/src/paimon/common/memory/memory_segment.h
+++ b/src/paimon/common/memory/memory_segment.h
@@ -133,9 +133,12 @@ class PAIMON_EXPORT MemorySegment {
         std::memcpy(MutableData() + index, &value, sizeof(T));
     }
 
-    inline uint64_t GetLongBigEndian(int32_t index) const {
-        auto native_value = GetValue<uint64_t>(index);
-        return EndianSwapValue(native_value);
+inline uint64_t GetLongBigEndian(int32_t index) const {
+        uint64_t value = GetValue<uint64_t>(index);
+        if constexpr (SystemByteOrder() == ByteOrder::PAIMON_LITTLE_ENDIAN) {
+            return EndianSwapValue(value);
+        }
+        return value;
     }
 
     void CopyTo(int32_t offset, MemorySegment* target, int32_t target_offset,

--- a/src/paimon/common/memory/memory_segment_test.cpp
+++ b/src/paimon/common/memory/memory_segment_test.cpp
@@ -158,6 +158,32 @@ TEST(MemorySegmentTest, TestCompare) {
     seg2.Put(i + 8, static_cast<char>(10));
     ASSERT_EQ(seg1.Compare(seg2, i, i, 7, 7), 0);
     ASSERT_LT(seg1.Compare(seg2, i, i, 9, 9), 0);
+
+    // Verify big-endian byte-order comparison semantics within a single 8-byte block.
+    // On little-endian machines, naive native-endian uint64 comparison would give wrong results.
+    MemorySegment seg3 = MemorySegment::AllocateHeapMemory(16, pool.get());
+    MemorySegment seg4 = MemorySegment::AllocateHeapMemory(16, pool.get());
+    Bytes zeros(16, pool.get());
+    seg3.Put(0, zeros);
+    seg4.Put(0, zeros);
+
+    // seg3: [0x00, 0x01, 0, 0, 0, 0, 0, 0] at offset 0
+    // seg4: [0x01, 0x00, 0, 0, 0, 0, 0, 0] at offset 0
+    // Lexicographic (byte-order) comparison: first byte 0x00 < 0x01, so seg3 < seg4.
+    seg3.Put(1, static_cast<char>(0x01));
+    seg4.Put(0, static_cast<char>(0x01));
+    ASSERT_LT(seg3.Compare(seg4, 0, 0, 8), 0);
+    ASSERT_GT(seg4.Compare(seg3, 0, 0, 8), 0);
+
+    // seg3: [0x01, 0x02, 0, 0, 0, 0, 0, 0]
+    // seg4: [0x01, 0x01, 0, 0, 0, 0, 0, 0]
+    // First bytes equal (0x01 == 0x01), second byte 0x02 > 0x01, so seg3 > seg4.
+    seg3.Put(0, static_cast<char>(0x01));
+    seg3.Put(1, static_cast<char>(0x02));
+    seg4.Put(0, static_cast<char>(0x01));
+    seg4.Put(1, static_cast<char>(0x01));
+    ASSERT_GT(seg3.Compare(seg4, 0, 0, 8), 0);
+    ASSERT_LT(seg4.Compare(seg3, 0, 0, 8), 0);
 }
 
 TEST(MemorySegmentTest, TestCharAccess) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
No Linked issue.

**Problem**

`MemorySegment::Compare` reads 8 bytes at a time using `GetValue<int64_t>()` which returns the value in native endianness. On little-endian platforms (x86/ARM), this breaks lexicographic (byte-order) comparison semantics — the most significant byte in memory becomes the least significant byte in the integer, causing incorrect comparison results.

For example, comparing `[0x00, 0x01, 0, 0, 0, 0, 0, 0]` vs `[0x01, 0x00, 0, 0, 0, 0, 0, 0]`:
- **Expected** (lexicographic): first byte `0x00 < 0x01`, result should be negative
- **Before fix** (little-endian native): reads as `0x0100 > 0x0001`, result was positive ❌

This is consistent with the existing TODO in the code and aligned with the Java implementation which uses `getLongBigEndian()`.

<!-- What is the purpose of the change -->

**Fix**

- Added `GetLongBigEndian()` method to `MemorySegment` that reads 8 bytes and converts to big-endian order using the existing `EndianSwapValue()` utility from `math.h`
- Updated `Compare()` to call `GetLongBigEndian()` instead of raw `GetValue<int64_t>()`

### Tests
MemorySegmentTest.TestCompare
<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling
Generated-by: Claude-4.7-Opus
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
