### PR TITLE
fix: Fix undefined behavior in BinarySection bitmask constants caused by signed left shift

### DIFF
--- a/src/paimon/common/data/binary_section.h
+++ b/src/paimon/common/data/binary_section.h
@@ -48,13 +48,13 @@ class PAIMON_EXPORT BinarySection {
     /// This is used to decide whether the data is stored in fixed-length part or
     /// variable-length part. see `MAX_FIX_PART_DATA_SIZE` for more information.
 
-    static constexpr int64_t HIGHEST_FIRST_BIT = 0x80L << 56;
+    static constexpr int64_t HIGHEST_FIRST_BIT = static_cast<int64_t>(0x80ULL << 56);
     /// To get the 7 bits length in second bit to eighth bit out of a int64_t. Form:
     /// 01111111 00000000... (8 bytes)
     /// This is used to get the length of the data which is stored in this int64_t. see
     /// `MAX_FIX_PART_DATA_SIZE` for more information.
 
-    static constexpr int64_t HIGHEST_SECOND_TO_EIGHTH_BIT = 0x7FL << 56;
+    static constexpr int64_t HIGHEST_SECOND_TO_EIGHTH_BIT = static_cast<int64_t>(0x7FULL << 56);
 
     /// Get binary, if len less than 8, will be include in variable_part_offset_and_len.
     /// @note Need to consider the ByteOrder.


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
No Linked issue.

## What is the problem?

In `BinarySection`, the bitmask constants `HIGHEST_FIRST_BIT` and `HIGHEST_SECOND_TO_EIGHTH_BIT` are defined using signed left shift:

```cpp
static constexpr int64_t HIGHEST_FIRST_BIT = 0x80L << 56;
static constexpr int64_t HIGHEST_SECOND_TO_EIGHTH_BIT = 0x7FL << 56;
```

`0x80L` is a signed `long` with value 128. Left-shifting it by 56 bits overflows into the sign bit of a 64-bit signed integer, which is **undefined behavior (UB)** per the C++ standard (before C++20, and still implementation-defined in C++20).


## What is the fix?

Use unsigned literals (`0x80ULL`, `0x7FULL`) for the shift operation to ensure defined behavior, then `static_cast` back to `int64_t`:

```cpp
static constexpr int64_t HIGHEST_FIRST_BIT = static_cast<int64_t>(0x80ULL << 56);
static constexpr int64_t HIGHEST_SECOND_TO_EIGHTH_BIT = static_cast<int64_t>(0x7FULL << 56);
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
