### PR TITLE
cherry-pick: pick #298 #299 #301 #303 #305 #308 to release-0.2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -218,7 +218,6 @@ This product includes code from Apache Arrow.
 
 * Core utilities:
   * docs utilities in docs/ directory
-  * build support utilities in build_support/ directory
   * orc adapter in src/paimon/format/orc/orc_adapter.cpp and src/paimon/format/orc/orc_adapter.h
   * parquet schema convertor in src/paimon/format/parquet/parquet_schema_util.cpp and src/paimon/format/parquet/parquet_schema_util.h
   * basic utilities in
@@ -228,6 +227,20 @@ This product includes code from Apache Arrow.
     - include/paimon/string_builder.h
     - src/paimon/common/utils/status.cpp
   * Arrow C Data Interface in include/paimon/arrow/abi.h
+* Build support utilities:
+  * build_support/asan-suppressions.txt
+  * build_support/get-upstream-commit.sh
+  * build_support/iwyu/iwyu-filter.awk
+  * build_support/iwyu/iwyu.sh
+  * build_support/iwyu/mappings/*.imp
+  * build_support/lint_exclusions.txt
+  * build_support/lintutils.py
+  * build_support/lsan-suppressions.txt
+  * build_support/run_clang_format.py
+  * build_support/run_clang_tidy.py
+  * build_support/sanitizer-disallowed-entries.txt
+  * build_support/tsan-suppressions.txt
+  * build_support/ubsan-suppressions.txt
 * Build system modules:
   * cmake_modules/BuildUtils.cmake
   * cmake_modules/DefineOptions.cmake
@@ -239,6 +252,78 @@ This product includes code from Apache Arrow.
 Copyright: 2016-2024 The Apache Software Foundation.
 Home page: https://arrow.apache.org/
 License: https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from LLVM compiler-rt.
+
+* AddressSanitizer symbolization utility:
+   * build_support/asan_symbolize.py
+
+Copyright: University of Illinois / LLVM contributors.
+License: University of Illinois/NCSA Open Source License.
+
+--------------------------------------------------------------------------------
+
+This product includes code from include-what-you-use.
+
+* IWYU driver utility:
+   * build_support/iwyu/iwyu_tool.py
+
+Copyright: 2003-2010 University of Illinois at Urbana-Champaign.
+License: University of Illinois/NCSA Open Source License.
+
+The University of Illinois/NCSA Open Source License
+
+Copyright (c) 2003-2010 University of Illinois at Urbana-Champaign.
+All rights reserved.
+
+Developed by:
+
+      LLVM Team
+
+      University of Illinois at Urbana-Champaign
+
+      http://llvm.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal with
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+      * Redistributions of source code must retain the above copyright notice,
+         this list of conditions and the following disclaimers.
+
+      * Redistributions in binary form must reproduce the above copyright notice,
+         this list of conditions and the following disclaimers in the
+         documentation and/or other materials provided with the distribution.
+
+      * Neither the names of the LLVM Team, University of Illinois at
+         Urbana-Champaign, nor the names of its contributors may be used to
+         endorse or promote products derived from this Software without specific
+         prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+This product includes code from Apache Kudu / Cloudera build support utilities.
+
+* Test and stacktrace utilities:
+   * build_support/run-test.sh
+   * build_support/stacktrace_addr2line.pl
+
+Copyright: 2014 Cloudera, Inc.
+License: https://www.apache.org/licenses/LICENSE-2.0
+
 --------------------------------------------------------------------------------
 
 This product includes code from Apache ORC.

--- a/src/paimon/common/compression/block_decompressor.cpp
+++ b/src/paimon/common/compression/block_decompressor.cpp
@@ -20,8 +20,10 @@
 namespace paimon {
 
 int32_t BlockDecompressor::ReadIntLE(const char* buf) {
-    return (buf[0] & 0xFF) | ((buf[1] & 0xFF) << 8) | ((buf[2] & 0xFF) << 16) |
-           ((buf[3] & 0xFF) << 24);
+    return static_cast<int32_t>(static_cast<uint32_t>(static_cast<uint8_t>(buf[0])) |
+                                (static_cast<uint32_t>(static_cast<uint8_t>(buf[1])) << 8) |
+                                (static_cast<uint32_t>(static_cast<uint8_t>(buf[2])) << 16) |
+                                (static_cast<uint32_t>(static_cast<uint8_t>(buf[3])) << 24));
 }
 
 Status BlockDecompressor::ValidateLength(int32_t compressed_len, int32_t original_len) {

--- a/src/paimon/common/data/abstract_binary_writer.cpp
+++ b/src/paimon/common/data/abstract_binary_writer.cpp
@@ -199,20 +199,18 @@ int32_t AbstractBinaryWriter::RoundNumberOfBytesToNearestWord(int32_t num_bytes)
 template <typename T>
 void AbstractBinaryWriter::WriteBytesToFixLenPart(MemorySegment* segment, int32_t field_offset,
                                                   const T& bytes, int32_t len) {
-    int64_t first_byte = len | 0x80;  // first bit is 1, other bits is len
-    int64_t seven_bytes = 0L;         // real data
+    uint64_t first_byte = static_cast<uint64_t>(len) | 0x80u;  // first bit is 1, other bits is len
+    uint64_t seven_bytes = 0;                                  // real data
     if ((SystemByteOrder() == ByteOrder::PAIMON_LITTLE_ENDIAN)) {
         for (int32_t i = 0; i < len; i++) {
-            seven_bytes |= ((0x00000000000000FFL & bytes[i]) << (i * 8L));
+            seven_bytes |= (static_cast<uint64_t>(static_cast<uint8_t>(bytes[i])) << (i * 8));
         }
     } else {
         for (int32_t i = 0; i < len; i++) {
-            seven_bytes |= ((0x00000000000000FFL & bytes[i]) << ((6 - i) * 8L));
+            seven_bytes |= (static_cast<uint64_t>(static_cast<uint8_t>(bytes[i])) << ((6 - i) * 8));
         }
     }
-    const int64_t offset_and_size =
-        (first_byte << 56) |  // NOLINT(clang-analyzer-core.UndefinedBinaryOperatorResult)
-        seven_bytes;
+    const auto offset_and_size = static_cast<int64_t>(first_byte << 56 | seven_bytes);
     segment->PutValue<int64_t>(field_offset, offset_and_size);
 }
 

--- a/src/paimon/common/data/binary_array_test.cpp
+++ b/src/paimon/common/data/binary_array_test.cpp
@@ -332,7 +332,7 @@ TEST(BinaryArrayTest, TestFromLongArray) {
                                                         R"([[123, null], [789], [12345], [12]])")
                   .ValueOrDie();
     auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
-    auto array = ColumnarArray(list_array->values(), pool, /*offset=*/0, 2);
+    auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/0, 2);
 
     BinaryArray ret = BinaryArray::FromLongArray(&array, pool.get());
 
@@ -363,7 +363,7 @@ TEST(BinaryArrayTest, TestFromAllNullLongArray) {
                                                         R"([[null, null], [789], [12345], [12]])")
                   .ValueOrDie();
     auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
-    auto array = ColumnarArray(list_array->values(), pool, /*offset=*/0, 2);
+    auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/0, 2);
 
     BinaryArray ret = BinaryArray::FromLongArray(&array, pool.get());
 

--- a/src/paimon/common/data/binary_array_writer.cpp
+++ b/src/paimon/common/data/binary_array_writer.cpp
@@ -95,7 +95,8 @@ int32_t BinaryArrayWriter::GetFieldOffset(int32_t pos) const {
 }
 
 void BinaryArrayWriter::SetOffsetAndSize(int32_t pos, int32_t offset, int64_t size) {
-    const int64_t offset_and_size = (static_cast<int64_t>(offset) << 32) | size;
+    const auto offset_and_size =
+        static_cast<int64_t>((static_cast<uint64_t>(offset) << 32) | static_cast<uint64_t>(size));
     segment_.PutValue<int64_t>(GetElementOffset(pos, 8), offset_and_size);
 }
 

--- a/src/paimon/common/data/binary_row.cpp
+++ b/src/paimon/common/data/binary_row.cpp
@@ -28,7 +28,9 @@
 
 namespace paimon {
 const int64_t BinaryRow::FIRST_BYTE_ZERO =
-    (SystemByteOrder() == ByteOrder::PAIMON_LITTLE_ENDIAN) ? (~0xFFL) : (~(0xFFL << 56L));
+    (SystemByteOrder() == ByteOrder::PAIMON_LITTLE_ENDIAN)
+        ? static_cast<int64_t>(~static_cast<uint64_t>(0xFF))
+        : static_cast<int64_t>(~(static_cast<uint64_t>(0xFF) << 56));
 
 const BinaryRow& BinaryRow::EmptyRow() {
     static const BinaryRow empty_row = GetEmptyRow();

--- a/src/paimon/common/data/binary_row_writer.h
+++ b/src/paimon/common/data/binary_row_writer.h
@@ -100,7 +100,8 @@ class BinaryRowWriter : public AbstractBinaryWriter {
     }
 
     void SetOffsetAndSize(int32_t pos, int32_t offset, int64_t size) override {
-        const int64_t offset_and_size = (static_cast<int64_t>(offset) << 32) | size;
+        const auto offset_and_size = static_cast<int64_t>((static_cast<uint64_t>(offset) << 32) |
+                                                          static_cast<uint64_t>(size));
         segment_.PutValue<int64_t>(GetFieldOffset(pos), offset_and_size);
     }
 

--- a/src/paimon/common/data/binary_section.h
+++ b/src/paimon/common/data/binary_section.h
@@ -48,13 +48,13 @@ class PAIMON_EXPORT BinarySection {
     /// This is used to decide whether the data is stored in fixed-length part or
     /// variable-length part. see `MAX_FIX_PART_DATA_SIZE` for more information.
 
-    static constexpr int64_t HIGHEST_FIRST_BIT = 0x80L << 56;
+    static constexpr int64_t HIGHEST_FIRST_BIT = static_cast<int64_t>(0x80ULL << 56);
     /// To get the 7 bits length in second bit to eighth bit out of a int64_t. Form:
     /// 01111111 00000000... (8 bytes)
     /// This is used to get the length of the data which is stored in this int64_t. see
     /// `MAX_FIX_PART_DATA_SIZE` for more information.
 
-    static constexpr int64_t HIGHEST_SECOND_TO_EIGHTH_BIT = 0x7FL << 56;
+    static constexpr int64_t HIGHEST_SECOND_TO_EIGHTH_BIT = static_cast<int64_t>(0x7FULL << 56);
 
     /// Get binary, if len less than 8, will be include in variable_part_offset_and_len.
     /// @note Need to consider the ByteOrder.

--- a/src/paimon/common/data/columnar/columnar_array.cpp
+++ b/src/paimon/common/data/columnar/columnar_array.cpp
@@ -70,7 +70,7 @@ std::shared_ptr<InternalArray> ColumnarArray::GetArray(int32_t pos) const {
     assert(list_array);
     int32_t offset = list_array->value_offset(offset_ + pos);
     int32_t length = list_array->value_length(offset_ + pos);
-    return std::make_shared<ColumnarArray>(list_array->values(), pool_, offset, length);
+    return std::make_shared<ColumnarArray>(list_array->values().get(), pool_, offset, length);
 }
 
 std::shared_ptr<InternalMap> ColumnarArray::GetMap(int32_t pos) const {

--- a/src/paimon/common/data/columnar/columnar_array.cpp
+++ b/src/paimon/common/data/columnar/columnar_array.cpp
@@ -46,8 +46,11 @@ Decimal ColumnarArray::GetDecimal(int32_t pos, int32_t precision, int32_t scale)
     auto array = arrow::internal::checked_cast<const ArrayType*>(array_);
     assert(array);
     arrow::Decimal128 decimal(array->GetValue(offset_ + pos));
-    return Decimal(precision, scale,
-                   static_cast<Decimal::int128_t>(decimal.high_bits()) << 64 | decimal.low_bits());
+    return Decimal(
+        precision, scale,
+        static_cast<Decimal::int128_t>(
+            static_cast<Decimal::uint128_t>(static_cast<uint64_t>(decimal.high_bits())) << 64 |
+            decimal.low_bits()));
 }
 
 Timestamp ColumnarArray::GetTimestamp(int32_t pos, int32_t precision) const {

--- a/src/paimon/common/data/columnar/columnar_array.h
+++ b/src/paimon/common/data/columnar/columnar_array.h
@@ -50,11 +50,16 @@ class Bytes;
 class MemoryPool;
 
 /// Columnar array to support access to vector column data.
+///
+/// NOTE: This class holds a non-owning raw pointer to the underlying arrow::Array for efficiency.
+/// The caller must ensure that the pointed-to Array outlives this ColumnarArray instance.
+/// Typically, lifetime is guaranteed by the owning ColumnarBatchContext or the parent
+/// arrow container (e.g., ListArray, MapArray) that holds the shared_ptr.
 class ColumnarArray : public InternalArray {
  public:
-    ColumnarArray(const std::shared_ptr<arrow::Array>& array,
-                  const std::shared_ptr<MemoryPool>& pool, int32_t offset, int32_t length)
-        : pool_(pool), array_(array.get()), offset_(offset), length_(length) {
+    ColumnarArray(const arrow::Array* array, const std::shared_ptr<MemoryPool>& pool,
+                  int32_t offset, int32_t length)
+        : pool_(pool), array_(array), offset_(offset), length_(length) {
         assert(array_);
         assert(array_->length() >= offset + length);
     }

--- a/src/paimon/common/data/columnar/columnar_array_test.cpp
+++ b/src/paimon/common/data/columnar/columnar_array_test.cpp
@@ -40,7 +40,7 @@ TEST(ColumnarArrayTest, TestSimple) {
                 arrow::list(arrow::boolean()), "[[true, false], [true], [false], [false, true]]")
                 .ValueOrDie();
         auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
-        auto array = ColumnarArray(list_array->values(), pool, /*offset=*/2, 1);
+        auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/2, 1);
         ASSERT_EQ(array.Size(), 1);
         ASSERT_EQ(array.GetBoolean(0), true);
         std::vector<char> expected_array = {static_cast<char>(1)};
@@ -51,7 +51,7 @@ TEST(ColumnarArrayTest, TestSimple) {
                                                             "[[1, 1, 2], [3], [2], [2]]")
                       .ValueOrDie();
         auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
-        auto array = ColumnarArray(list_array->values(), pool, /*offset=*/5, 1);
+        auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/5, 1);
         ASSERT_EQ(array.GetByte(0), 2);
         std::vector<char> expected_array = {static_cast<char>(2)};
         ASSERT_EQ(array.ToByteArray().value(), expected_array);
@@ -61,7 +61,7 @@ TEST(ColumnarArrayTest, TestSimple) {
                                                             "[[1, 1, 2], [3], [2], [-4]]")
                       .ValueOrDie();
         auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
-        auto array = ColumnarArray(list_array->values(), pool, /*offset=*/0, 3);
+        auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/0, 3);
         ASSERT_EQ(array.GetShort(0), 1);
         ASSERT_EQ(array.GetShort(1), 1);
         ASSERT_EQ(array.GetShort(2), 2);
@@ -73,7 +73,7 @@ TEST(ColumnarArrayTest, TestSimple) {
                                                             "[[1, 1, 2], [3], [2], [-4]]")
                       .ValueOrDie();
         auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
-        auto array = ColumnarArray(list_array->values(), pool, /*offset=*/3, 1);
+        auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/3, 1);
         ASSERT_EQ(array.GetInt(0), 3);
         std::vector<int32_t> expected_array = {3};
         ASSERT_EQ(array.ToIntArray().value(), expected_array);
@@ -83,7 +83,7 @@ TEST(ColumnarArrayTest, TestSimple) {
                                                             "[[1, 1, 2], [3], [2], [-4]]")
                       .ValueOrDie();
         auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
-        auto array = ColumnarArray(list_array->values(), pool, /*offset=*/4, 1);
+        auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/4, 1);
         ASSERT_EQ(array.GetLong(0), 2);
         std::vector<int64_t> expected_array = {2};
         ASSERT_EQ(array.ToLongArray().value(), expected_array);
@@ -93,7 +93,7 @@ TEST(ColumnarArrayTest, TestSimple) {
                                                             "[[1, 1, 2], [3], [null], null]")
                       .ValueOrDie();
         auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
-        auto array = ColumnarArray(list_array->values(), pool, /*offset=*/4, 1);
+        auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/4, 1);
         ASSERT_NOK_WITH_MSG(array.ToLongArray(), "is null");
     }
     {
@@ -101,7 +101,7 @@ TEST(ColumnarArrayTest, TestSimple) {
                       arrow::list(arrow::float32()), "[[0.0, 1.1, 2.2], [3.3], [4.4], [5.5]]")
                       .ValueOrDie();
         auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
-        auto array = ColumnarArray(list_array->values(), pool, /*offset=*/0, 3);
+        auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/0, 3);
         ASSERT_NEAR(array.GetFloat(1), 1.1, 0.001);
         std::vector<float> expected_array = {0.0, 1.1, 2.2};
         ASSERT_EQ(array.ToFloatArray().value(), expected_array);
@@ -111,7 +111,7 @@ TEST(ColumnarArrayTest, TestSimple) {
                       arrow::list(arrow::float64()), "[[0.0, 1.1, 2.2], [3.3], [4.4], [5.5]]")
                       .ValueOrDie();
         auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
-        auto array = ColumnarArray(list_array->values(), pool, /*offset=*/3, 1);
+        auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/3, 1);
         ASSERT_NEAR(array.GetDouble(0), 3.3, 0.001);
         std::vector<double> expected_array = {3.3};
         ASSERT_EQ(array.ToDoubleArray().value(), expected_array);
@@ -121,7 +121,7 @@ TEST(ColumnarArrayTest, TestSimple) {
                       arrow::list(arrow::utf8()), R"([["abc", "def"], ["efg"], ["hello"], ["hi"]])")
                       .ValueOrDie();
         auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
-        auto array = ColumnarArray(list_array->values(), pool, /*offset=*/4, 1);
+        auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/4, 1);
         ASSERT_EQ(array.GetString(0).ToString(), "hi");
         ASSERT_EQ(std::string(array.GetStringView(0)), "hi");
     }
@@ -134,7 +134,7 @@ TEST(ColumnarArrayTest, TestComplexAndNestedType) {
                                                             "[[1, 1, 2], [3], [2], [-4]]")
                       .ValueOrDie();
         auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
-        auto array = ColumnarArray(list_array->values(), pool, /*offset=*/3, 1);
+        auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/3, 1);
         ASSERT_EQ(array.GetDate(0), 3);
     }
     {
@@ -143,7 +143,7 @@ TEST(ColumnarArrayTest, TestComplexAndNestedType) {
                       R"([["1.234", "1234.000"], ["-9876.543"], ["666.888"]])")
                       .ValueOrDie();
         auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
-        auto array = ColumnarArray(list_array->values(), pool, /*offset=*/0, 2);
+        auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/0, 2);
         ASSERT_EQ(array.GetDecimal(0, 10, 3), Decimal(10, 3, 1234));
     }
     {
@@ -153,7 +153,7 @@ TEST(ColumnarArrayTest, TestComplexAndNestedType) {
           "1899-01-01T00:59:20"],["2033-05-18T03:33:20"]])")
                       .ValueOrDie();
         auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
-        auto array = ColumnarArray(list_array->values(), pool, /*offset=*/0, 1);
+        auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/0, 1);
         auto ts = array.GetTimestamp(0, 9);
         ASSERT_EQ(ts, Timestamp(59000, 0));
     }
@@ -162,7 +162,7 @@ TEST(ColumnarArrayTest, TestComplexAndNestedType) {
                                                             R"([["aaa", "bb"], ["ccc"], ["bbb"]])")
                       .ValueOrDie();
         auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
-        auto array = ColumnarArray(list_array->values(), pool, /*offset=*/0, 2);
+        auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/0, 2);
         ASSERT_EQ(*array.GetBinary(1), Bytes("bb", pool.get()));
         ASSERT_EQ(std::string(array.GetStringView(1)), "bb");
     }
@@ -181,7 +181,7 @@ TEST(ColumnarArrayTest, TestComplexAndNestedType) {
     ])")
                       .ValueOrDie();
         auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
-        auto array = ColumnarArray(list_array->values(), pool, /*offset=*/0, 2);
+        auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/0, 2);
         auto result_row = array.GetRow(1, 4);
         ASSERT_EQ(result_row->GetLong(0), 2);
         ASSERT_EQ(result_row->GetLong(1), 2);
@@ -193,7 +193,7 @@ TEST(ColumnarArrayTest, TestComplexAndNestedType) {
                       arrow::list(arrow::list(arrow::int64())), "[[[1, 2, 3], [4, 5, 6]], []]")
                       .ValueOrDie();
         auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
-        auto array = ColumnarArray(list_array->values(), pool, /*offset=*/0, 1);
+        auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/0, 1);
         auto result_array = array.GetArray(0);
         auto inner_result_array = array.GetArray(0);
         std::vector<int64_t> values = {1, 2, 3};
@@ -208,7 +208,7 @@ TEST(ColumnarArrayTest, TestComplexAndNestedType) {
                       .ValueOrDie();
         auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
         ASSERT_TRUE(list_array);
-        auto array = ColumnarArray(list_array->values(), pool, /*offset=*/0, 1);
+        auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/0, 1);
         auto result_key = array.GetMap(0)->KeyArray();
         auto result_value = array.GetMap(0)->ValueArray();
         ASSERT_EQ(result_key->ToIntArray().value(), std::vector<int32_t>({1, 4}));
@@ -225,7 +225,7 @@ TEST(ColumnarArrayTest, TestTimestampType) {
           "1899-01-01T00:59:20"],["2033-05-18T03:33:20"]])")
                       .ValueOrDie();
         auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
-        auto array = ColumnarArray(list_array->values(), pool, /*offset=*/1, 2);
+        auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/1, 2);
         auto ts = array.GetTimestamp(0, 0);
         ASSERT_EQ(ts, Timestamp(951866603000, 0)) << ts.GetMillisecond();
     }
@@ -236,7 +236,7 @@ TEST(ColumnarArrayTest, TestTimestampType) {
           "1899-01-01T00:59:20"],["2033-05-18T03:33:20"]])")
                       .ValueOrDie();
         auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
-        auto array = ColumnarArray(list_array->values(), pool, /*offset=*/1, 2);
+        auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/1, 2);
         auto ts = array.GetTimestamp(0, 3);
         ASSERT_EQ(ts, Timestamp(951866603001, 0)) << ts.GetMillisecond();
     }
@@ -247,7 +247,7 @@ TEST(ColumnarArrayTest, TestTimestampType) {
           "1899-01-01T00:59:20"],["2033-05-18T03:33:20"]])")
                       .ValueOrDie();
         auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
-        auto array = ColumnarArray(list_array->values(), pool, /*offset=*/1, 2);
+        auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/1, 2);
         auto ts = array.GetTimestamp(0, 6);
         ASSERT_EQ(ts, Timestamp(951866603001, 1000)) << ts.GetMillisecond();
     }
@@ -258,7 +258,7 @@ TEST(ColumnarArrayTest, TestTimestampType) {
           "1899-01-01T00:59:20"],["2033-05-18T03:33:20"]])")
                       .ValueOrDie();
         auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
-        auto array = ColumnarArray(list_array->values(), pool, /*offset=*/1, 2);
+        auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/1, 2);
         auto ts = array.GetTimestamp(0, 9);
         ASSERT_EQ(ts, Timestamp(951866603001, 1001)) << ts.GetMillisecond();
     }
@@ -269,7 +269,7 @@ TEST(ColumnarArrayTest, TestTimestampType) {
           "1899-01-01T00:59:20"],["2033-05-18T03:33:20"]])")
                       .ValueOrDie();
         auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
-        auto array = ColumnarArray(list_array->values(), pool, /*offset=*/1, 2);
+        auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/1, 2);
         auto ts = array.GetTimestamp(0, 0);
         ASSERT_EQ(ts, Timestamp(951866603000, 0)) << ts.GetMillisecond();
     }
@@ -280,7 +280,7 @@ TEST(ColumnarArrayTest, TestTimestampType) {
           "1899-01-01T00:59:20"],["2033-05-18T03:33:20"]])")
                       .ValueOrDie();
         auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
-        auto array = ColumnarArray(list_array->values(), pool, /*offset=*/1, 2);
+        auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/1, 2);
         auto ts = array.GetTimestamp(0, 3);
         ASSERT_EQ(ts, Timestamp(951866603001, 0)) << ts.GetMillisecond();
     }
@@ -291,7 +291,7 @@ TEST(ColumnarArrayTest, TestTimestampType) {
           "1899-01-01T00:59:20"],["2033-05-18T03:33:20"]])")
                       .ValueOrDie();
         auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
-        auto array = ColumnarArray(list_array->values(), pool, /*offset=*/1, 2);
+        auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/1, 2);
         auto ts = array.GetTimestamp(0, 6);
         ASSERT_EQ(ts, Timestamp(951866603001, 1000)) << ts.GetMillisecond();
     }
@@ -302,7 +302,7 @@ TEST(ColumnarArrayTest, TestTimestampType) {
           "1899-01-01T00:59:20"],["2033-05-18T03:33:20"]])")
                       .ValueOrDie();
         auto list_array = arrow::internal::checked_pointer_cast<arrow::ListArray>(f1);
-        auto array = ColumnarArray(list_array->values(), pool, /*offset=*/1, 2);
+        auto array = ColumnarArray(list_array->values().get(), pool, /*offset=*/1, 2);
         auto ts = array.GetTimestamp(0, 9);
         ASSERT_EQ(ts, Timestamp(951866603001, 1001)) << ts.GetMillisecond();
     }

--- a/src/paimon/common/data/columnar/columnar_map.cpp
+++ b/src/paimon/common/data/columnar/columnar_map.cpp
@@ -35,10 +35,10 @@ ColumnarMap::ColumnarMap(const std::shared_ptr<arrow::Array>& key_array,
       length_(length) {}
 
 std::shared_ptr<InternalArray> ColumnarMap::KeyArray() const {
-    return std::make_shared<ColumnarArray>(key_array_, pool_, offset_, length_);
+    return std::make_shared<ColumnarArray>(key_array_.get(), pool_, offset_, length_);
 }
 std::shared_ptr<InternalArray> ColumnarMap::ValueArray() const {
-    return std::make_shared<ColumnarArray>(value_array_, pool_, offset_, length_);
+    return std::make_shared<ColumnarArray>(value_array_.get(), pool_, offset_, length_);
 }
 
 }  // namespace paimon

--- a/src/paimon/common/data/columnar/columnar_row.cpp
+++ b/src/paimon/common/data/columnar/columnar_row.cpp
@@ -26,7 +26,9 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/decimal.h"
 #include "paimon/common/data/columnar/columnar_array.h"
+#include "paimon/common/data/columnar/columnar_batch_context.h"
 #include "paimon/common/data/columnar/columnar_map.h"
+#include "paimon/common/data/columnar/columnar_row_ref.h"
 #include "paimon/common/utils/date_time_utils.h"
 
 namespace paimon {
@@ -35,8 +37,11 @@ Decimal ColumnarRow::GetDecimal(int32_t pos, int32_t precision, int32_t scale) c
     auto array = arrow::internal::checked_cast<const ArrayType*>(array_vec_[pos]);
     assert(array);
     arrow::Decimal128 decimal(array->GetValue(row_id_));
-    return Decimal(precision, scale,
-                   static_cast<Decimal::int128_t>(decimal.high_bits()) << 64 | decimal.low_bits());
+    return Decimal(
+        precision, scale,
+        static_cast<Decimal::int128_t>(
+            static_cast<Decimal::uint128_t>(static_cast<uint64_t>(decimal.high_bits())) << 64 |
+            decimal.low_bits()));
 }
 
 Timestamp ColumnarRow::GetTimestamp(int32_t pos, int32_t precision) const {
@@ -57,6 +62,9 @@ Timestamp ColumnarRow::GetTimestamp(int32_t pos, int32_t precision) const {
 std::shared_ptr<InternalRow> ColumnarRow::GetRow(int32_t pos, int32_t num_fields) const {
     auto struct_array = arrow::internal::checked_cast<const arrow::StructArray*>(array_vec_[pos]);
     assert(struct_array);
+    // NOTE: For performance, the returned nested row does NOT hold shared ownership of the parent
+    // StructArray. Callers must ensure the parent ColumnarRow (or its underlying RecordBatch)
+    // outlives the returned row to avoid dangling pointers.
     return std::make_shared<ColumnarRow>(struct_array->fields(), pool_, row_id_);
 }
 

--- a/src/paimon/common/data/columnar/columnar_row.cpp
+++ b/src/paimon/common/data/columnar/columnar_row.cpp
@@ -65,7 +65,7 @@ std::shared_ptr<InternalArray> ColumnarRow::GetArray(int32_t pos) const {
     assert(list_array);
     int32_t offset = list_array->value_offset(row_id_);
     int32_t length = list_array->value_length(row_id_);
-    return std::make_shared<ColumnarArray>(list_array->values(), pool_, offset, length);
+    return std::make_shared<ColumnarArray>(list_array->values().get(), pool_, offset, length);
 }
 
 std::shared_ptr<InternalMap> ColumnarRow::GetMap(int32_t pos) const {

--- a/src/paimon/common/data/columnar/columnar_row.h
+++ b/src/paimon/common/data/columnar/columnar_row.h
@@ -46,10 +46,19 @@ class MemoryPool;
 /// Columnar row to support access to vector column data. It is a row view in arrow::Array.
 class ColumnarRow : public InternalRow {
  public:
+    /// @brief Construct a ColumnarRow without holding ownership of the underlying arrays.
+    /// @warning The caller MUST ensure the data source (e.g., RecordBatch or parent StructArray)
+    /// outlives this ColumnarRow. The internal array_vec_ stores raw pointers only; if the
+    /// source is freed first, these pointers will dangle. This design is intentional for
+    /// performance—avoiding per-row shared_ptr ref-count overhead on the hot read path.
     ColumnarRow(const arrow::ArrayVector& array_vec, const std::shared_ptr<MemoryPool>& pool,
                 int64_t row_id)
         : ColumnarRow(/*struct_array holder*/ nullptr, array_vec, pool, row_id) {}
 
+    /// @brief Construct a ColumnarRow that holds shared ownership of a StructArray.
+    /// @note When struct_array is non-null it keeps the underlying buffers alive, making it safe
+    /// to outlive the original batch. Prefer this overload when the row may escape the scope of
+    /// its parent container.
     ColumnarRow(const std::shared_ptr<arrow::StructArray>& struct_array,
                 const arrow::ArrayVector& array_vec, const std::shared_ptr<MemoryPool>& pool,
                 int64_t row_id)

--- a/src/paimon/common/data/columnar/columnar_row_ref.cpp
+++ b/src/paimon/common/data/columnar/columnar_row_ref.cpp
@@ -34,8 +34,11 @@ Decimal ColumnarRowRef::GetDecimal(int32_t pos, int32_t precision, int32_t scale
     auto array = arrow::internal::checked_cast<const ArrayType*>(ctx_->array_vec[pos].get());
     assert(array);
     arrow::Decimal128 decimal(array->GetValue(row_id_));
-    return Decimal(precision, scale,
-                   static_cast<Decimal::int128_t>(decimal.high_bits()) << 64 | decimal.low_bits());
+    return Decimal(
+        precision, scale,
+        static_cast<Decimal::int128_t>(
+            static_cast<Decimal::uint128_t>(static_cast<uint64_t>(decimal.high_bits())) << 64 |
+            decimal.low_bits()));
 }
 
 Timestamp ColumnarRowRef::GetTimestamp(int32_t pos, int32_t precision) const {

--- a/src/paimon/common/data/columnar/columnar_row_ref.cpp
+++ b/src/paimon/common/data/columnar/columnar_row_ref.cpp
@@ -67,7 +67,7 @@ std::shared_ptr<InternalArray> ColumnarRowRef::GetArray(int32_t pos) const {
     assert(list_array);
     int32_t offset = list_array->value_offset(row_id_);
     int32_t length = list_array->value_length(row_id_);
-    return std::make_shared<ColumnarArray>(list_array->values(), ctx_->pool, offset, length);
+    return std::make_shared<ColumnarArray>(list_array->values().get(), ctx_->pool, offset, length);
 }
 
 std::shared_ptr<InternalMap> ColumnarRowRef::GetMap(int32_t pos) const {

--- a/src/paimon/common/data/columnar/columnar_utils.h
+++ b/src/paimon/common/data/columnar/columnar_utils.h
@@ -65,7 +65,17 @@ class ColumnarUtils {
             auto value_type_id = dict_type->value_type()->id();
             auto index_type_id = dict_type->index_type()->id();
             int64_t dict_index = -1;
-            if (index_type_id == arrow::Type::type::INT32) {
+            if (index_type_id == arrow::Type::type::INT8) {
+                auto indices =
+                    arrow::internal::checked_cast<arrow::Int8Array*>(typed_array->indices().get());
+                assert(indices);
+                dict_index = indices->Value(pos);
+            } else if (index_type_id == arrow::Type::type::INT16) {
+                auto indices =
+                    arrow::internal::checked_cast<arrow::Int16Array*>(typed_array->indices().get());
+                assert(indices);
+                dict_index = indices->Value(pos);
+            } else if (index_type_id == arrow::Type::type::INT32) {
                 auto indices =
                     arrow::internal::checked_cast<arrow::Int32Array*>(typed_array->indices().get());
                 assert(indices);

--- a/src/paimon/common/data/decimal.cpp
+++ b/src/paimon/common/data/decimal.cpp
@@ -46,10 +46,10 @@ const int64_t Decimal::POWERS_OF_TEN[MAX_COMPACT_PRECISION + 1] = {1,
                                                                    10000000000000000l,
                                                                    100000000000000000l,
                                                                    1000000000000000000l};
-const Decimal::int128_t Decimal::INT128_MAXIMUM_VALUE =
-    static_cast<Decimal::int128_t>(0x7fffffffffffffff) << 64 | 0xffffffffffffffff;
+const Decimal::int128_t Decimal::INT128_MAXIMUM_VALUE = static_cast<Decimal::int128_t>(
+    static_cast<Decimal::uint128_t>(0x7fffffffffffffffULL) << 64 | 0xffffffffffffffff);
 const Decimal::int128_t Decimal::INT128_MINIMUM_VALUE =
-    static_cast<Decimal::int128_t>(0x8000000000000000) << 64;
+    static_cast<Decimal::int128_t>(static_cast<Decimal::uint128_t>(0x8000000000000000ULL) << 64);
 
 std::string Decimal::ToString() const {
     auto type = arrow::decimal128(Precision(), Scale());

--- a/src/paimon/common/file_index/bloomfilter/bloom_filter_file_index.cpp
+++ b/src/paimon/common/file_index/bloomfilter/bloom_filter_file_index.cpp
@@ -60,7 +60,11 @@ Result<std::shared_ptr<BloomFilterFileIndexReader>> BloomFilterFileIndexReader::
     const std::shared_ptr<arrow::DataType>& arrow_type, const std::shared_ptr<Bytes>& bytes) {
     // compatible with java, little endian
     const char* data = bytes->data();
-    int32_t num_hash_functions = ((data[0] << 24) + (data[1] << 16) + (data[2] << 8) + data[3]);
+    auto num_hash_functions =
+        static_cast<int32_t>((static_cast<uint32_t>(static_cast<uint8_t>(data[0])) << 24) |
+                             (static_cast<uint32_t>(static_cast<uint8_t>(data[1])) << 16) |
+                             (static_cast<uint32_t>(static_cast<uint8_t>(data[2])) << 8) |
+                             static_cast<uint32_t>(static_cast<uint8_t>(data[3])));
     PAIMON_ASSIGN_OR_RAISE(FastHash::HashFunction hash_function,
                            FastHash::GetHashFunction(arrow_type));
     auto bit_set = std::make_unique<BloomFilter64::BitSet>(bytes, /*offset=*/sizeof(int32_t));

--- a/src/paimon/common/file_index/bloomfilter/fast_hash.cpp
+++ b/src/paimon/common/file_index/bloomfilter/fast_hash.cpp
@@ -94,14 +94,39 @@ Result<FastHash::HashFunction> FastHash::GetHashFunction(
 }
 
 int64_t FastHash::GetLongHash(int64_t key) {
-    key = (~key) + (key << 21);  // key = (key << 21) - key - 1;
-    key = key ^ (key >> 24);
-    key = (key + (key << 3)) + (key << 8);  // key * 265
-    key = key ^ (key >> 14);
-    key = (key + (key << 2)) + (key << 4);  // key * 21
-    key = key ^ (key >> 28);
-    key = key + (key << 31);
-    return key;
+    // NOTE: This hash function must produce results identical to the Java implementation.
+    // Java uses two's-complement wrapping arithmetic and arithmetic right-shift (>>).
+
+    auto to_unsigned = [](int64_t v) -> uint64_t {
+        uint64_t result;
+        std::memcpy(&result, &v, sizeof(result));
+        return result;
+    };
+    auto to_signed = [](uint64_t v) -> int64_t {
+        int64_t result;
+        std::memcpy(&result, &v, sizeof(result));
+        return result;
+    };
+    // Arithmetic right-shift: shift unsigned then sign-extend from the top.
+    auto asr = [](uint64_t v, int32_t shift) -> uint64_t {
+        bool sign = (v >> 63) != 0;
+        uint64_t shifted = v >> shift;
+        if (sign) {
+            // Fill the top `shift` bits with 1s.
+            shifted |= ~(~static_cast<uint64_t>(0) >> shift);
+        }
+        return shifted;
+    };
+
+    uint64_t k = to_unsigned(key);
+    k = (~k) + (k << 21);  // key = (key << 21) - key - 1;
+    k = k ^ asr(k, 24);
+    k = (k + (k << 3)) + (k << 8);  // key * 265
+    k = k ^ asr(k, 14);
+    k = (k + (k << 2)) + (k << 4);  // key * 21
+    k = k ^ asr(k, 28);
+    k = k + (k << 31);
+    return to_signed(k);
 }
 
 int64_t FastHash::Hash64(const char* data, size_t length) {

--- a/src/paimon/common/memory/memory_segment.cpp
+++ b/src/paimon/common/memory/memory_segment.cpp
@@ -23,11 +23,8 @@ namespace paimon {
 int32_t MemorySegment::Compare(const MemorySegment& seg2, int32_t offset1, int32_t offset2,
                                int32_t len) const {
     while (len >= 8) {
-        // TODO(yonghao.fyh): support big endian, decide SmallEndian or BigEndian
-        // long l1 = GetLongBigEndian(offset1);
-        // long l2 = seg2.getLongBigEndian(offset2);
-        uint64_t l1 = GetValue<int64_t>(offset1);
-        uint64_t l2 = seg2.GetValue<int64_t>(offset2);
+        uint64_t l1 = GetLongBigEndian(offset1);
+        uint64_t l2 = seg2.GetLongBigEndian(offset2);
 
         if (l1 != l2) {
             return (l1 < l2) ? -1 : 1;

--- a/src/paimon/common/memory/memory_segment.h
+++ b/src/paimon/common/memory/memory_segment.h
@@ -22,6 +22,8 @@
 #include <memory>
 #include <type_traits>
 
+#include "paimon/common/utils/math.h"
+#include "paimon/io/byte_order.h"
 #include "paimon/memory/bytes.h"
 #include "paimon/visibility.h"
 
@@ -130,6 +132,14 @@ class PAIMON_EXPORT MemorySegment {
         static_assert(std::is_trivially_copyable_v<T>, "T must be trivially copyable");
 
         std::memcpy(MutableData() + index, &value, sizeof(T));
+    }
+
+    inline uint64_t GetLongBigEndian(int32_t index) const {
+        auto value = GetValue<uint64_t>(index);
+        if constexpr (SystemByteOrder() == ByteOrder::PAIMON_LITTLE_ENDIAN) {
+            return EndianSwapValue(value);
+        }
+        return value;
     }
 
     void CopyTo(int32_t offset, MemorySegment* target, int32_t target_offset,

--- a/src/paimon/common/memory/memory_segment_test.cpp
+++ b/src/paimon/common/memory/memory_segment_test.cpp
@@ -158,6 +158,32 @@ TEST(MemorySegmentTest, TestCompare) {
     seg2.Put(i + 8, static_cast<char>(10));
     ASSERT_EQ(seg1.Compare(seg2, i, i, 7, 7), 0);
     ASSERT_LT(seg1.Compare(seg2, i, i, 9, 9), 0);
+
+    // Verify big-endian byte-order comparison semantics within a single 8-byte block.
+    // On little-endian machines, naive native-endian uint64 comparison would give wrong results.
+    MemorySegment seg3 = MemorySegment::AllocateHeapMemory(16, pool.get());
+    MemorySegment seg4 = MemorySegment::AllocateHeapMemory(16, pool.get());
+    Bytes zeros(16, pool.get());
+    seg3.Put(0, zeros);
+    seg4.Put(0, zeros);
+
+    // seg3: [0x00, 0x01, 0, 0, 0, 0, 0, 0] at offset 0
+    // seg4: [0x01, 0x00, 0, 0, 0, 0, 0, 0] at offset 0
+    // Lexicographic (byte-order) comparison: first byte 0x00 < 0x01, so seg3 < seg4.
+    seg3.Put(1, static_cast<char>(0x01));
+    seg4.Put(0, static_cast<char>(0x01));
+    ASSERT_LT(seg3.Compare(seg4, 0, 0, 8), 0);
+    ASSERT_GT(seg4.Compare(seg3, 0, 0, 8), 0);
+
+    // seg3: [0x01, 0x02, 0, 0, 0, 0, 0, 0]
+    // seg4: [0x01, 0x01, 0, 0, 0, 0, 0, 0]
+    // First bytes equal (0x01 == 0x01), second byte 0x02 > 0x01, so seg3 > seg4.
+    seg3.Put(0, static_cast<char>(0x01));
+    seg3.Put(1, static_cast<char>(0x02));
+    seg4.Put(0, static_cast<char>(0x01));
+    seg4.Put(1, static_cast<char>(0x01));
+    ASSERT_GT(seg3.Compare(seg4, 0, 0, 8), 0);
+    ASSERT_LT(seg4.Compare(seg3, 0, 0, 8), 0);
 }
 
 TEST(MemorySegmentTest, TestCharAccess) {

--- a/src/paimon/common/memory/memory_segment_utils.cpp
+++ b/src/paimon/common/memory/memory_segment_utils.cpp
@@ -132,21 +132,21 @@ int32_t MemorySegmentUtils::ByteIndex(int32_t bit_index) {
 void MemorySegmentUtils::BitUnSet(MemorySegment* segment, int32_t base_offset, int32_t index) {
     int32_t offset = base_offset + ByteIndex(index);
     char current = segment->Get(offset);
-    current &= ~(1 << (index & BIT_BYTE_INDEX_MASK));
+    current &= static_cast<char>(~(1u << (index & BIT_BYTE_INDEX_MASK)));
     segment->Put(offset, current);
 }
 
 void MemorySegmentUtils::BitSet(MemorySegment* segment, int32_t base_offset, int32_t index) {
     int32_t offset = base_offset + ByteIndex(index);
     char current = segment->Get(offset);
-    current |= (1 << (index & BIT_BYTE_INDEX_MASK));
+    current |= static_cast<char>(1u << (index & BIT_BYTE_INDEX_MASK));
     segment->Put(offset, current);
 }
 
 bool MemorySegmentUtils::BitGet(const MemorySegment& segment, int32_t base_offset, int32_t index) {
     int32_t offset = base_offset + ByteIndex(index);
     char current = segment.Get(offset);
-    return (current & (1 << (index & BIT_BYTE_INDEX_MASK))) != 0;
+    return (current & static_cast<char>(1u << (index & BIT_BYTE_INDEX_MASK))) != 0;
 }
 
 void MemorySegmentUtils::BitSet(std::vector<MemorySegment>* segments, int32_t base_offset,
@@ -155,7 +155,7 @@ void MemorySegmentUtils::BitSet(std::vector<MemorySegment>* segments, int32_t ba
         int32_t offset = base_offset + ByteIndex(index);
         MemorySegment& segment = (*segments)[0];
         char current = segment.Get(offset);
-        current |= (1 << (index & BIT_BYTE_INDEX_MASK));
+        current |= static_cast<char>(1u << (index & BIT_BYTE_INDEX_MASK));
         segment.Put(offset, current);
     } else {
         BitSetMultiSegments(segments, base_offset, index);
@@ -171,7 +171,7 @@ void MemorySegmentUtils::BitSetMultiSegments(std::vector<MemorySegment>* segment
     MemorySegment& segment = (*segments)[seg_index];
 
     char current = segment.Get(seg_offset);
-    current |= (1 << (index & BIT_BYTE_INDEX_MASK));
+    current |= static_cast<char>(1u << (index & BIT_BYTE_INDEX_MASK));
     segment.Put(seg_offset, current);
 }
 
@@ -179,7 +179,7 @@ bool MemorySegmentUtils::BitGet(const std::vector<MemorySegment>& segments, int3
                                 int32_t index) {
     int32_t offset = base_offset + ByteIndex(index);
     char current = GetValue<char>(segments, offset);
-    return (current & (1 << (index & BIT_BYTE_INDEX_MASK))) != 0;
+    return (current & static_cast<char>(1u << (index & BIT_BYTE_INDEX_MASK))) != 0;
 }
 
 void MemorySegmentUtils::BitUnSet(std::vector<MemorySegment>* segments, int32_t base_offset,
@@ -188,7 +188,7 @@ void MemorySegmentUtils::BitUnSet(std::vector<MemorySegment>* segments, int32_t 
         MemorySegment& segment = (*segments)[0];
         int32_t offset = base_offset + ByteIndex(index);
         char current = segment.Get(offset);
-        current &= ~(1 << (index & BIT_BYTE_INDEX_MASK));
+        current &= static_cast<char>(~(1u << (index & BIT_BYTE_INDEX_MASK)));
         segment.Put(offset, current);
     } else {
         BitUnSetMultiSegments(segments, base_offset, index);
@@ -204,7 +204,7 @@ void MemorySegmentUtils::BitUnSetMultiSegments(std::vector<MemorySegment>* segme
     MemorySegment& segment = (*segments)[seg_index];
 
     char current = segment.Get(seg_offset);
-    current &= ~(1 << (index & BIT_BYTE_INDEX_MASK));
+    current &= static_cast<char>(~(1u << (index & BIT_BYTE_INDEX_MASK)));
     segment.Put(seg_offset, current);
 }
 

--- a/src/paimon/common/memory/memory_segment_utils.h
+++ b/src/paimon/common/memory/memory_segment_utils.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <type_traits>
 #include <vector>
 
 #include "fmt/format.h"
@@ -429,22 +430,31 @@ template <typename T>
 inline T MemorySegmentUtils::GetValueSlowly(const std::vector<MemorySegment>& segments,
                                             int32_t seg_size, int32_t seg_num, int32_t seg_offset) {
     MemorySegment segment = segments[seg_num];
-    T ret = 0;
-    for (size_t i = 0; i < sizeof(T); i++) {
+    if constexpr (std::is_same_v<T, bool>) {
         if (seg_offset == seg_size) {
             segment = segments[++seg_num];
             seg_offset = 0;
         }
-        T unsigned_byte = segment.Get(seg_offset) & 0xff;
-        if (SystemByteOrder() == ByteOrder::PAIMON_LITTLE_ENDIAN) {
-            ret |= (unsigned_byte << (i * 8));
-        } else {
-            int32_t shift_count = sizeof(T) - 1;
-            ret |= (unsigned_byte << ((shift_count - i) * 8));
+        return static_cast<bool>(static_cast<uint8_t>(segment.Get(seg_offset)));
+    } else {
+        using UnsignedT = std::make_unsigned_t<T>;
+        UnsignedT ret = 0;
+        for (size_t i = 0; i < sizeof(T); i++) {
+            if (seg_offset == seg_size) {
+                segment = segments[++seg_num];
+                seg_offset = 0;
+            }
+            UnsignedT unsigned_byte = static_cast<uint8_t>(segment.Get(seg_offset));
+            if (SystemByteOrder() == ByteOrder::PAIMON_LITTLE_ENDIAN) {
+                ret |= (unsigned_byte << (i * 8));
+            } else {
+                int32_t shift_count = sizeof(T) - 1;
+                ret |= (unsigned_byte << ((shift_count - i) * 8));
+            }
+            seg_offset++;
         }
-        seg_offset++;
+        return static_cast<T>(ret);
     }
-    return ret;
 }
 
 inline Status MemorySegmentUtils::CopyToStream(const std::vector<MemorySegment>& segments,

--- a/src/paimon/common/memory/memory_slice_output.cpp
+++ b/src/paimon/common/memory/memory_slice_output.cpp
@@ -94,6 +94,8 @@ void MemorySliceOutput::EnsureSize(int32_t size) {
     int32_t capacity = segment_.Size();
     int32_t min_capacity = segment_.Size() + size;
     while (capacity < min_capacity) {
+        // capacity is always a power-of-two and <= INT32_MAX/2 in practice,
+        // so this shift does not overflow.
         capacity <<= 1;
     }
 

--- a/src/paimon/common/predicate/literal_converter.cpp
+++ b/src/paimon/common/predicate/literal_converter.cpp
@@ -239,8 +239,9 @@ std::vector<Literal> LiteralConverter::GetLiteralFromDecimalArray(const arrow::A
             literals.emplace_back(FieldType::DECIMAL);
         } else {
             const arrow::Decimal128 decimal(array_.GetValue(i));
-            auto value =
-                static_cast<Decimal::int128_t>(decimal.high_bits()) << 64 | decimal.low_bits();
+            auto value = static_cast<Decimal::int128_t>(
+                static_cast<Decimal::uint128_t>(static_cast<uint64_t>(decimal.high_bits())) << 64 |
+                decimal.low_bits());
             literals.emplace_back(Decimal(precision, scale, value));
         }
     }

--- a/src/paimon/common/types/data_type_json_parser.cpp
+++ b/src/paimon/common/types/data_type_json_parser.cpp
@@ -267,6 +267,7 @@ std::vector<Token> Tokenize(const std::string& chars) {
             case CHAR_END_SUBTYPE:
                 tokens.emplace_back(TokenType::END_SUBTYPE, cursor,
                                     std::to_string(CHAR_END_SUBTYPE));
+                break;
             case CHAR_BEGIN_PARAMETER:
                 tokens.emplace_back(TokenType::BEGIN_PARAMETER, cursor,
                                     std::to_string(CHAR_BEGIN_PARAMETER));

--- a/src/paimon/common/utils/bit_set.cpp
+++ b/src/paimon/common/utils/bit_set.cpp
@@ -39,7 +39,7 @@ Status BitSet::Set(uint32_t index) {
     }
     uint32_t byte_index = index >> 3;
     auto val = segment_.Get(offset_ + byte_index);
-    val |= (1 << (index & BYTE_INDEX_MASK));
+    val |= static_cast<char>(1u << (index & BYTE_INDEX_MASK));
     segment_.PutValue(offset_ + byte_index, val);
     return Status::OK();
 }
@@ -50,7 +50,7 @@ bool BitSet::Get(uint32_t index) {
     }
     uint32_t byte_index = index >> 3;
     auto val = segment_.Get(offset_ + byte_index);
-    return (val & (1 << (index & BYTE_INDEX_MASK))) != 0;
+    return (val & static_cast<char>(1u << (index & BYTE_INDEX_MASK))) != 0;
 }
 
 void BitSet::Clear() {

--- a/src/paimon/common/utils/bit_set.h
+++ b/src/paimon/common/utils/bit_set.h
@@ -30,7 +30,8 @@ class MemoryPool;
 /// BitSet based on MemorySegment.
 class PAIMON_EXPORT BitSet {
  public:
-    explicit BitSet(int64_t byte_length) : byte_length_(byte_length), bit_size_(byte_length << 3) {}
+    explicit BitSet(int64_t byte_length)
+        : byte_length_(byte_length), bit_size_(static_cast<uint64_t>(byte_length) << 3) {}
 
     Status SetMemorySegment(MemorySegment segment, int32_t offset = 0);
     void UnsetMemorySegment();

--- a/src/paimon/common/utils/bloom_filter.cpp
+++ b/src/paimon/common/utils/bloom_filter.cpp
@@ -50,8 +50,8 @@ std::shared_ptr<BloomFilter> BloomFilter::Create(int64_t expect_entries, double 
 
 BloomFilter::BloomFilter(int64_t expected_entries, int32_t byte_length)
     : expected_entries_(expected_entries) {
-    num_hash_functions_ =
-        OptimalNumOfHashFunctions(expected_entries, static_cast<int64_t>(byte_length) << 3);
+    num_hash_functions_ = OptimalNumOfHashFunctions(
+        expected_entries, static_cast<int64_t>(static_cast<uint64_t>(byte_length) << 3));
     bit_set_ = std::make_shared<BitSet>(byte_length);
 }
 

--- a/src/paimon/common/utils/bloom_filter64.cpp
+++ b/src/paimon/common/utils/bloom_filter64.cpp
@@ -35,13 +35,13 @@ BloomFilter64::BitSet::BitSet(const std::shared_ptr<Bytes>& bytes, int32_t offse
 void BloomFilter64::BitSet::Set(int32_t index) {
     char* data = bytes_->data();
     data[(static_cast<uint32_t>(index) >> 3) + offset_] |=
-        static_cast<int8_t>(static_cast<int8_t>(1) << (index & BloomFilter64::BitSet::MASK));
+        static_cast<char>(1u << (index & BloomFilter64::BitSet::MASK));
 }
 
 bool BloomFilter64::BitSet::Get(int32_t index) const {
     const char* data = bytes_->data();
     return (data[(static_cast<uint32_t>(index) >> 3) + offset_] &
-            (static_cast<int8_t>(1) << (index & BloomFilter64::BitSet::MASK))) != 0;
+            static_cast<char>(1u << (index & BloomFilter64::BitSet::MASK))) != 0;
 }
 
 int32_t BloomFilter64::BitSet::BitSize() const {

--- a/src/paimon/common/utils/var_length_int_utils.h
+++ b/src/paimon/common/utils/var_length_int_utils.h
@@ -87,14 +87,20 @@ class VarLengthIntUtils {
             ++(*offset);
             return static_cast<int32_t>(first_byte);
         }
-        // Multi-byte: fall through to generic loop
-        int32_t result = 0;
+        // Multi-byte: fall through to generic loop.
+        // NOTE: EncodeInt only encodes non-negative values, so a decoded negative result
+        // indicates malformed data.
+        uint32_t result = 0;
         for (int32_t shift = 0; shift < 32; shift += 7) {
             auto byte_val = static_cast<uint8_t>(data[*offset]);
             ++(*offset);
-            result |= static_cast<int32_t>(byte_val & 0x7F) << shift;
+            result |= static_cast<uint32_t>(byte_val & 0x7F) << shift;
             if ((byte_val & 0x80) == 0) {
-                return result;
+                auto signed_result = static_cast<int32_t>(result);
+                if (PAIMON_UNLIKELY(signed_result < 0)) {
+                    return Status::Invalid("Malformed varint32: decoded negative value");
+                }
+                return signed_result;
             }
         }
         return Status::Invalid("Malformed varint32: too many continuation bytes");
@@ -108,14 +114,20 @@ class VarLengthIntUtils {
             ++(*offset);
             return static_cast<int64_t>(first_byte);
         }
-        // Multi-byte: fall through to generic loop
-        int64_t result = 0;
+        // Multi-byte: fall through to generic loop.
+        // NOTE: EncodeLong only encodes non-negative values, so a decoded negative result
+        // indicates malformed data.
+        uint64_t result = 0;
         for (int32_t shift = 0; shift < 64; shift += 7) {
             auto byte_val = static_cast<uint8_t>(data[*offset]);
             ++(*offset);
-            result |= static_cast<int64_t>(byte_val & 0x7F) << shift;
+            result |= static_cast<uint64_t>(byte_val & 0x7F) << shift;
             if ((byte_val & 0x80) == 0) {
-                return result;
+                auto signed_result = static_cast<int64_t>(result);
+                if (PAIMON_UNLIKELY(signed_result < 0)) {
+                    return Status::Invalid("Malformed varint64: decoded negative value");
+                }
+                return signed_result;
             }
         }
         return Status::Invalid("Malformed varint64: too many continuation bytes");

--- a/src/paimon/core/bucket/bucket_id_calculator.cpp
+++ b/src/paimon/core/bucket/bucket_id_calculator.cpp
@@ -227,8 +227,11 @@ static Result<WriteFunction> WriteBucketRow(int32_t col_id,
                 }
                 arrow::Decimal128 decimal128(typed_array->GetValue(row_id));
                 Decimal decimal(precision, scale,
-                                static_cast<Decimal::int128_t>(decimal128.high_bits()) << 64 |
-                                    decimal128.low_bits());
+                                static_cast<Decimal::int128_t>(
+                                    static_cast<Decimal::uint128_t>(
+                                        static_cast<uint64_t>(decimal128.high_bits()))
+                                        << 64 |
+                                    decimal128.low_bits()));
                 row_writer->WriteDecimal(col_id, decimal, precision);
             };
             return writer_func;

--- a/src/paimon/core/casting/boolean_to_decimal_cast_executor.cpp
+++ b/src/paimon/core/casting/boolean_to_decimal_cast_executor.cpp
@@ -55,10 +55,12 @@ Result<Literal> BooleanToDecimalCastExecutor::Cast(
     if (scaled_decimal == std::nullopt) {
         return Literal(FieldType::DECIMAL);
     }
-    return Literal(
-        Decimal(decimal_type->precision(), decimal_type->scale(),
-                static_cast<Decimal::int128_t>(scaled_decimal.value().high_bits()) << 64 |
-                    scaled_decimal.value().low_bits()));
+    return Literal(Decimal(
+        decimal_type->precision(), decimal_type->scale(),
+        static_cast<Decimal::int128_t>(static_cast<Decimal::uint128_t>(static_cast<uint64_t>(
+                                           scaled_decimal.value().high_bits()))
+                                           << 64 |
+                                       scaled_decimal.value().low_bits())));
 }
 
 Result<std::shared_ptr<arrow::Array>> BooleanToDecimalCastExecutor::Cast(

--- a/src/paimon/core/casting/decimal_to_decimal_cast_executor.cpp
+++ b/src/paimon/core/casting/decimal_to_decimal_cast_executor.cpp
@@ -56,10 +56,12 @@ Result<Literal> DecimalToDecimalCastExecutor::Cast(
     if (scaled_decimal == std::nullopt) {
         return Literal(FieldType::DECIMAL);
     }
-    return Literal(
-        Decimal(target_decimal_type->precision(), target_decimal_type->scale(),
-                static_cast<Decimal::int128_t>(scaled_decimal.value().high_bits()) << 64 |
-                    scaled_decimal.value().low_bits()));
+    return Literal(Decimal(
+        target_decimal_type->precision(), target_decimal_type->scale(),
+        static_cast<Decimal::int128_t>(static_cast<Decimal::uint128_t>(static_cast<uint64_t>(
+                                           scaled_decimal.value().high_bits()))
+                                           << 64 |
+                                       scaled_decimal.value().low_bits())));
 }
 
 Result<std::shared_ptr<arrow::Array>> DecimalToDecimalCastExecutor::Cast(

--- a/src/paimon/core/casting/numeric_primitive_to_decimal_cast_executor.cpp
+++ b/src/paimon/core/casting/numeric_primitive_to_decimal_cast_executor.cpp
@@ -59,20 +59,24 @@ Result<Literal> NumericPrimitiveToDecimalCastExecutor::Cast(
         auto decimal_result = arrow::Decimal128::FromReal(src_value, decimal_type->precision(),
                                                           decimal_type->scale());
         if (decimal_result.ok()) {
-            return Literal{Decimal(
-                decimal_type->precision(), decimal_type->scale(),
-                static_cast<Decimal::int128_t>(decimal_result.ValueUnsafe().high_bits()) << 64 |
-                    decimal_result.ValueUnsafe().low_bits())};
+            return Literal{Decimal(decimal_type->precision(), decimal_type->scale(),
+                                   static_cast<Decimal::int128_t>(
+                                       static_cast<Decimal::uint128_t>(static_cast<uint64_t>(
+                                           decimal_result.ValueUnsafe().high_bits()))
+                                           << 64 |
+                                       decimal_result.ValueUnsafe().low_bits()))};
         }
     } else {
         auto scaled_decimal = DecimalUtils::RescaleDecimalWithOverflowCheck(
             arrow::Decimal128(src_value), /*src_scale=*/0, decimal_type->precision(),
             decimal_type->scale());
         if (scaled_decimal != std::nullopt) {
-            return Literal(
-                Decimal(decimal_type->precision(), decimal_type->scale(),
-                        static_cast<Decimal::int128_t>(scaled_decimal.value().high_bits()) << 64 |
-                            scaled_decimal.value().low_bits()));
+            return Literal(Decimal(decimal_type->precision(), decimal_type->scale(),
+                                   static_cast<Decimal::int128_t>(
+                                       static_cast<Decimal::uint128_t>(static_cast<uint64_t>(
+                                           scaled_decimal.value().high_bits()))
+                                           << 64 |
+                                       scaled_decimal.value().low_bits())));
         }
     }
     return Literal(FieldType::DECIMAL);

--- a/src/paimon/core/casting/string_to_decimal_cast_executor.cpp
+++ b/src/paimon/core/casting/string_to_decimal_cast_executor.cpp
@@ -67,10 +67,12 @@ Result<Literal> StringToDecimalCastExecutor::Cast(
     if (scaled_decimal == std::nullopt) {
         return Literal(FieldType::DECIMAL);
     }
-    return Literal(
-        Decimal(decimal_type->precision(), decimal_type->scale(),
-                static_cast<Decimal::int128_t>(scaled_decimal.value().high_bits()) << 64 |
-                    scaled_decimal.value().low_bits()));
+    return Literal(Decimal(
+        decimal_type->precision(), decimal_type->scale(),
+        static_cast<Decimal::int128_t>(static_cast<Decimal::uint128_t>(static_cast<uint64_t>(
+                                           scaled_decimal.value().high_bits()))
+                                           << 64 |
+                                       scaled_decimal.value().low_bits())));
 }
 
 Result<std::shared_ptr<arrow::Array>> StringToDecimalCastExecutor::Cast(

--- a/src/paimon/format/blob/blob_file_batch_reader.cpp
+++ b/src/paimon/format/blob/blob_file_batch_reader.cpp
@@ -317,8 +317,11 @@ Status BlobFileBatchReader::ReadBlobContentAt(const int64_t offset, const int64_
 }
 
 int32_t BlobFileBatchReader::GetIndexLength(const int8_t* bytes, int32_t offset) {
-    return (bytes[offset + 3] << 24) | ((bytes[offset + 2] & 0xff) << 16) |
-           ((bytes[offset + 1] & 0xff) << 8) | (bytes[offset] & 0xff);
+    return static_cast<int32_t>(
+        (static_cast<uint32_t>(static_cast<uint8_t>(bytes[offset + 3])) << 24) |
+        (static_cast<uint32_t>(static_cast<uint8_t>(bytes[offset + 2])) << 16) |
+        (static_cast<uint32_t>(static_cast<uint8_t>(bytes[offset + 1])) << 8) |
+        static_cast<uint32_t>(static_cast<uint8_t>(bytes[offset])));
 }
 
 // Note: blob file has no self-describing schema, use read schema instead.

--- a/src/paimon/format/orc/orc_stats_extractor.cpp
+++ b/src/paimon/format/orc/orc_stats_extractor.cpp
@@ -265,9 +265,11 @@ Result<std::unique_ptr<ColumnStats>> OrcStatsExtractor::FetchColumnStatistics(
             }
             auto min_decimal = typed_stats->getMinimum();
             Decimal min_value(precision, min_decimal.scale,
-                              static_cast<Decimal::int128_t>(min_decimal.value.getHighBits())
+                              static_cast<Decimal::int128_t>(
+                                  static_cast<Decimal::uint128_t>(
+                                      static_cast<uint64_t>(min_decimal.value.getHighBits()))
                                       << 64 |
-                                  min_decimal.value.getLowBits());
+                                  min_decimal.value.getLowBits()));
             std::shared_ptr<arrow::DataType> target_type = arrow::decimal128(precision, scale);
             auto cast_executor = std::make_shared<DecimalToDecimalCastExecutor>();
             if (min_decimal.scale != scale) {
@@ -278,9 +280,11 @@ Result<std::unique_ptr<ColumnStats>> OrcStatsExtractor::FetchColumnStatistics(
             }
             auto max_decimal = typed_stats->getMaximum();
             Decimal max_value(precision, max_decimal.scale,
-                              static_cast<Decimal::int128_t>(max_decimal.value.getHighBits())
+                              static_cast<Decimal::int128_t>(
+                                  static_cast<Decimal::uint128_t>(
+                                      static_cast<uint64_t>(max_decimal.value.getHighBits()))
                                       << 64 |
-                                  max_decimal.value.getLowBits());
+                                  max_decimal.value.getLowBits()));
             if (max_decimal.scale != scale) {
                 // need casting
                 PAIMON_ASSIGN_OR_RAISE(Literal converted_max_value,


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
No Linked issue.

| PR | Commit | Title |
|---|---|---|
| #298 | `19ee2c1` | fix: Fix MemorySegment::Compare big-endian comparison |
| #299 | `8bf2ede` | fix: add break for CHAR_END_SUBTYPE |
| #301 | `6f18879` | chore(license): refine build support notices |
| #303 | `ecae61e` | fix: Fix undefined behavior in BinarySection bitmask |
| #305 | `bfac838` | refactor: ColumnarArray constructor raw pointer |
| #308 | `9777c30` | fix: fix undefined behavior in bitwise left-shift |

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
