### PR TITLE
refact: Reuse RowGroupPageIndexReader across columns to improve page-level predicate pushdown performance regression on wide tables

### DIFF
--- a/src/paimon/format/parquet/page_filtered_row_group_reader.cpp
+++ b/src/paimon/format/parquet/page_filtered_row_group_reader.cpp
@@ -138,9 +138,10 @@ std::pair<RowRanges, int64_t> PageFilteredRowGroupReader::ComputeCompressedRowRa
 Result<std::shared_ptr<arrow::ChunkedArray>> PageFilteredRowGroupReader::ReadFilteredColumn(
     const std::shared_ptr<::parquet::RowGroupReader>& row_group_reader,
     ::parquet::ParquetFileReader* parquet_reader,
-    const std::shared_ptr<::parquet::RowGroupPageIndexReader>& rg_page_index_reader, int32_t row_group_index,
-    int32_t column_index, const RowRanges& row_ranges, const std::shared_ptr<arrow::Field>& field,
-    int64_t row_group_row_count, ::arrow::MemoryPool* pool) {
+    const std::shared_ptr<::parquet::RowGroupPageIndexReader>& rg_page_index_reader,
+    int32_t row_group_index, int32_t column_index, const RowRanges& row_ranges,
+    const std::shared_ptr<arrow::Field>& field, int64_t row_group_row_count,
+    ::arrow::MemoryPool* pool) {
     auto file_metadata = parquet_reader->metadata();
     const auto* col_descriptor = file_metadata->schema()->Column(column_index);
 
@@ -260,7 +261,8 @@ Result<std::unique_ptr<arrow::RecordBatchReader>> PageFilteredRowGroupReader::Re
     int64_t row_group_row_count = rg_metadata->num_rows();
     auto page_index_reader = parquet_reader->GetPageIndexReader();
 
-    // reuse RowGroupPageIndexReader for multiple columns in the same row group to avoid redundant metadata reads
+    // reuse RowGroupPageIndexReader for multiple columns in the same row group to avoid redundant
+    // metadata reads
     std::shared_ptr<::parquet::RowGroupPageIndexReader> rg_page_index_reader;
     if (page_index_reader) {
         rg_page_index_reader = page_index_reader->RowGroup(row_group_index);
@@ -273,8 +275,8 @@ Result<std::unique_ptr<arrow::RecordBatchReader>> PageFilteredRowGroupReader::Re
     for (size_t i = 0; i < column_indices.size(); ++i) {
         PAIMON_ASSIGN_OR_RAISE(
             std::shared_ptr<arrow::ChunkedArray> chunked_array,
-            ReadFilteredColumn(row_group_reader, parquet_reader, rg_page_index_reader, row_group_index,
-                               column_indices[i], row_ranges,
+            ReadFilteredColumn(row_group_reader, parquet_reader, rg_page_index_reader,
+                               row_group_index, column_indices[i], row_ranges,
                                arrow_schema->field(static_cast<int>(i)), row_group_row_count,
                                pool));
 

--- a/src/paimon/format/parquet/page_filtered_row_group_reader.cpp
+++ b/src/paimon/format/parquet/page_filtered_row_group_reader.cpp
@@ -138,7 +138,7 @@ std::pair<RowRanges, int64_t> PageFilteredRowGroupReader::ComputeCompressedRowRa
 Result<std::shared_ptr<arrow::ChunkedArray>> PageFilteredRowGroupReader::ReadFilteredColumn(
     const std::shared_ptr<::parquet::RowGroupReader>& row_group_reader,
     ::parquet::ParquetFileReader* parquet_reader,
-    const std::shared_ptr<::parquet::PageIndexReader>& page_index_reader, int32_t row_group_index,
+    const std::shared_ptr<::parquet::RowGroupPageIndexReader>& rg_page_index_reader, int32_t row_group_index,
     int32_t column_index, const RowRanges& row_ranges, const std::shared_ptr<arrow::Field>& field,
     int64_t row_group_row_count, ::arrow::MemoryPool* pool) {
     auto file_metadata = parquet_reader->metadata();
@@ -149,11 +149,8 @@ Result<std::shared_ptr<arrow::ChunkedArray>> PageFilteredRowGroupReader::ReadFil
     int64_t effective_row_count = row_group_row_count;
 
     std::shared_ptr<::parquet::OffsetIndex> offset_index;
-    if (page_index_reader) {
-        auto rg_page_index_reader = page_index_reader->RowGroup(row_group_index);
-        if (rg_page_index_reader) {
-            offset_index = rg_page_index_reader->GetOffsetIndex(column_index);
-        }
+    if (rg_page_index_reader) {
+        offset_index = rg_page_index_reader->GetOffsetIndex(column_index);
     }
 
     auto page_reader = row_group_reader->GetColumnPageReader(column_index);
@@ -263,6 +260,12 @@ Result<std::unique_ptr<arrow::RecordBatchReader>> PageFilteredRowGroupReader::Re
     int64_t row_group_row_count = rg_metadata->num_rows();
     auto page_index_reader = parquet_reader->GetPageIndexReader();
 
+    // reuse RowGroupPageIndexReader for multiple columns in the same row group to avoid redundant metadata reads
+    std::shared_ptr<::parquet::RowGroupPageIndexReader> rg_page_index_reader;
+    if (page_index_reader) {
+        rg_page_index_reader = page_index_reader->RowGroup(row_group_index);
+    }
+
     // Read each column with page filtering
     std::vector<std::shared_ptr<arrow::ChunkedArray>> columns;
     columns.reserve(column_indices.size());
@@ -270,7 +273,7 @@ Result<std::unique_ptr<arrow::RecordBatchReader>> PageFilteredRowGroupReader::Re
     for (size_t i = 0; i < column_indices.size(); ++i) {
         PAIMON_ASSIGN_OR_RAISE(
             std::shared_ptr<arrow::ChunkedArray> chunked_array,
-            ReadFilteredColumn(row_group_reader, parquet_reader, page_index_reader, row_group_index,
+            ReadFilteredColumn(row_group_reader, parquet_reader, rg_page_index_reader, row_group_index,
                                column_indices[i], row_ranges,
                                arrow_schema->field(static_cast<int>(i)), row_group_row_count,
                                pool));

--- a/src/paimon/format/parquet/page_filtered_row_group_reader.h
+++ b/src/paimon/format/parquet/page_filtered_row_group_reader.h
@@ -90,7 +90,7 @@ class PageFilteredRowGroupReader {
     static Result<std::shared_ptr<arrow::ChunkedArray>> ReadFilteredColumn(
         const std::shared_ptr<::parquet::RowGroupReader>& row_group_reader,
         ::parquet::ParquetFileReader* parquet_reader,
-        const std::shared_ptr<::parquet::PageIndexReader>& page_index_reader,
+        const std::shared_ptr<::parquet::RowGroupPageIndexReader>& rg_page_index_reader,
         int32_t row_group_index, int32_t column_index, const RowRanges& row_ranges,
         const std::shared_ptr<arrow::Field>& field, int64_t row_group_row_count,
         ::arrow::MemoryPool* pool);


### PR DESCRIPTION

<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #137 

<!-- What is the purpose of the change -->

In `PageFilteredRowGroupReader::ReadFilteredRowGroup`, the original implementation passed PageIndexReader into ReadFilteredColumn, where each column called `page_index_reader->RowGroup(row_group_index)` to reconstruct a `RowGroupPageIndexReader`. The `RowGroup()` call reads and parses **all** ColumnIndex and OffsetIndex metadata for every column in that row group. For wide tables (hundreds or even thousands of columns), the same metadata was redundantly read N times (N = number of columns being read), causing page index read time to scale linearly and resulting in a significant performance drop for point-query scenarios where page-level predicate pushdown was supposed to help.


Fix: Simply Hoist the RowGroupPageIndexReader creation out of the per-column loop in ReadFilteredRowGroup — construct it once and reuse it across all columns. Change the ReadFilteredColumn parameter type from PageIndexReader to RowGroupPageIndexReader, eliminating redundant metadata reads.


### Tests

<!-- List UT and IT cases to verify this change -->
On a test case with a wide table containing over 1,000 columns, the original code took significantly longer to execute queries. The flamegraph clearly shows that RowGroup() consumed a substantial portion of the total execution time:
<img width="1576" height="1090" alt="image" src="https://github.com/user-attachments/assets/462b9877-51e1-4480-9c13-b11889f45740" />
<img width="2758" height="1056" alt="image" src="https://github.com/user-attachments/assets/907a71c8-9492-483d-8d7d-5b81050d5619" />


After applying the changes in this PR, range query performance on the wide table shows a significant improvement:
<img width="1670" height="1080" alt="image" src="https://github.com/user-attachments/assets/beae1567-2cb8-4552-9a9f-4a6ec671e772" />

The redundant RowGroup() calls are no longer visible in the flamegraph:
<img width="2750" height="978" alt="image" src="https://github.com/user-attachments/assets/7a52bbed-fbac-46b9-b81a-57c7acaf8804" />


### API and Format

Not API and format changes.
<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

No new features were introduced.
<!-- Does this change introduce a new feature -->

### Generative AI tooling

Claude code (Opus 4.6)
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->