### PR TITLE
fix: avoid signed integer overflow UB in BloomFilter and DeltaVarintCompressor

### DIFF
--- a/src/paimon/common/utils/bloom_filter.cpp
+++ b/src/paimon/common/utils/bloom_filter.cpp
@@ -59,7 +59,10 @@ Status BloomFilter::AddHash(int32_t hash1) {
     auto hash2 = static_cast<int32_t>(static_cast<uint32_t>(hash1) >> 16);
 
     for (int32_t i = 1; i <= num_hash_functions_; i++) {
-        int32_t combined_hash = hash1 + (i * hash2);
+        // Use uint32_t arithmetic to avoid signed overflow UB (matches Java int wrap semantics)
+        int32_t combined_hash =
+            static_cast<int32_t>(static_cast<uint32_t>(hash1) +
+                                 (static_cast<uint32_t>(i) * static_cast<uint32_t>(hash2)));
         // hashcode should be positive, flip all the bits if it's negative
         if (combined_hash < 0) {
             combined_hash = ~combined_hash;
@@ -74,7 +77,10 @@ bool BloomFilter::TestHash(int32_t hash1) const {
     auto hash2 = static_cast<int32_t>(static_cast<uint32_t>(hash1) >> 16);
 
     for (int32_t i = 1; i <= num_hash_functions_; i++) {
-        int32_t combined_hash = hash1 + (i * hash2);
+        // Use uint32_t arithmetic to avoid signed overflow UB (matches Java int wrap semantics)
+        int32_t combined_hash =
+            static_cast<int32_t>(static_cast<uint32_t>(hash1) +
+                                 (static_cast<uint32_t>(i) * static_cast<uint32_t>(hash2)));
         // hashcode should be positive, flip all the bits if it's negative
         if (combined_hash < 0) {
             combined_hash = ~combined_hash;

--- a/src/paimon/common/utils/bloom_filter.cpp
+++ b/src/paimon/common/utils/bloom_filter.cpp
@@ -60,7 +60,7 @@ Status BloomFilter::AddHash(int32_t hash1) {
 
     for (int32_t i = 1; i <= num_hash_functions_; i++) {
         // Use uint32_t arithmetic to avoid signed overflow UB (matches Java int wrap semantics)
-        int32_t combined_hash =
+        auto combined_hash =
             static_cast<int32_t>(static_cast<uint32_t>(hash1) +
                                  (static_cast<uint32_t>(i) * static_cast<uint32_t>(hash2)));
         // hashcode should be positive, flip all the bits if it's negative
@@ -78,7 +78,7 @@ bool BloomFilter::TestHash(int32_t hash1) const {
 
     for (int32_t i = 1; i <= num_hash_functions_; i++) {
         // Use uint32_t arithmetic to avoid signed overflow UB (matches Java int wrap semantics)
-        int32_t combined_hash =
+        auto combined_hash =
             static_cast<int32_t>(static_cast<uint32_t>(hash1) +
                                  (static_cast<uint32_t>(i) * static_cast<uint32_t>(hash2)));
         // hashcode should be positive, flip all the bits if it's negative

--- a/src/paimon/common/utils/bloom_filter64.cpp
+++ b/src/paimon/common/utils/bloom_filter64.cpp
@@ -68,7 +68,10 @@ void BloomFilter64::AddHash(int64_t hash64) {
     auto hash2 = static_cast<int32_t>(static_cast<uint64_t>(hash64) >> 32);
 
     for (int32_t i = 1; i <= num_hash_functions_; i++) {
-        int32_t combined_hash = hash1 + (i * hash2);
+        // Use uint32_t arithmetic to avoid signed overflow UB (matches Java int wrap semantics)
+        int32_t combined_hash =
+            static_cast<int32_t>(static_cast<uint32_t>(hash1) +
+                                 (static_cast<uint32_t>(i) * static_cast<uint32_t>(hash2)));
         // hashcode should be positive, flip all the bits if it's negative
         if (combined_hash < 0) {
             combined_hash = ~combined_hash;
@@ -83,7 +86,10 @@ bool BloomFilter64::TestHash(int64_t hash64) const {
     auto hash2 = static_cast<int32_t>(static_cast<uint64_t>(hash64) >> 32);
 
     for (int32_t i = 1; i <= num_hash_functions_; i++) {
-        int32_t combined_hash = hash1 + (i * hash2);
+        // Use uint32_t arithmetic to avoid signed overflow UB (matches Java int wrap semantics)
+        int32_t combined_hash =
+            static_cast<int32_t>(static_cast<uint32_t>(hash1) +
+                                 (static_cast<uint32_t>(i) * static_cast<uint32_t>(hash2)));
         // hashcode should be positive, flip all the bits if it's negative
         if (combined_hash < 0) {
             combined_hash = ~combined_hash;

--- a/src/paimon/common/utils/bloom_filter64.cpp
+++ b/src/paimon/common/utils/bloom_filter64.cpp
@@ -69,7 +69,7 @@ void BloomFilter64::AddHash(int64_t hash64) {
 
     for (int32_t i = 1; i <= num_hash_functions_; i++) {
         // Use uint32_t arithmetic to avoid signed overflow UB (matches Java int wrap semantics)
-        int32_t combined_hash =
+        auto combined_hash =
             static_cast<int32_t>(static_cast<uint32_t>(hash1) +
                                  (static_cast<uint32_t>(i) * static_cast<uint32_t>(hash2)));
         // hashcode should be positive, flip all the bits if it's negative
@@ -87,7 +87,7 @@ bool BloomFilter64::TestHash(int64_t hash64) const {
 
     for (int32_t i = 1; i <= num_hash_functions_; i++) {
         // Use uint32_t arithmetic to avoid signed overflow UB (matches Java int wrap semantics)
-        int32_t combined_hash =
+        auto combined_hash =
             static_cast<int32_t>(static_cast<uint32_t>(hash1) +
                                  (static_cast<uint32_t>(i) * static_cast<uint32_t>(hash2)));
         // hashcode should be positive, flip all the bits if it's negative

--- a/src/paimon/common/utils/delta_varint_compressor.cpp
+++ b/src/paimon/common/utils/delta_varint_compressor.cpp
@@ -30,12 +30,14 @@ std::vector<char> DeltaVarintCompressor::Compress(const std::vector<int64_t>& da
         return {};
     }
 
-    // 1. Delta encoding
+    // 1. Delta encoding (use unsigned subtraction to avoid signed overflow UB)
     std::vector<int64_t> deltas;
     deltas.reserve(data.size());
     deltas.push_back(data[0]);
     for (size_t i = 1; i < data.size(); i++) {
-        deltas.push_back(data[i] - data[i - 1]);
+        uint64_t unsigned_delta =
+            static_cast<uint64_t>(data[i]) - static_cast<uint64_t>(data[i - 1]);
+        deltas.push_back(static_cast<int64_t>(unsigned_delta));
     }
 
     // 2. ZigZag + Varint
@@ -61,11 +63,13 @@ Result<std::vector<int64_t>> DeltaVarintCompressor::Decompress(const std::vector
         deltas.push_back(delta);
     }
 
-    // 2. Delta decoding
+    // 2. Delta decoding (use unsigned addition to avoid signed overflow UB)
     std::vector<int64_t> result(deltas.size());
     result[0] = deltas[0];
     for (size_t i = 1; i < result.size(); i++) {
-        result[i] = result[i - 1] + deltas[i];
+        uint64_t reconstructed =
+            static_cast<uint64_t>(result[i - 1]) + static_cast<uint64_t>(deltas[i]);
+        result[i] = static_cast<int64_t>(reconstructed);
     }
     return result;
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
No Linked issue.
Fixes signed integer overflow undefined behavior (UB) in utility classes (`bloom_filter.cpp`, `bloom_filter64.cpp`, `delta_varint_compressor.cpp` ). Both issues stem from porting Java integer arithmetic (which wraps mod 2^N) directly to C++ signed types (where signed overflow is UB and may fail under UBSan or compiler optimization).
<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
