### PR TITLE
fix: fix unstable prefetch reader case

### DIFF
--- a/src/paimon/common/reader/prefetch_file_batch_reader_impl_test.cpp
+++ b/src/paimon/common/reader/prefetch_file_batch_reader_impl_test.cpp
@@ -488,7 +488,8 @@ TEST_F(PrefetchFileBatchReaderImplTest, SetReadRangesReturnErrorWhenPushDownFail
         data_array, data_type_, batch_size,
         /*read_ranges=*/{{0, 50}, {50, 100}},
         /*need_prefetch=*/true,
-        /*set_read_ranges_statuses=*/{Status::OK(), Status::IOError("set read ranges failed")});
+        /*set_read_ranges_statuses=*/{Status::IOError("set read ranges failed"),
+                                      Status::IOError("set read ranges failed")});
 
     ASSERT_OK_AND_ASSIGN(
         auto reader,

--- a/src/paimon/common/reader/prefetch_file_batch_reader_impl_test.cpp
+++ b/src/paimon/common/reader/prefetch_file_batch_reader_impl_test.cpp
@@ -488,8 +488,8 @@ TEST_F(PrefetchFileBatchReaderImplTest, SetReadRangesReturnErrorWhenPushDownFail
         data_array, data_type_, batch_size,
         /*read_ranges=*/{{0, 50}, {50, 100}},
         /*need_prefetch=*/true,
-        /*set_read_ranges_statuses=*/{Status::IOError("set read ranges failed"),
-                                      Status::IOError("set read ranges failed")});
+        /*set_read_ranges_statuses=*/
+        {Status::IOError("set read ranges failed"), Status::IOError("set read ranges failed")});
 
     ASSERT_OK_AND_ASSIGN(
         auto reader,


### PR DESCRIPTION
fix: stabilize prefetch SetReadRanges failure test

### Purpose

Linked issue: N/A

Stabilize `PrefetchFileBatchReaderImplTest.SetReadRangesReturnErrorWhenPushDownFailed` by making the injected `SetReadRanges` failure independent of concurrent reader build order.

Previously the test used one OK status and one IOError status for mock readers. Since readers are built concurrently, the failure injection depended on thread scheduling and could become flaky. This change injects IOError into both mock readers so the test deterministically verifies that `PrefetchFileBatchReaderImpl::SetReadRanges` propagates pushdown failures.

### Tests

- `./build/debug/paimon-common-test --gtest_filter=PrefetchFileBatchReaderImplTest.SetReadRangesReturnErrorWhenPushDownFailed`
- Repeated stability check: `PASSED 100/100`
- Lint check for `src/paimon/common/reader/prefetch_file_batch_reader_impl_test.cpp`: no lint errors found

### API and Format

No API, storage format, or protocol changes.

### Documentation

No user-facing feature or documentation changes.

### Generative AI tooling

Generated-by: Aone Copilot ide-idealab/gpt-5.5
