### PR TITLE
Allow FileStoreCommit for PK tables with postpone bucket mode

### DIFF
--- a/src/paimon/core/operation/file_store_commit.cpp
+++ b/src/paimon/core/operation/file_store_commit.cpp
@@ -69,15 +69,10 @@ Result<std::unique_ptr<FileStoreCommit>> FileStoreCommit::Create(
     const auto& schema = table_schema.value();
     if (!schema->PrimaryKeys().empty() &&
         ctx->GetOptions().find("enable-pk-commit-in-inte-test") == ctx->GetOptions().end()) {
-        // Postpone bucket mode (bucket=-2) writes data like an append table: all files go to
-        // bucket-postpone/ directory and the REST catalog server handles bucket redistribution
-        // during compaction. The commit logic is the same as append tables, so we allow it.
-        auto schema_opts = schema->Options();
-        auto bucket_it = schema_opts.find("bucket");
-        bool is_postpone_bucket =
-            bucket_it != schema_opts.end() &&
-            bucket_it->second == std::to_string(BucketModeDefine::POSTPONE_BUCKET);
-        if (!is_postpone_bucket) {
+        // Postpone bucket mode (bucket=-2) writes all data files to the bucket-postpone/ directory.
+        // A compaction job will later redistribute files into real buckets. The commit logic
+        // (manifest and snapshot generation) is the same as append tables, so we allow it.
+        if (schema->NumBuckets() != BucketModeDefine::POSTPONE_BUCKET) {
             return Status::NotImplemented("not support pk table commit yet");
         }
     }

--- a/src/paimon/core/operation/file_store_commit.cpp
+++ b/src/paimon/core/operation/file_store_commit.cpp
@@ -31,6 +31,7 @@
 #include "paimon/core/operation/file_store_commit_impl.h"
 #include "paimon/core/schema/schema_manager.h"
 #include "paimon/core/schema/table_schema.h"
+#include "paimon/core/table/bucket_mode.h"
 #include "paimon/core/utils/field_mapping.h"
 #include "paimon/core/utils/file_store_path_factory.h"
 #include "paimon/core/utils/snapshot_manager.h"
@@ -68,7 +69,17 @@ Result<std::unique_ptr<FileStoreCommit>> FileStoreCommit::Create(
     const auto& schema = table_schema.value();
     if (!schema->PrimaryKeys().empty() &&
         ctx->GetOptions().find("enable-pk-commit-in-inte-test") == ctx->GetOptions().end()) {
-        return Status::NotImplemented("not support pk table commit yet");
+        // Postpone bucket mode (bucket=-2) writes data like an append table: all files go to
+        // bucket-postpone/ directory and the REST catalog server handles bucket redistribution
+        // during compaction. The commit logic is the same as append tables, so we allow it.
+        auto schema_opts = schema->Options();
+        auto bucket_it = schema_opts.find("bucket");
+        bool is_postpone_bucket =
+            bucket_it != schema_opts.end() &&
+            bucket_it->second == std::to_string(BucketModeDefine::POSTPONE_BUCKET);
+        if (!is_postpone_bucket) {
+            return Status::NotImplemented("not support pk table commit yet");
+        }
     }
     auto opts = schema->Options();
     for (const auto& [key, value] : ctx->GetOptions()) {

--- a/src/paimon/core/operation/file_store_commit_impl_test.cpp
+++ b/src/paimon/core/operation/file_store_commit_impl_test.cpp
@@ -1688,4 +1688,61 @@ TEST_F(FileStoreCommitImplTest, TestObjectStoreAllowedWithRESTCatalogCommit) {
     ASSERT_FALSE(json.empty());
 }
 
+// Verify that FileStoreCommit::Create succeeds for PK tables with postpone bucket mode (bucket=-2)
+// without requiring the enable-pk-commit-in-inte-test workaround flag.
+TEST_F(FileStoreCommitImplTest, TestPostponeBucketPKTableCommitAllowed) {
+    auto pk_dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(pk_dir);
+    std::string pk_root = pk_dir->Str();
+    ASSERT_OK_AND_ASSIGN(auto catalog, Catalog::Create(pk_root, {}));
+    ASSERT_OK(catalog->CreateDatabase("db", {}, false));
+
+    arrow::Schema pk_schema(
+        {arrow::field("pk", arrow::int32()), arrow::field("val", arrow::utf8())});
+    ::ArrowSchema arrow_schema;
+    ASSERT_TRUE(arrow::ExportSchema(pk_schema, &arrow_schema).ok());
+    std::map<std::string, std::string> table_options = {{"bucket", "-2"}};
+    ASSERT_OK(catalog->CreateTable(Identifier("db", "pk_tbl"), &arrow_schema,
+                                   /*partition_keys=*/{}, /*primary_keys=*/{"pk"}, table_options,
+                                   /*ignore_if_exists=*/false));
+
+    std::string pk_table_path = PathUtil::JoinPath(pk_root, "db.db/pk_tbl");
+
+    // Create FileStoreCommit WITHOUT the workaround flag — should succeed for postpone bucket
+    CommitContextBuilder builder(pk_table_path, "test_user");
+    builder.AddOption(Options::FILE_SYSTEM, "local").UseRESTCatalogCommit(true);
+    ASSERT_OK_AND_ASSIGN(auto commit_context, builder.Finish());
+    ASSERT_OK_AND_ASSIGN(auto committer, FileStoreCommit::Create(std::move(commit_context)));
+    ASSERT_TRUE(committer != nullptr);
+}
+
+// Verify that FileStoreCommit::Create still rejects PK tables with fixed bucket (bucket > 0)
+// when the workaround flag is not set.
+TEST_F(FileStoreCommitImplTest, TestFixedBucketPKTableCommitRejected) {
+    auto pk_dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(pk_dir);
+    std::string pk_root = pk_dir->Str();
+    ASSERT_OK_AND_ASSIGN(auto catalog, Catalog::Create(pk_root, {}));
+    ASSERT_OK(catalog->CreateDatabase("db", {}, false));
+
+    arrow::Schema pk_schema(
+        {arrow::field("pk", arrow::int32()), arrow::field("val", arrow::utf8())});
+    ::ArrowSchema arrow_schema;
+    ASSERT_TRUE(arrow::ExportSchema(pk_schema, &arrow_schema).ok());
+    std::map<std::string, std::string> table_options = {{"bucket", "4"}};
+    ASSERT_OK(catalog->CreateTable(Identifier("db", "pk_tbl_fixed"), &arrow_schema,
+                                   /*partition_keys=*/{}, /*primary_keys=*/{"pk"}, table_options,
+                                   /*ignore_if_exists=*/false));
+
+    std::string pk_table_path = PathUtil::JoinPath(pk_root, "db.db/pk_tbl_fixed");
+
+    CommitContextBuilder builder(pk_table_path, "test_user");
+    builder.AddOption(Options::FILE_SYSTEM, "local").UseRESTCatalogCommit(true);
+    ASSERT_OK_AND_ASSIGN(auto commit_context, builder.Finish());
+    auto result = FileStoreCommit::Create(std::move(commit_context));
+    ASSERT_FALSE(result.ok());
+    ASSERT_TRUE(result.status().ToString().find("not support pk table commit") !=
+                std::string::npos);
+}
+
 }  // namespace paimon::test

--- a/src/paimon/core/operation/file_store_commit_impl_test.cpp
+++ b/src/paimon/core/operation/file_store_commit_impl_test.cpp
@@ -1701,7 +1701,7 @@ TEST_F(FileStoreCommitImplTest, TestPostponeBucketPKTableCommitAllowed) {
         {arrow::field("pk", arrow::int32()), arrow::field("val", arrow::utf8())});
     ::ArrowSchema arrow_schema;
     ASSERT_TRUE(arrow::ExportSchema(pk_schema, &arrow_schema).ok());
-    std::map<std::string, std::string> table_options = {{"bucket", "-2"}};
+    std::map<std::string, std::string> table_options = {{Options::BUCKET, "-2"}};
     ASSERT_OK(catalog->CreateTable(Identifier("db", "pk_tbl"), &arrow_schema,
                                    /*partition_keys=*/{}, /*primary_keys=*/{"pk"}, table_options,
                                    /*ignore_if_exists=*/false));
@@ -1729,7 +1729,7 @@ TEST_F(FileStoreCommitImplTest, TestFixedBucketPKTableCommitRejected) {
         {arrow::field("pk", arrow::int32()), arrow::field("val", arrow::utf8())});
     ::ArrowSchema arrow_schema;
     ASSERT_TRUE(arrow::ExportSchema(pk_schema, &arrow_schema).ok());
-    std::map<std::string, std::string> table_options = {{"bucket", "4"}};
+    std::map<std::string, std::string> table_options = {{Options::BUCKET, "4"}};
     ASSERT_OK(catalog->CreateTable(Identifier("db", "pk_tbl_fixed"), &arrow_schema,
                                    /*partition_keys=*/{}, /*primary_keys=*/{"pk"}, table_options,
                                    /*ignore_if_exists=*/false));
@@ -1741,6 +1741,7 @@ TEST_F(FileStoreCommitImplTest, TestFixedBucketPKTableCommitRejected) {
     ASSERT_OK_AND_ASSIGN(auto commit_context, builder.Finish());
     auto result = FileStoreCommit::Create(std::move(commit_context));
     ASSERT_FALSE(result.ok());
+    ASSERT_TRUE(result.status().IsNotImplemented());
     ASSERT_TRUE(result.status().ToString().find("not support pk table commit") !=
                 std::string::npos);
 }


### PR DESCRIPTION
## Summary

- Allow `FileStoreCommit::Create` to proceed for PK tables when using postpone bucket mode (`bucket=-2`)
- In postpone bucket mode, all records are first stored in the `bucket-postpone` directory of each partition and are not available to readers. To move the records into the correct bucket and make them readable, a compaction job needs to be run (via `compact` procedure or triggered by the catalog server)
- The commit logic (manifest and snapshot generation) is identical to append tables, so there is no reason to block it
- PK tables with fixed bucket (`bucket > 0`) remain blocked as before

## Test plan

- [x] `TestPostponeBucketPKTableCommitAllowed`: PK table with `bucket=-2` → `FileStoreCommit::Create` succeeds without workaround flag
- [x] `TestFixedBucketPKTableCommitRejected`: PK table with `bucket=4` → `FileStoreCommit::Create` returns `NotImplemented`

## Reference

- [Paimon Postpone Bucket Documentation](https://paimon.apache.org/docs/master/primary-key-table/data-distribution/#postpone-bucket)