### PR TITLE
feat: add Bucket() virtual interface to DataSplit base class

### DIFF
--- a/include/paimon/table/source/data_split.h
+++ b/include/paimon/table/source/data_split.h
@@ -74,6 +74,9 @@ class PAIMON_EXPORT DataSplit : public Split {
         std::string ToString() const;
     };
 
+    /// Get the bucket id of this data split.
+    virtual int32_t Bucket() const = 0;
+
     /// Get the list of metadata for all data files in this split.
     /// @note This method will be removed in future versions and is only used for append tables.
     virtual std::vector<SimpleDataFileMeta> GetFileList() const = 0;

--- a/src/paimon/core/table/source/data_split_impl.h
+++ b/src/paimon/core/table/source/data_split_impl.h
@@ -51,7 +51,7 @@ class DataSplitImpl : public DataSplit {
         return partition_;
     }
 
-    int32_t Bucket() const {
+    int32_t Bucket() const override {
         return bucket_;
     }
 

--- a/src/paimon/core/table/source/fallback_data_split.h
+++ b/src/paimon/core/table/source/fallback_data_split.h
@@ -27,6 +27,10 @@ class FallbackDataSplit : public DataSplit {
     FallbackDataSplit(const std::shared_ptr<DataSplit>& split, bool is_fallback)
         : is_fallback_(is_fallback), split_(split) {}
 
+    int32_t Bucket() const override {
+        return split_->Bucket();
+    }
+
     std::vector<SimpleDataFileMeta> GetFileList() const override {
         return split_->GetFileList();
     }


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: N/A

<!-- What is the purpose of the change -->
Expose `Bucket()` as a pure virtual interface in the `DataSplit` base class, so that callers can access the bucket id directly through a `DataSplit` pointer without downcasting to `DataSplitImpl`.

### Tests

Existing tests cover `DataSplitImpl::Bucket()` behavior. No new tests needed as this is a pure interface extraction.

### API and Format

Yes, this adds a new public virtual method `int32_t Bucket() const` to the `DataSplit` class in the `include` directory.

### Documentation

No.

### Generative AI tooling

Generated-by: Aone Copilot (Claude)