### PR TITLE
fix: Avoid signed overflow UB in BSI index and null-deref in bloom filter index

### DIFF
--- a/src/paimon/common/file_index/bloomfilter/bloom_filter_file_index.cpp
+++ b/src/paimon/common/file_index/bloomfilter/bloom_filter_file_index.cpp
@@ -78,9 +78,15 @@ BloomFilterFileIndexReader::BloomFilterFileIndexReader(const FastHash::HashFunct
 
 Result<std::shared_ptr<FileIndexResult>> BloomFilterFileIndexReader::VisitEqual(
     const Literal& literal) {
+    // This returns `Remain` to align with the current Java implementation in BF index, even though
+    // its predicate semantics are inconsistent here. In practice, equality tests in predicate
+    // evaluation always return false when the literal is null. See
+    // `null_false_leaf_binary_function.h`.
+    if (literal.IsNull()) {
+        return FileIndexResult::Remain();
+    }
     int64_t hash = hash_function_(literal);
-    return literal.IsNull() || filter_.TestHash(hash) ? FileIndexResult::Remain()
-                                                      : FileIndexResult::Skip();
+    return filter_.TestHash(hash) ? FileIndexResult::Remain() : FileIndexResult::Skip();
 }
 
 }  // namespace paimon

--- a/src/paimon/common/file_index/bsi/bit_slice_index_bitmap_file_index.cpp
+++ b/src/paimon/common/file_index/bsi/bit_slice_index_bitmap_file_index.cpp
@@ -165,7 +165,11 @@ Result<std::shared_ptr<FileIndexResult>> BitSliceIndexBitmapFileIndexReader::Vis
     BitmapIndexResult::BitmapSupplier bitmap_supplier =
         [literal = literal, reader = shared_from_this()]() -> Result<RoaringBitmap32> {
         PAIMON_ASSIGN_OR_RAISE(int64_t value, reader->value_mapper_(literal));
-        if (value >= 0) {
+        if (value == INT64_MIN) {
+            // Everything is greater than INT64_MIN (writer cannot store it)
+            return RoaringBitmap32::Or(reader->positive_->IsNotNull(),
+                                       reader->negative_->IsNotNull());
+        } else if (value >= 0) {
             return reader->positive_->GreaterThan(value);
         } else {
             PAIMON_ASSIGN_OR_RAISE(RoaringBitmap32 b1, reader->negative_->LessThan(SafeAbs(value)));
@@ -182,7 +186,11 @@ Result<std::shared_ptr<FileIndexResult>> BitSliceIndexBitmapFileIndexReader::Vis
     BitmapIndexResult::BitmapSupplier bitmap_supplier =
         [literal = literal, reader = shared_from_this()]() -> Result<RoaringBitmap32> {
         PAIMON_ASSIGN_OR_RAISE(int64_t value, reader->value_mapper_(literal));
-        if (value >= 0) {
+        if (value == INT64_MIN) {
+            // All non-null rows satisfy x >= INT64_MIN
+            return RoaringBitmap32::Or(reader->positive_->IsNotNull(),
+                                       reader->negative_->IsNotNull());
+        } else if (value >= 0) {
             return reader->positive_->GreaterOrEqual(value);
         } else {
             PAIMON_ASSIGN_OR_RAISE(RoaringBitmap32 b1,
@@ -200,7 +208,10 @@ Result<std::shared_ptr<FileIndexResult>> BitSliceIndexBitmapFileIndexReader::Vis
     BitmapIndexResult::BitmapSupplier bitmap_supplier =
         [literal = literal, reader = shared_from_this()]() -> Result<RoaringBitmap32> {
         PAIMON_ASSIGN_OR_RAISE(int64_t value, reader->value_mapper_(literal));
-        if (value < 0) {
+        if (value == INT64_MIN) {
+            // Nothing is less than INT64_MIN
+            return RoaringBitmap32();
+        } else if (value < 0) {
             return reader->negative_->GreaterThan(SafeAbs(value));
         } else {
             PAIMON_ASSIGN_OR_RAISE(RoaringBitmap32 b1, reader->positive_->LessThan(value));
@@ -216,7 +227,10 @@ Result<std::shared_ptr<FileIndexResult>> BitSliceIndexBitmapFileIndexReader::Vis
     BitmapIndexResult::BitmapSupplier bitmap_supplier =
         [literal = literal, reader = shared_from_this()]() -> Result<RoaringBitmap32> {
         PAIMON_ASSIGN_OR_RAISE(int64_t value, reader->value_mapper_(literal));
-        if (value < 0) {
+        if (value == INT64_MIN) {
+            // Writer cannot store INT64_MIN, so no row can match
+            return RoaringBitmap32();
+        } else if (value < 0) {
             return reader->negative_->GreaterOrEqual(SafeAbs(value));
         } else {
             PAIMON_ASSIGN_OR_RAISE(RoaringBitmap32 b1, reader->positive_->LessOrEqual(value));
@@ -245,13 +259,17 @@ Result<std::shared_ptr<FileIndexResult>> BitSliceIndexBitmapFileIndexReader::Vis
         result_bitmaps.reserve(literals.size());
         for (const auto& literal : literals) {
             PAIMON_ASSIGN_OR_RAISE(int64_t value, reader->value_mapper_(literal));
-            RoaringBitmap32 equal;
-            if (value < 0) {
-                PAIMON_ASSIGN_OR_RAISE(equal, reader->negative_->Equal(SafeAbs(value)));
+            if (value == INT64_MIN) {
+                // Writer cannot store INT64_MIN, so no row can match it
+                result_bitmaps.emplace_back(RoaringBitmap32());
+            } else if (value < 0) {
+                PAIMON_ASSIGN_OR_RAISE(RoaringBitmap32 equal,
+                                       reader->negative_->Equal(SafeAbs(value)));
+                result_bitmaps.emplace_back(std::move(equal));
             } else {
-                PAIMON_ASSIGN_OR_RAISE(equal, reader->positive_->Equal(value));
+                PAIMON_ASSIGN_OR_RAISE(RoaringBitmap32 equal, reader->positive_->Equal(value));
+                result_bitmaps.emplace_back(std::move(equal));
             }
-            result_bitmaps.emplace_back(std::move(equal));
         }
         return RoaringBitmap32::FastUnion(result_bitmaps);
     };
@@ -268,13 +286,17 @@ Result<std::shared_ptr<FileIndexResult>> BitSliceIndexBitmapFileIndexReader::Vis
         result_bitmaps.reserve(literals.size());
         for (const auto& literal : literals) {
             PAIMON_ASSIGN_OR_RAISE(int64_t value, reader->value_mapper_(literal));
-            RoaringBitmap32 equal;
-            if (value < 0) {
-                PAIMON_ASSIGN_OR_RAISE(equal, reader->negative_->Equal(SafeAbs(value)));
+            if (value == INT64_MIN) {
+                // Writer cannot store INT64_MIN, so no row can match it
+                result_bitmaps.emplace_back(RoaringBitmap32());
+            } else if (value < 0) {
+                PAIMON_ASSIGN_OR_RAISE(RoaringBitmap32 equal,
+                                       reader->negative_->Equal(SafeAbs(value)));
+                result_bitmaps.emplace_back(std::move(equal));
             } else {
-                PAIMON_ASSIGN_OR_RAISE(equal, reader->positive_->Equal(value));
+                PAIMON_ASSIGN_OR_RAISE(RoaringBitmap32 equal, reader->positive_->Equal(value));
+                result_bitmaps.emplace_back(std::move(equal));
             }
-            result_bitmaps.emplace_back(std::move(equal));
         }
         auto in = RoaringBitmap32::FastUnion(result_bitmaps);
         ebm -= in;

--- a/src/paimon/common/file_index/bsi/bit_slice_index_bitmap_file_index.cpp
+++ b/src/paimon/common/file_index/bsi/bit_slice_index_bitmap_file_index.cpp
@@ -35,7 +35,7 @@
 #include "paimon/utils/roaring_bitmap32.h"
 namespace {
 // Safe absolute value for int64_t that avoids undefined behavior when value == INT64_MIN.
-// This mirrors Java's Math.abs() wrapping semantics but produces the correct magnitude.
+// This mirrors Java's Math.abs() wrapping semantics.
 inline int64_t SafeAbs(int64_t value) {
     if (value == INT64_MIN) {
         return INT64_MIN;

--- a/src/paimon/common/file_index/bsi/bit_slice_index_bitmap_file_index.cpp
+++ b/src/paimon/common/file_index/bsi/bit_slice_index_bitmap_file_index.cpp
@@ -261,7 +261,7 @@ Result<std::shared_ptr<FileIndexResult>> BitSliceIndexBitmapFileIndexReader::Vis
             PAIMON_ASSIGN_OR_RAISE(int64_t value, reader->value_mapper_(literal));
             if (value == INT64_MIN) {
                 // Writer cannot store INT64_MIN, so no row can match it
-                result_bitmaps.emplace_back(RoaringBitmap32());
+                result_bitmaps.emplace_back();
             } else if (value < 0) {
                 PAIMON_ASSIGN_OR_RAISE(RoaringBitmap32 equal,
                                        reader->negative_->Equal(SafeAbs(value)));
@@ -288,7 +288,7 @@ Result<std::shared_ptr<FileIndexResult>> BitSliceIndexBitmapFileIndexReader::Vis
             PAIMON_ASSIGN_OR_RAISE(int64_t value, reader->value_mapper_(literal));
             if (value == INT64_MIN) {
                 // Writer cannot store INT64_MIN, so no row can match it
-                result_bitmaps.emplace_back(RoaringBitmap32());
+                result_bitmaps.emplace_back();
             } else if (value < 0) {
                 PAIMON_ASSIGN_OR_RAISE(RoaringBitmap32 equal,
                                        reader->negative_->Equal(SafeAbs(value)));

--- a/src/paimon/common/file_index/bsi/bit_slice_index_bitmap_file_index.cpp
+++ b/src/paimon/common/file_index/bsi/bit_slice_index_bitmap_file_index.cpp
@@ -17,7 +17,9 @@
 #include "paimon/common/file_index/bsi/bit_slice_index_bitmap_file_index.h"
 
 #include <cassert>
+#include <climits>
 #include <cstddef>
+#include <cstdint>
 
 #include "fmt/format.h"
 #include "paimon/common/file_index/bsi/bit_slice_index_roaring_bitmap.h"
@@ -31,7 +33,17 @@
 #include "paimon/io/data_input_stream.h"
 #include "paimon/memory/bytes.h"
 #include "paimon/utils/roaring_bitmap32.h"
+namespace {
+// Safe absolute value for int64_t that avoids undefined behavior when value == INT64_MIN.
+// This mirrors Java's Math.abs() wrapping semantics but produces the correct magnitude.
+inline int64_t SafeAbs(int64_t value) {
+    if (value == INT64_MIN) {
+        return INT64_MIN;
+    }
+    return value < 0 ? -value : value;
+}
 
+}  // namespace
 namespace paimon {
 class MemoryPool;
 
@@ -156,7 +168,7 @@ Result<std::shared_ptr<FileIndexResult>> BitSliceIndexBitmapFileIndexReader::Vis
         if (value >= 0) {
             return reader->positive_->GreaterThan(value);
         } else {
-            PAIMON_ASSIGN_OR_RAISE(RoaringBitmap32 b1, reader->negative_->LessThan(-value));
+            PAIMON_ASSIGN_OR_RAISE(RoaringBitmap32 b1, reader->negative_->LessThan(SafeAbs(value)));
             RoaringBitmap32 b2 = reader->positive_->IsNotNull();
             b1 |= b2;
             return b1;
@@ -173,7 +185,8 @@ Result<std::shared_ptr<FileIndexResult>> BitSliceIndexBitmapFileIndexReader::Vis
         if (value >= 0) {
             return reader->positive_->GreaterOrEqual(value);
         } else {
-            PAIMON_ASSIGN_OR_RAISE(RoaringBitmap32 b1, reader->negative_->LessOrEqual(-value));
+            PAIMON_ASSIGN_OR_RAISE(RoaringBitmap32 b1,
+                                   reader->negative_->LessOrEqual(SafeAbs(value)));
             RoaringBitmap32 b2 = reader->positive_->IsNotNull();
             b1 |= b2;
             return b1;
@@ -188,7 +201,7 @@ Result<std::shared_ptr<FileIndexResult>> BitSliceIndexBitmapFileIndexReader::Vis
         [literal = literal, reader = shared_from_this()]() -> Result<RoaringBitmap32> {
         PAIMON_ASSIGN_OR_RAISE(int64_t value, reader->value_mapper_(literal));
         if (value < 0) {
-            return reader->negative_->GreaterThan(-value);
+            return reader->negative_->GreaterThan(SafeAbs(value));
         } else {
             PAIMON_ASSIGN_OR_RAISE(RoaringBitmap32 b1, reader->positive_->LessThan(value));
             RoaringBitmap32 b2 = reader->negative_->IsNotNull();
@@ -204,7 +217,7 @@ Result<std::shared_ptr<FileIndexResult>> BitSliceIndexBitmapFileIndexReader::Vis
         [literal = literal, reader = shared_from_this()]() -> Result<RoaringBitmap32> {
         PAIMON_ASSIGN_OR_RAISE(int64_t value, reader->value_mapper_(literal));
         if (value < 0) {
-            return reader->negative_->GreaterOrEqual(-value);
+            return reader->negative_->GreaterOrEqual(SafeAbs(value));
         } else {
             PAIMON_ASSIGN_OR_RAISE(RoaringBitmap32 b1, reader->positive_->LessOrEqual(value));
             RoaringBitmap32 b2 = reader->negative_->IsNotNull();
@@ -234,7 +247,7 @@ Result<std::shared_ptr<FileIndexResult>> BitSliceIndexBitmapFileIndexReader::Vis
             PAIMON_ASSIGN_OR_RAISE(int64_t value, reader->value_mapper_(literal));
             RoaringBitmap32 equal;
             if (value < 0) {
-                PAIMON_ASSIGN_OR_RAISE(equal, reader->negative_->Equal(-value));
+                PAIMON_ASSIGN_OR_RAISE(equal, reader->negative_->Equal(SafeAbs(value)));
             } else {
                 PAIMON_ASSIGN_OR_RAISE(equal, reader->positive_->Equal(value));
             }
@@ -257,7 +270,7 @@ Result<std::shared_ptr<FileIndexResult>> BitSliceIndexBitmapFileIndexReader::Vis
             PAIMON_ASSIGN_OR_RAISE(int64_t value, reader->value_mapper_(literal));
             RoaringBitmap32 equal;
             if (value < 0) {
-                PAIMON_ASSIGN_OR_RAISE(equal, reader->negative_->Equal(-value));
+                PAIMON_ASSIGN_OR_RAISE(equal, reader->negative_->Equal(SafeAbs(value)));
             } else {
                 PAIMON_ASSIGN_OR_RAISE(equal, reader->positive_->Equal(value));
             }

--- a/src/paimon/common/file_index/bsi/bit_slice_index_bitmap_file_index_test.cpp
+++ b/src/paimon/common/file_index/bsi/bit_slice_index_bitmap_file_index_test.cpp
@@ -16,6 +16,7 @@
 
 #include "paimon/common/file_index/bsi/bit_slice_index_bitmap_file_index.h"
 
+#include <cstdint>
 #include <utility>
 
 #include "gtest/gtest.h"
@@ -383,6 +384,51 @@ TEST_F(BitSliceIndexBitmapIndexReaderTest, TestUnInvalidType) {
         file_index.CreateReader(CreateArrowSchema(arrow::boolean()).get(),
                                 /*start=*/0, /*length=*/index_bytes.size(), input_stream, pool_),
         "BitSliceIndexBitmapFileIndex only support TINYINT/SMALLINT/INT/BIGINT/DATE");
+}
+
+TEST_F(BitSliceIndexBitmapIndexReaderTest, TestReaderPredicatePruningWithInt64Min) {
+    // Reuse TestPrimitiveType's index bytes.
+    // data: null, 1, null, 2, -1   (non-null rows: {1, 3, 4})
+    std::vector<char> index_bytes = {
+        1,  0, 0, 0,  5,  1,  1,  0, 0, 0, 0, 0,  0, 0, 0, 0,  0, 0,  0,  0, 0, 0, 2, 58,
+        48, 0, 0, 1,  0,  0,  0,  0, 0, 1, 0, 16, 0, 0, 0, 1,  0, 3,  0,  0, 0, 0, 2, 58,
+        48, 0, 0, 1,  0,  0,  0,  0, 0, 0, 0, 16, 0, 0, 0, 1,  0, 58, 48, 0, 0, 1, 0, 0,
+        0,  0, 0, 0,  0,  16, 0,  0, 0, 3, 0, 1,  1, 0, 0, 0,  0, 0,  0,  0, 0, 0, 0, 0,
+        0,  0, 0, 0,  1,  58, 48, 0, 0, 1, 0, 0,  0, 0, 0, 0,  0, 16, 0,  0, 0, 4, 0, 0,
+        0,  0, 1, 58, 48, 0,  0,  1, 0, 0, 0, 0,  0, 0, 0, 16, 0, 0,  0,  4, 0};
+    auto input_stream =
+        std::make_shared<ByteArrayInputStream>(index_bytes.data(), index_bytes.size());
+    BitSliceIndexBitmapFileIndex file_index({});
+    ASSERT_OK_AND_ASSIGN(
+        auto reader,
+        file_index.CreateReader(CreateArrowSchema(arrow::int64()).get(),
+                                /*start=*/0, /*length=*/index_bytes.size(), input_stream, pool_));
+
+    // x > INT64_MIN: all non-null rows (writer cannot store INT64_MIN)
+    CheckResult(reader->VisitGreaterThan(Literal(INT64_MIN)).value(), {1, 3, 4});
+
+    // x >= INT64_MIN: all non-null rows
+    CheckResult(reader->VisitGreaterOrEqual(Literal(INT64_MIN)).value(), {1, 3, 4});
+
+    // x < INT64_MIN: empty
+    CheckResult(reader->VisitLessThan(Literal(INT64_MIN)).value(), {});
+
+    // x <= INT64_MIN: empty (no row has INT64_MIN)
+    CheckResult(reader->VisitLessOrEqual(Literal(INT64_MIN)).value(), {});
+
+    // x == INT64_MIN: empty
+    CheckResult(reader->VisitEqual(Literal(INT64_MIN)).value(), {});
+
+    // x != INT64_MIN: all non-null rows
+    CheckResult(reader->VisitNotEqual(Literal(INT64_MIN)).value(), {1, 3, 4});
+
+    // x IN (INT64_MIN, -1): only -1 matches → row 4
+    CheckResult(reader->VisitIn({Literal(INT64_MIN), Literal(static_cast<int64_t>(-1))}).value(),
+                {4});
+
+    // x NOT IN (INT64_MIN, -1): all non-null except row 4
+    CheckResult(reader->VisitNotIn({Literal(INT64_MIN), Literal(static_cast<int64_t>(-1))}).value(),
+                {1, 3});
 }
 
 }  // namespace paimon::test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
No Linked issue.

Fix two undefined-behavior bugs in file index readers:

1. **BSI reader signed overflow**: negative branches computed `-value`, which is
   UB when value is `INT64_MIN`. Now use a `SafeAbs()` helper that clamps
   `INT64_MIN` to `INT64_MIN`.

2. **Bloom filter null deref**: `VisitEqual` hashed the literal before checking
   `IsNull()`, dereferencing a null value. Now returns `Remain()`
   for null literals before hashing.

Cross-checked with Java `BitSliceIndexBitmapFileIndex`: Java's `Math.abs` wraps
`Long.MIN_VALUE` back to negative, so its writer rejects `MIN_VALUE` outright —
the value can never reach a BSI index. The C++ fix is defensive and matches Java
results for all valid values.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling
Generated-by: Aone Copilot (Claude)
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
