### PR TITLE
fix(schema): use Arrow concrete decimal type IDs in schema validation

### DIFF
--- a/src/paimon/common/data/binary_row_writer.cpp
+++ b/src/paimon/common/data/binary_row_writer.cpp
@@ -140,7 +140,7 @@ Result<BinaryRowWriter::FieldSetterFunc> BinaryRowWriter::CreateFieldSetter(
             };
             return field_setter;
         }
-        case arrow::Type::type::DECIMAL: {
+        case arrow::Type::type::DECIMAL128: {
             auto* decimal_type =
                 arrow::internal::checked_cast<arrow::Decimal128Type*>(field_type.get());
             assert(decimal_type);

--- a/src/paimon/common/data/internal_row.cpp
+++ b/src/paimon/common/data/internal_row.cpp
@@ -110,7 +110,7 @@ Result<InternalRow::FieldGetterFunc> InternalRow::CreateFieldGetter(
             };
             break;
         }
-        case arrow::Type::type::DECIMAL: {
+        case arrow::Type::type::DECIMAL128: {
             auto* decimal_type =
                 arrow::internal::checked_cast<arrow::Decimal128Type*>(field_type.get());
             assert(decimal_type);

--- a/src/paimon/common/data/serializer/binary_serializer_utils.cpp
+++ b/src/paimon/common/data/serializer/binary_serializer_utils.cpp
@@ -103,7 +103,7 @@ Status BinarySerializerUtils::WriteBinaryData(const std::shared_ptr<arrow::DataT
         if (array_writer) {
             array_writer->SetNullAt(pos, type_id);
             return Status::OK();
-        } else if (type_id != arrow::Type::type::DECIMAL &&
+        } else if (type_id != arrow::Type::type::DECIMAL128 &&
                    type_id != arrow::Type::type::TIMESTAMP) {
             // if row writer, exclude decimal and timestamp when set null
             writer->SetNullAt(pos);
@@ -167,7 +167,7 @@ Status BinarySerializerUtils::WriteBinaryData(const std::shared_ptr<arrow::DataT
             }
             break;
         }
-        case arrow::Type::type::DECIMAL: {
+        case arrow::Type::type::DECIMAL128: {
             auto* decimal_type = arrow::internal::checked_cast<arrow::Decimal128Type*>(type.get());
             assert(decimal_type);
             auto precision = decimal_type->precision();

--- a/src/paimon/common/data/serializer/row_compacted_serializer.cpp
+++ b/src/paimon/common/data/serializer/row_compacted_serializer.cpp
@@ -94,7 +94,7 @@ Result<int32_t> RowCompactedSerializer::CompareField(const FieldInfo& field_info
             PAIMON_ASSIGN_OR_RAISE(Timestamp val2, reader2->ReadTimestamp(field_info.precision));
             return val1 == val2 ? 0 : (val1 < val2 ? -1 : 1);
         }
-        case arrow::Type::type::DECIMAL: {
+        case arrow::Type::type::DECIMAL128: {
             PAIMON_ASSIGN_OR_RAISE(Decimal val1,
                                    reader1->ReadDecimal(field_info.precision, field_info.scale));
             PAIMON_ASSIGN_OR_RAISE(Decimal val2,
@@ -124,7 +124,7 @@ Result<MemorySlice::SliceComparator> RowCompactedSerializer::CreateSliceComparat
                 arrow::internal::checked_pointer_cast<arrow::TimestampType>(field_type);
             assert(timestamp_type);
             field_infos[i].precision = DateTimeUtils::GetPrecisionFromType(timestamp_type);
-        } else if (field_type->id() == arrow::Type::type::DECIMAL) {
+        } else if (field_type->id() == arrow::Type::type::DECIMAL128) {
             auto decimal_type =
                 arrow::internal::checked_pointer_cast<arrow::Decimal128Type>(field_type);
             assert(decimal_type);
@@ -275,7 +275,7 @@ Result<RowCompactedSerializer::FieldReader> RowCompactedSerializer::CreateFieldR
             };
             break;
         }
-        case arrow::Type::type::DECIMAL: {
+        case arrow::Type::type::DECIMAL128: {
             auto* decimal_type =
                 arrow::internal::checked_cast<arrow::Decimal128Type*>(field_type.get());
             assert(decimal_type);
@@ -410,7 +410,7 @@ Result<RowCompactedSerializer::FieldWriter> RowCompactedSerializer::CreateFieldW
             };
             break;
         }
-        case arrow::Type::type::DECIMAL: {
+        case arrow::Type::type::DECIMAL128: {
             auto* decimal_type =
                 arrow::internal::checked_cast<arrow::Decimal128Type*>(field_type.get());
             assert(decimal_type);

--- a/src/paimon/common/utils/fields_comparator.cpp
+++ b/src/paimon/common/utils/fields_comparator.cpp
@@ -163,7 +163,7 @@ Result<FieldsComparator::FieldComparatorFunc> FieldsComparator::CompareField(
                     return lvalue == rvalue ? 0 : (lvalue < rvalue ? -1 : 1);
                 });
         }
-        case arrow::Type::type::DECIMAL: {
+        case arrow::Type::type::DECIMAL128: {
             auto* decimal_type =
                 arrow::internal::checked_cast<arrow::Decimal128Type*>(input_type.get());
             assert(decimal_type);

--- a/src/paimon/core/bucket/bucket_id_calculator.cpp
+++ b/src/paimon/core/bucket/bucket_id_calculator.cpp
@@ -206,7 +206,7 @@ static Result<WriteFunction> WriteBucketRow(int32_t col_id,
             };
             return writer_func;
         }
-        case arrow::Type::type::DECIMAL: {
+        case arrow::Type::type::DECIMAL128: {
             const auto* decimal_type =
                 arrow::internal::checked_cast<const arrow::Decimal128Type*>(field->type().get());
             assert(decimal_type);

--- a/src/paimon/core/io/row_to_arrow_array_converter.h
+++ b/src/paimon/core/io/row_to_arrow_array_converter.h
@@ -129,7 +129,7 @@ Status RowToArrowArrayConverter<T, R>::Reserve(arrow::ArrayBuilder* array_builde
         case arrow::Type::type::FLOAT:
         case arrow::Type::type::DOUBLE:
         case arrow::Type::type::TIMESTAMP:
-        case arrow::Type::type::DECIMAL:
+        case arrow::Type::type::DECIMAL128:
             break;
         case arrow::Type::type::STRING: {
             // reserve string data buffer
@@ -201,7 +201,7 @@ Status RowToArrowArrayConverter<T, R>::Accumulate(const arrow::Array* array, int
         case arrow::Type::type::FLOAT:
         case arrow::Type::type::DOUBLE:
         case arrow::Type::type::TIMESTAMP:
-        case arrow::Type::type::DECIMAL:
+        case arrow::Type::type::DECIMAL128:
             break;
         case arrow::Type::type::STRING: {
             auto string_array = arrow::internal::checked_cast<const arrow::StringArray*>(array);
@@ -403,7 +403,7 @@ RowToArrowArrayConverter<T, R>::AppendField(bool use_view, arrow::ArrayBuilder* 
                         DateTimeUtils::TimestampToInteger(timestamp, time_type));
                 });
         }
-        case arrow::Type::type::DECIMAL: {
+        case arrow::Type::type::DECIMAL128: {
             PAIMON_ASSIGN_OR_RAISE(auto* field_builder,
                                    CastToTypedBuilder<arrow::Decimal128Builder>(array_builder));
             auto decimal_type =

--- a/src/paimon/core/mergetree/compact/aggregate/field_max_agg.h
+++ b/src/paimon/core/mergetree/compact/aggregate/field_max_agg.h
@@ -61,7 +61,7 @@ class FieldMaxAgg : public FieldAggregator {
             case arrow::Type::type::FLOAT:
             case arrow::Type::type::DOUBLE:
             case arrow::Type::type::TIMESTAMP:
-            case arrow::Type::type::DECIMAL:
+            case arrow::Type::type::DECIMAL128:
             case arrow::Type::type::STRING:
             case arrow::Type::type::BINARY:
                 return FieldMaxFunc([](const VariantType& accumulator,

--- a/src/paimon/core/mergetree/compact/aggregate/field_min_agg.h
+++ b/src/paimon/core/mergetree/compact/aggregate/field_min_agg.h
@@ -61,7 +61,7 @@ class FieldMinAgg : public FieldAggregator {
             case arrow::Type::type::FLOAT:
             case arrow::Type::type::DOUBLE:
             case arrow::Type::type::TIMESTAMP:
-            case arrow::Type::type::DECIMAL:
+            case arrow::Type::type::DECIMAL128:
             case arrow::Type::type::STRING:
             case arrow::Type::type::BINARY:
                 return FieldMinFunc([](const VariantType& accumulator,

--- a/src/paimon/core/mergetree/compact/aggregate/field_sum_agg.cpp
+++ b/src/paimon/core/mergetree/compact/aggregate/field_sum_agg.cpp
@@ -71,7 +71,7 @@ Result<FieldSumAgg::FieldSumFunc> FieldSumAgg::CreateSumFunc(
                                  DataDefine::GetVariantValue<double>(input_field);
                     return sum;
                 });
-        case arrow::Type::type::DECIMAL: {
+        case arrow::Type::type::DECIMAL128: {
             return FieldSumFunc(
                 [](const VariantType& accumulator, const VariantType& input_field) -> VariantType {
                     auto v1 = DataDefine::GetVariantValue<Decimal>(accumulator);
@@ -120,7 +120,7 @@ Result<FieldSumAgg::FieldNegFunc> FieldSumAgg::CreateNegFunc(
                 auto value = DataDefine::GetVariantValue<double>(input_field);
                 return (-value);
             });
-        case arrow::Type::type::DECIMAL: {
+        case arrow::Type::type::DECIMAL128: {
             return FieldNegFunc([](const VariantType& input_field) -> VariantType {
                 auto value = DataDefine::GetVariantValue<Decimal>(input_field);
                 return Decimal(value.Precision(), value.Scale(), -value.Value());

--- a/src/paimon/core/mergetree/in_memory_sort_buffer.cpp
+++ b/src/paimon/core/mergetree/in_memory_sort_buffer.cpp
@@ -140,7 +140,7 @@ Result<int64_t> InMemorySortBuffer::EstimateMemoryUse(const std::shared_ptr<arro
             return null_bits_size_in_bytes + array->length() * sizeof(double);
         case arrow::Type::type::TIMESTAMP:
             return null_bits_size_in_bytes + array->length() * sizeof(int64_t);
-        case arrow::Type::type::DECIMAL:
+        case arrow::Type::type::DECIMAL128:
             return null_bits_size_in_bytes + array->length() * sizeof(Decimal::int128_t);
         case arrow::Type::type::STRING:
         case arrow::Type::type::BINARY: {

--- a/src/paimon/core/schema/schema_validation.cpp
+++ b/src/paimon/core/schema/schema_validation.cpp
@@ -48,8 +48,9 @@
 namespace paimon {
 
 bool SchemaValidation::IsComplexType(const std::shared_ptr<arrow::Field>& field) {
-    return (field->type()->id() == arrow::Type::TIMESTAMP ||
-            field->type()->id() == arrow::Type::DECIMAL || BlobUtils::IsBlobField(field));
+    arrow::Type::type arrow_type_id = field->type()->id();
+    return (arrow_type_id == arrow::Type::TIMESTAMP || arrow_type_id == arrow::Type::DECIMAL128 ||
+            BlobUtils::IsBlobField(field));
 }
 
 Status SchemaValidation::ValidateTableSchema(const TableSchema& schema) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

This change checks the whole codebase and replaces Arrow decimal enum usages with concrete Arrow C++ decimal type IDs while preserving the original enum namespace style:

- `arrow::Type::DECIMAL` -> `arrow::Type::DECIMAL128`
- `arrow::Type::type::DECIMAL` -> `arrow::Type::type::DECIMAL128`

### Tests

<!-- List UT and IT cases to verify this change -->


### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

No API, storage format, or protocol changes.

### Documentation

<!-- Does this change introduce a new feature -->

No. This is a compatibility fix and does not introduce a new feature.

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Generated-by: Aone Copilot (ide-idealab/gpt-5.5)
