### PR TITLE
fix: remove trailing semicolons from statement-like macro definitions

### DIFF
--- a/include/paimon/result.h
+++ b/include/paimon/result.h
@@ -270,11 +270,11 @@ inline Status GenericToStatus(Result<T>&& res) {
 #define PAIMON_ASSIGN_OR_RAISE_IMPL(result_name, lhs, rexpr)                                 \
     auto&& result_name = (rexpr);                                                            \
     PAIMON_RETURN_IF_(!(result_name).ok(), (result_name).status(), PAIMON_STRINGIFY(rexpr)); \
-    lhs = std::move(result_name).value();
+    lhs = std::move(result_name).value()
 
 #define PAIMON_ASSIGN_OR_RAISE_NAME(x, y) PAIMON_CONCAT(x, y)
 
 #define PAIMON_ASSIGN_OR_RAISE(lhs, rexpr)                                                      \
     PAIMON_ASSIGN_OR_RAISE_IMPL(PAIMON_ASSIGN_OR_RAISE_NAME(_error_or_value, __COUNTER__), lhs, \
-                                (rexpr));
+                                (rexpr))
 }  // namespace paimon

--- a/src/paimon/common/file_index/bitmap/bitmap_index_result.cpp
+++ b/src/paimon/common/file_index/bitmap/bitmap_index_result.cpp
@@ -48,7 +48,7 @@ Result<std::shared_ptr<FileIndexResult>> BitmapIndexResult::And(
              typed_other]() -> Result<RoaringBitmap32> {
                 PAIMON_ASSIGN_OR_RAISE(const RoaringBitmap32* bitmap, result->GetBitmap());
                 PAIMON_ASSIGN_OR_RAISE(const RoaringBitmap32* other_bitmap,
-                                       typed_other->GetBitmap())
+                                       typed_other->GetBitmap());
                 return RoaringBitmap32::And(*bitmap, *other_bitmap);
             });
     }
@@ -64,7 +64,7 @@ Result<std::shared_ptr<FileIndexResult>> BitmapIndexResult::Or(
              typed_other]() -> Result<RoaringBitmap32> {
                 PAIMON_ASSIGN_OR_RAISE(const RoaringBitmap32* bitmap, result->GetBitmap());
                 PAIMON_ASSIGN_OR_RAISE(const RoaringBitmap32* other_bitmap,
-                                       typed_other->GetBitmap())
+                                       typed_other->GetBitmap());
                 return RoaringBitmap32::Or(*bitmap, *other_bitmap);
             });
     }

--- a/src/paimon/common/utils/arrow/status_utils.h
+++ b/src/paimon/common/utils/arrow/status_utils.h
@@ -96,10 +96,10 @@ inline Status ToPaimonStatus(const arrow::Status& status) {
     auto&& result_name = (rexpr);                                                  \
     PAIMON_RETURN_IF_(!(result_name).ok(), ToPaimonStatus((result_name).status()), \
                       PAIMON_STRINGIFY(rexpr));                                    \
-    lhs = std::move(result_name).ValueUnsafe();
+    lhs = std::move(result_name).ValueUnsafe()
 
 #define PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(lhs, rexpr) \
     PAIMON_ASSIGN_OR_RAISE_IMPL_FROM_ARROW(           \
-        PAIMON_ASSIGN_OR_RAISE_NAME(_error_or_value, __COUNTER__), lhs, (rexpr));
+        PAIMON_ASSIGN_OR_RAISE_NAME(_error_or_value, __COUNTER__), lhs, (rexpr))
 
 }  // namespace paimon

--- a/src/paimon/core/casting/cast_executor_test.cpp
+++ b/src/paimon/core/casting/cast_executor_test.cpp
@@ -2522,7 +2522,7 @@ TEST_F(CastExecutorTest, TestBooleanToDecimalCastExecutorCastLiteral) {
     }
     {
         ASSERT_OK_AND_ASSIGN(Literal valid_literal,
-                             cast_executor->Cast(Literal(false), arrow::decimal128(3, 3)))
+                             cast_executor->Cast(Literal(false), arrow::decimal128(3, 3)));
         ASSERT_EQ(valid_literal, Literal(Decimal(3, 3, 0)));
     }
 }

--- a/src/paimon/core/manifest/manifest_entry_serializer.cpp
+++ b/src/paimon/core/manifest/manifest_entry_serializer.cpp
@@ -53,7 +53,7 @@ Result<ManifestEntry> ManifestEntrySerializer::ConvertFrom(int32_t version,
         return Status::Invalid("ManifestEntry convert from row failed, with null DataFileMeta");
     }
     PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<DataFileMeta> meta,
-                           data_file_meta_serializer_.FromRow(*file))
+                           data_file_meta_serializer_.FromRow(*file));
     return ManifestEntry(file_kind, partition, bucket, total_buckets, meta);
 }
 

--- a/src/paimon/core/mergetree/compact/merge_tree_compact_rewriter_test.cpp
+++ b/src/paimon/core/mergetree/compact/merge_tree_compact_rewriter_test.cpp
@@ -117,7 +117,7 @@ TEST_F(MergeTreeCompactRewriterTest, TestSimple) {
 
     // generate sorted runs and rewrite
     ASSERT_OK_AND_ASSIGN(auto runs, GenerateSortedRuns(table_path, table_schema, /*bucket=*/1,
-                                                       /*partition=*/{{"f1", "10"}}))
+                                                       /*partition=*/{{"f1", "10"}}));
     ASSERT_OK_AND_ASSIGN(auto compact_result, rewriter->Rewrite(
                                                   /*output_level=*/5, /*drop_delete=*/true, runs));
     // check compact result
@@ -214,7 +214,7 @@ TEST_F(MergeTreeCompactRewriterTest, TestNotDropDelete) {
 
     // generate sorted runs and rewrite
     ASSERT_OK_AND_ASSIGN(auto runs, GenerateSortedRuns(table_path, table_schema, /*bucket=*/1,
-                                                       /*partition=*/{{"f1", "10"}}))
+                                                       /*partition=*/{{"f1", "10"}}));
     ASSERT_OK_AND_ASSIGN(auto compact_result, rewriter->Rewrite(
                                                   /*output_level=*/5, /*drop_delete=*/false, runs));
     // check compact result
@@ -285,7 +285,7 @@ TEST_F(MergeTreeCompactRewriterTest, TestIOException) {
 
         // generate sorted runs and rewrite
         ASSERT_OK_AND_ASSIGN(auto runs, GenerateSortedRuns(table_path, table_schema, /*bucket=*/1,
-                                                           /*partition=*/{{"f1", "10"}}))
+                                                           /*partition=*/{{"f1", "10"}}));
         // rewrite may trigger I/O exception
         ScopeGuard guard([&io_hook]() { io_hook->Clear(); });
         io_hook->Reset(i, IOHook::Mode::RETURN_ERROR);

--- a/src/paimon/core/operation/abstract_file_store_write.cpp
+++ b/src/paimon/core/operation/abstract_file_store_write.cpp
@@ -126,7 +126,7 @@ Status AbstractFileStoreWrite::Write(std::unique_ptr<RecordBatch>&& batch) {
     PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportArray(*data, batch->GetData()));
 
     PAIMON_ASSIGN_OR_RAISE(BinaryRow partition,
-                           file_store_path_factory_->ToBinaryRow(batch->GetPartition()))
+                           file_store_path_factory_->ToBinaryRow(batch->GetPartition()));
     PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<BatchWriter> writer,
                            GetWriter(partition, batch->GetBucket()));
     assert(writer);

--- a/src/paimon/core/operation/file_store_commit_impl_test.cpp
+++ b/src/paimon/core/operation/file_store_commit_impl_test.cpp
@@ -254,7 +254,7 @@ class FileStoreCommitImplTest : public testing::Test {
         EXPECT_OK_AND_ASSIGN(std::unique_ptr<InputStream> in_stream, file_system->Open(path));
         EXPECT_TRUE(in_stream);
         EXPECT_OK_AND_ASSIGN([[maybe_unused]] int32_t length,
-                             in_stream->Read(reinterpret_cast<char*>(buffer.data()), buffer.size()))
+                             in_stream->Read(reinterpret_cast<char*>(buffer.data()), buffer.size()));
         EXPECT_OK(in_stream->Close());
         auto pool = GetDefaultPool();
 

--- a/src/paimon/core/operation/file_store_commit_impl_test.cpp
+++ b/src/paimon/core/operation/file_store_commit_impl_test.cpp
@@ -253,8 +253,9 @@ class FileStoreCommitImplTest : public testing::Test {
 
         EXPECT_OK_AND_ASSIGN(std::unique_ptr<InputStream> in_stream, file_system->Open(path));
         EXPECT_TRUE(in_stream);
-        EXPECT_OK_AND_ASSIGN([[maybe_unused]] int32_t length,
-                             in_stream->Read(reinterpret_cast<char*>(buffer.data()), buffer.size()));
+        EXPECT_OK_AND_ASSIGN(
+            [[maybe_unused]] int32_t length,
+            in_stream->Read(reinterpret_cast<char*>(buffer.data()), buffer.size()));
         EXPECT_OK(in_stream->Close());
         auto pool = GetDefaultPool();
 

--- a/src/paimon/format/orc/orc_file_batch_reader_test.cpp
+++ b/src/paimon/format/orc/orc_file_batch_reader_test.cpp
@@ -154,7 +154,7 @@ class OrcFileBatchReaderTest : public ::testing::Test,
         const std::optional<RoaringBitmap32>& selection_bitmap, int32_t batch_size) const {
         EXPECT_OK_AND_ASSIGN(
             auto orc_batch_reader,
-            OrcFileBatchReader::Create(std::move(in_stream), pool_, options, batch_size))
+            OrcFileBatchReader::Create(std::move(in_stream), pool_, options, batch_size));
         EXPECT_TRUE(orc_batch_reader);
         std::unique_ptr<ArrowSchema> c_schema = std::make_unique<ArrowSchema>();
         auto arrow_status = arrow::ExportSchema(*read_schema, c_schema.get());

--- a/src/paimon/global_index/lumina/lumina_global_index.cpp
+++ b/src/paimon/global_index/lumina/lumina_global_index.cpp
@@ -321,7 +321,7 @@ Result<std::vector<GlobalIndexIOMeta>> LuminaIndexWriter::Finish() {
     PAIMON_ASSIGN_OR_RAISE(std::string index_file_name,
                            file_manager_->NewFileName(LuminaDefines::kIdentifier));
     PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<OutputStream> out,
-                           file_manager_->NewOutputStream(index_file_name))
+                           file_manager_->NewOutputStream(index_file_name));
     auto file_writer = std::make_unique<LuminaFileWriter>(out);
     PAIMON_RETURN_NOT_OK_FROM_LUMINA(builder.Dump(std::move(file_writer), io_options_));
     // prepare GlobalIndexIOMeta

--- a/src/paimon/global_index/lumina/lumina_utils.h
+++ b/src/paimon/global_index/lumina/lumina_utils.h
@@ -34,11 +34,11 @@ namespace paimon::lumina {
     auto&& result_name = (rexpr);                                                             \
     PAIMON_RETURN_IF_(!(result_name).IsOk(), LuminaToPaimonStatus((result_name).GetStatus()), \
                       PAIMON_STRINGIFY(rexpr));                                               \
-    lhs = std::move(result_name).TakeValue();
+    lhs = std::move(result_name).TakeValue()
 
 #define PAIMON_ASSIGN_OR_RAISE_FROM_LUMINA(lhs, rexpr) \
     PAIMON_ASSIGN_OR_RAISE_IMPL_FROM_LUMINA(           \
-        PAIMON_ASSIGN_OR_RAISE_NAME(_error_or_value, __COUNTER__), lhs, (rexpr));
+        PAIMON_ASSIGN_OR_RAISE_NAME(_error_or_value, __COUNTER__), lhs, (rexpr))
 
 inline ::lumina::core::Status PaimonToLuminaStatus(const Status& status) {
     switch (status.code()) {

--- a/src/paimon/testing/utils/testharness.h
+++ b/src/paimon/testing/utils/testharness.h
@@ -91,15 +91,15 @@ int64_t RandomNumber(int64_t min, int64_t max);
 #define ASSIGN_OR_HANDLE_ERROR_IMPL(handle_error, status_name, lhs, rexpr) \
     auto&& status_name = (rexpr);                                          \
     handle_error(status_name.status());                                    \
-    lhs = std::move(status_name).value();
+    lhs = std::move(status_name).value()
 
 #define ASSERT_OK_AND_ASSIGN(lhs, rexpr) \
     ASSIGN_OR_HANDLE_ERROR_IMPL(         \
-        ASSERT_OK, PAIMON_ASSIGN_OR_RAISE_NAME(_error_or_value, __COUNTER__), lhs, rexpr);
+        ASSERT_OK, PAIMON_ASSIGN_OR_RAISE_NAME(_error_or_value, __COUNTER__), lhs, rexpr)
 
 #define EXPECT_OK_AND_ASSIGN(lhs, rexpr) \
     ASSIGN_OR_HANDLE_ERROR_IMPL(         \
-        EXPECT_OK, PAIMON_ASSIGN_OR_RAISE_NAME(_error_or_value, __COUNTER__), lhs, rexpr);
+        EXPECT_OK, PAIMON_ASSIGN_OR_RAISE_NAME(_error_or_value, __COUNTER__), lhs, rexpr)
 
 #define EXPECT_OK(s) EXPECT_PRED_FORMAT1(paimon::test::AssertStatus, s)
 #define EXPECT_NOK(s) EXPECT_FALSE((s).ok())


### PR DESCRIPTION
### Purpose

Fix statement-like macro definitions (`PAIMON_ASSIGN_OR_RAISE` family and `ASSERT_OK_AND_ASSIGN` / `EXPECT_OK_AND_ASSIGN`) that included a trailing semicolon in the macro body. This silently allowed callers to omit the semicolon without any compiler error. Removing the trailing semicolon from the macro definitions ensures the compiler enforces correct usage at all call sites.

Also fix 11 call sites across src/ and test/ that were missing the required semicolon.

### Tests

- Full-repo static scan confirmed all `PAIMON_ASSIGN_OR_RAISE` / `ASSERT_OK_AND_ASSIGN` / `EXPECT_OK_AND_ASSIGN` call sites now have trailing semicolons
- Incremental compilation of modified `.cpp` files passed

### API and Format

No. This change only affects macro definitions in internal/test headers. The calling convention (always write a trailing `;`) is unchanged for correct existing code.

### Documentation

No.

### Generative AI tooling

Generated-by: Aone Copilot (GPT-5.5)