### PR TITLE
fix: change FileStorePathFactory::Create() to return shared_ptr

### DIFF
--- a/src/paimon/core/append/append_compact_coordinator.cpp
+++ b/src/paimon/core/append/append_compact_coordinator.cpp
@@ -209,7 +209,7 @@ Status ValidateTable(const std::shared_ptr<TableSchema>& table_schema,
 }
 
 /// Build FileStorePathFactory from core options and table schema.
-Result<std::unique_ptr<FileStorePathFactory>> BuildPathFactory(
+Result<std::shared_ptr<FileStorePathFactory>> BuildPathFactory(
     const std::string& table_path, const std::shared_ptr<TableSchema>& table_schema,
     const std::shared_ptr<arrow::Schema>& arrow_schema, const CoreOptions& core_options,
     const std::shared_ptr<MemoryPool>& pool) {

--- a/src/paimon/core/migrate/file_meta_utils.cpp
+++ b/src/paimon/core/migrate/file_meta_utils.cpp
@@ -148,7 +148,7 @@ Result<std::unique_ptr<CommitMessage>> FileMetaUtils::GenerateCommitMessage(
 
     // generate bucket path
     PAIMON_ASSIGN_OR_RAISE(
-        std::unique_ptr<FileStorePathFactory> file_store_path_factory,
+        std::shared_ptr<FileStorePathFactory> file_store_path_factory,
         FileStorePathFactory::Create(dst_table_path, schema, table_schema->PartitionKeys(),
                                      core_options.GetPartitionDefaultName(), format->Identifier(),
                                      core_options.DataFilePrefix(),

--- a/src/paimon/core/operation/expire_snapshots_test.cpp
+++ b/src/paimon/core/operation/expire_snapshots_test.cpp
@@ -107,7 +107,7 @@ class ExpireSnapshotsTest : public testing::Test {
         return true;
     }
 
-    std::unique_ptr<FileStorePathFactory> CreateFactory(const std::string& root) const {
+    std::shared_ptr<FileStorePathFactory> CreateFactory(const std::string& root) const {
         std::map<std::string, std::string> raw_options;
         raw_options[Options::FILE_FORMAT] = "orc";
         raw_options[Options::MANIFEST_FORMAT] = "orc";

--- a/src/paimon/core/utils/file_store_path_factory.cpp
+++ b/src/paimon/core/utils/file_store_path_factory.cpp
@@ -52,7 +52,7 @@ FileStorePathFactory::FileStorePathFactory(
       global_index_external_path_(global_index_external_path),
       index_file_in_data_file_dir_(index_file_in_data_file_dir) {}
 
-Result<std::unique_ptr<FileStorePathFactory>> FileStorePathFactory::Create(
+Result<std::shared_ptr<FileStorePathFactory>> FileStorePathFactory::Create(
     const std::string& root, const std::shared_ptr<arrow::Schema>& schema,
     const std::vector<std::string>& partition_keys, const std::string& default_part_value,
     const std::string& identifier, const std::string& data_file_prefix,
@@ -70,7 +70,7 @@ Result<std::unique_ptr<FileStorePathFactory>> FileStorePathFactory::Create(
         std::unique_ptr<BinaryRowPartitionComputer> partition_computer,
         BinaryRowPartitionComputer::Create(partition_keys, schema, default_part_value,
                                            legacy_partition_name_enabled, memory_pool));
-    return std::unique_ptr<FileStorePathFactory>(new FileStorePathFactory(
+    return std::shared_ptr<FileStorePathFactory>(new FileStorePathFactory(
         root, identifier, data_file_prefix, uuid, std::move(partition_computer), external_paths,
         global_index_external_path, index_file_in_data_file_dir));
 }

--- a/src/paimon/core/utils/file_store_path_factory.h
+++ b/src/paimon/core/utils/file_store_path_factory.h
@@ -50,7 +50,7 @@ class FileStorePathFactory : public std::enable_shared_from_this<FileStorePathFa
  public:
     static constexpr char BUCKET_PATH_PREFIX[] = "bucket-";
 
-    static Result<std::unique_ptr<FileStorePathFactory>> Create(
+    static Result<std::shared_ptr<FileStorePathFactory>> Create(
         const std::string& root, const std::shared_ptr<arrow::Schema>& schema,
         const std::vector<std::string>& partition_keys, const std::string& default_part_value,
         const std::string& identifier, const std::string& data_file_prefix,

--- a/src/paimon/core/utils/file_store_path_factory_test.cpp
+++ b/src/paimon/core/utils/file_store_path_factory_test.cpp
@@ -44,7 +44,7 @@ class FileStorePathFactoryTest : public ::testing::Test {
     }
     void TearDown() override {}
 
-    std::unique_ptr<FileStorePathFactory> CreateFactory(const std::string& root) const {
+    std::shared_ptr<FileStorePathFactory> CreateFactory(const std::string& root) const {
         arrow::FieldVector fields = {arrow::field("f0", arrow::boolean()),
                                      arrow::field("f1", arrow::int8()),
                                      arrow::field("f2", arrow::int8()),


### PR DESCRIPTION
fix: change FileStorePathFactory::Create() to return shared_ptr

### Purpose

FileStorePathFactory inherits `enable_shared_from_this<FileStorePathFactory>` but `Create()` returned `unique_ptr`. The following 4 public methods call `shared_from_this()` internally:

- `CreateManifestFileFactory()`
- `CreateManifestListFactory()`
- `CreateIndexManifestFileFactory()`
- `CreateGlobalIndexFileFactory()`

When the object is held by `unique_ptr`, calling any of these methods throws `std::bad_weak_ptr`. This PR changes `Create()` to return `std::shared_ptr` so the ownership model is consistent.

### Tests

- Existing `FileStorePathFactoryTest` (9 cases) and `FileStorePathFactoryCacheTest` (1 case) all pass.
- No new tests needed — this is a type-signature fix; runtime behavior is verified by existing tests that exercise `CreateManifestFileFactory()` etc.

### API and Format

- `FileStorePathFactory::Create()` return type changes from `Result<std::unique_ptr<FileStorePathFactory>>` to `Result<std::shared_ptr<FileStorePathFactory>>`. Most callers already receive the result into `std::shared_ptr` (via implicit conversion), so impact is minimal.
- No storage format or protocol changes.

### Documentation

No.

### Generative AI tooling

Generated-by: Aone Copilot (Claude 4.8 Opus)