### PR TITLE
fix: make byte hashing independent of char signedness

### DIFF
--- a/src/paimon/common/utils/murmurhash_utils.h
+++ b/src/paimon/common/utils/murmurhash_utils.h
@@ -182,7 +182,9 @@ class MurmurHashUtils {
         int32_t length_aligned = length_in_bytes - length_in_bytes % 4;
         int32_t h1 = HashBytesByInt(segment, offset, length_aligned, seed);
         for (int32_t i = length_aligned; i < length_in_bytes; i++) {
-            int32_t k1 = MixK1(segment.Get(offset + i));
+            auto byte = static_cast<uint8_t>(segment.Get(offset + i));
+            int32_t signed_byte = byte < 128 ? byte : static_cast<int32_t>(byte) - 256;
+            int32_t k1 = MixK1(signed_byte);
             h1 = MixH1(h1, k1);
         }
         return Fmix(h1, length_in_bytes);
@@ -238,10 +240,10 @@ class MurmurHashUtils {
         return value;
     }
 
-    static char GetByte(const void* base, int64_t offset) {
-        char value;
-        std::memcpy(&value, static_cast<const char*>(base) + offset, sizeof(char));
-        return value;
+    static int32_t GetByte(const void* base, int64_t offset) {
+        uint8_t value;
+        std::memcpy(&value, static_cast<const char*>(base) + offset, sizeof(uint8_t));
+        return value < 128 ? value : static_cast<int32_t>(value) - 256;
     }
 
  public:

--- a/src/paimon/core/bucket/hive_bucket_function.cpp
+++ b/src/paimon/core/bucket/hive_bucket_function.cpp
@@ -86,8 +86,11 @@ uint32_t HiveBucketFunction::ComputeHash(const BinaryRow& row, int32_t field_ind
     switch (info.type) {
         case FieldType::BOOLEAN:
             return HiveHasher::HashInt(row.GetBoolean(field_index) ? 1 : 0);
-        case FieldType::TINYINT:
-            return HiveHasher::HashInt(static_cast<uint32_t>(row.GetByte(field_index)));
+        case FieldType::TINYINT: {
+            auto byte = static_cast<uint8_t>(row.GetByte(field_index));
+            int32_t signed_byte = byte < 128 ? byte : static_cast<int32_t>(byte) - 256;
+            return HiveHasher::HashInt(static_cast<uint32_t>(signed_byte));
+        }
         case FieldType::SMALLINT:
             return HiveHasher::HashInt(static_cast<uint32_t>(row.GetShort(field_index)));
         case FieldType::INT:

--- a/src/paimon/core/bucket/hive_hasher.h
+++ b/src/paimon/core/bucket/hive_hasher.h
@@ -42,7 +42,9 @@ class HiveHasher {
     static uint32_t HashBytes(const char* bytes, int32_t length) {
         uint32_t result = 0;
         for (int32_t i = 0; i < length; i++) {
-            result = result * 31U + static_cast<uint32_t>(static_cast<int32_t>(bytes[i]));
+            auto byte = static_cast<uint8_t>(bytes[i]);
+            int32_t signed_byte = byte < 128 ? byte : static_cast<int32_t>(byte) - 256;
+            result = result * 31U + static_cast<uint32_t>(signed_byte);
         }
         return result;
     }


### PR DESCRIPTION
### Purpose

Fix ARM bucket mismatches caused by platform-dependent `char` signedness.

This change makes byte hashing explicit:
- Hive `TINYINT` hashing now treats row bytes as signed Java bytes.
- Hive string/binary byte-array hashing now treats high-bit bytes as signed Java bytes.
- Murmur tail-byte hashing now reads tail bytes as `int8_t`, avoiding unsigned plain-`char` drift.

### Tests

Pass existing CI.

### API and Format

N/A

### Documentation

N/A

### Generative AI tooling

Generated-by: OpenAI Codex