### PR TITLE
feat(schema): Shrink PK table to unsupported schema evolution

### DIFF
--- a/include/paimon/defs.h
+++ b/include/paimon/defs.h
@@ -508,6 +508,14 @@ struct PAIMON_EXPORT Options {
     /// "lookup.cache-max-disk-size" - Max disk size for lookup cache, you can use this option
     /// to limit the use of local disks. Default value is unlimited (INT64_MAX).
     static const char LOOKUP_CACHE_MAX_DISK_SIZE[];
+
+    /// "scan.pk.schema-compatibility.ignored-options" - A comma-separated list of regular
+    /// expressions describing option keys that are allowed to differ across schema versions when
+    /// performing the primary-key scan compatibility check. This is NOT general schema-evolution
+    /// support: it only permits property-only changes that do not affect the read semantics of
+    /// PK tables (e.g. write-side knobs). All other options must still be identical across schema
+    /// versions, otherwise the scan will fail. No default value (no extra options ignored).
+    static const char SCAN_PK_SCHEMA_COMPATIBILITY_IGNORED_OPTIONS[];
 };
 
 static constexpr int64_t BATCH_WRITE_COMMIT_IDENTIFIER = std::numeric_limits<int64_t>::max();

--- a/src/paimon/common/defs.cpp
+++ b/src/paimon/common/defs.cpp
@@ -141,4 +141,6 @@ const char Options::LOOKUP_CACHE_HIGH_PRIO_POOL_RATIO[] = "lookup.cache.high-pri
 const char Options::BUCKET_FUNCTION_TYPE[] = "bucket-function.type";
 const char Options::LOOKUP_CACHE_FILE_RETENTION[] = "lookup.cache-file-retention";
 const char Options::LOOKUP_CACHE_MAX_DISK_SIZE[] = "lookup.cache-max-disk-size";
+const char Options::SCAN_PK_SCHEMA_COMPATIBILITY_IGNORED_OPTIONS[] =
+    "scan.pk.schema-compatibility.ignored-options";
 }  // namespace paimon

--- a/src/paimon/core/core_options.cpp
+++ b/src/paimon/core/core_options.cpp
@@ -381,6 +381,7 @@ struct CoreOptions::Impl {
     std::vector<std::string> blob_descriptor_fields;
     std::vector<std::string> blob_view_fields;
     std::vector<std::string> blob_external_storage_fields;
+    std::vector<std::string> pk_scan_schema_compatibility_ignored_options;
 
     std::string partition_default_name = "__DEFAULT_PARTITION__";
     StartupMode startup_mode = StartupMode::Default();
@@ -721,6 +722,11 @@ struct CoreOptions::Impl {
         PAIMON_RETURN_NOT_OK(parser.Parse(Options::BRANCH, &branch));
         // Parse scan.tag-name - optional tag name for "from-snapshot" scan mode
         PAIMON_RETURN_NOT_OK(parser.Parse(Options::SCAN_TAG_NAME, &scan_tag_name));
+        // Parse scan.pk.schema-compatibility.ignored-options - regex list of option keys that may
+        // differ across schema versions when doing the conservative PK scan compatibility check.
+        PAIMON_RETURN_NOT_OK(parser.ParseList<std::string>(
+            Options::SCAN_PK_SCHEMA_COMPATIBILITY_IGNORED_OPTIONS, Options::FIELDS_SEPARATOR,
+            &pk_scan_schema_compatibility_ignored_options, /*need_trim=*/true));
         return Status::OK();
     }
 
@@ -1261,6 +1267,10 @@ std::vector<std::string> CoreOptions::GetPartialUpdateRemoveRecordOnSequenceGrou
 
 std::optional<std::string> CoreOptions::GetScanFallbackBranch() const {
     return impl_->scan_fallback_branch;
+}
+
+const std::vector<std::string>& CoreOptions::GetPKScanSchemaCompatibilityIgnoredOptions() const {
+    return impl_->pk_scan_schema_compatibility_ignored_options;
 }
 
 std::string CoreOptions::GetBranch() const {

--- a/src/paimon/core/core_options.h
+++ b/src/paimon/core/core_options.h
@@ -133,6 +133,7 @@ class PAIMON_EXPORT CoreOptions {
     std::vector<std::string> GetPartialUpdateRemoveRecordOnSequenceGroup() const;
 
     std::optional<std::string> GetScanFallbackBranch() const;
+    const std::vector<std::string>& GetPKScanSchemaCompatibilityIgnoredOptions() const;
     std::string GetBranch() const;
 
     ExternalPathStrategy GetExternalPathStrategy() const;

--- a/src/paimon/core/core_options_test.cpp
+++ b/src/paimon/core/core_options_test.cpp
@@ -262,7 +262,9 @@ TEST(CoreOptionsTest, TestFromMap) {
         {Options::LOOKUP_REMOTE_LEVEL_THRESHOLD, "2"},
         {Options::TABLE_READ_SEQUENCE_NUMBER_ENABLED, "true"},
         {Options::KEY_VALUE_SEQUENCE_NUMBER_ENABLED, "true"},
-        {Options::BUCKET_FUNCTION_TYPE, "mod"}};
+        {Options::BUCKET_FUNCTION_TYPE, "mod"},
+        {Options::SCAN_PK_SCHEMA_COMPATIBILITY_IGNORED_OPTIONS,
+         "custom\\.property, write\\..*"}};
 
     ASSERT_OK_AND_ASSIGN(CoreOptions core_options, CoreOptions::FromMap(options));
     auto fs = core_options.GetFileSystem();
@@ -404,6 +406,8 @@ TEST(CoreOptionsTest, TestFromMap) {
     ASSERT_TRUE(core_options.LookupRemoteFileEnabled());
     ASSERT_EQ(core_options.GetLookupRemoteLevelThreshold(), 2);
     ASSERT_EQ(BucketFunctionType::MOD, core_options.GetBucketFunctionType());
+    ASSERT_EQ((std::vector<std::string>{"custom\\.property", "write\\..*"}),
+              core_options.GetPKScanSchemaCompatibilityIgnoredOptions());
 }
 
 TEST(CoreOptionsTest, TestInvalidCase) {

--- a/src/paimon/core/operation/key_value_file_store_scan.cpp
+++ b/src/paimon/core/operation/key_value_file_store_scan.cpp
@@ -33,6 +33,7 @@
 #include "paimon/core/core_options.h"
 #include "paimon/core/io/data_file_meta.h"
 #include "paimon/core/options/merge_engine.h"
+#include "paimon/core/schema/schema_manager.h"
 #include "paimon/core/schema/table_schema.h"
 #include "paimon/core/stats/simple_stats.h"
 #include "paimon/core/stats/simple_stats_evolution.h"
@@ -61,6 +62,14 @@ Result<std::unique_ptr<KeyValueFileStoreScan>> KeyValueFileStoreScan::Create(
     const std::shared_ptr<arrow::Schema>& arrow_schema,
     const std::shared_ptr<ScanFilter>& scan_filters, const CoreOptions& core_options,
     const std::shared_ptr<Executor>& executor, const std::shared_ptr<MemoryPool>& pool) {
+    PAIMON_ASSIGN_OR_RAISE(
+        bool compatible,
+        schema_manager->IsSchemasCompatibleForPKScan(
+            *table_schema, core_options.GetPKScanSchemaCompatibilityIgnoredOptions()));
+    if (!compatible) {
+        return Status::NotImplemented(
+            "do not support schema evolution in pk table while scan process");
+    }
     auto scan = std::unique_ptr<KeyValueFileStoreScan>(
         new KeyValueFileStoreScan(snapshot_manager, schema_manager, manifest_list, manifest_file,
                                   table_schema, arrow_schema, core_options, executor, pool));
@@ -188,15 +197,12 @@ Result<bool> KeyValueFileStoreScan::FilterByValueFilter(const ManifestEntry& ent
     }
 
     const auto& meta = entry.File();
-
-    // Primary key table currently does not support schema evolution for value filtering.
-    // Here we only handle `value_stats_cols` (dense stats) projection.
+    std::shared_ptr<TableSchema> data_schema = table_schema_;
     if (meta->schema_id != table_schema_->Id()) {
-        return Status::NotImplemented(
-            "Primary key table does not support schema evolution in FilterByValueFilter");
+        PAIMON_ASSIGN_OR_RAISE(data_schema, schema_manager_->ReadSchema(meta->schema_id));
     }
 
-    auto evolution = evolutions_->GetOrCreate(table_schema_);
+    auto evolution = evolutions_->GetOrCreate(data_schema);
 
     PAIMON_ASSIGN_OR_RAISE(
         SimpleStatsEvolution::EvolutionStats new_stats,

--- a/src/paimon/core/operation/key_value_file_store_scan_test.cpp
+++ b/src/paimon/core/operation/key_value_file_store_scan_test.cpp
@@ -42,6 +42,7 @@
 #include "paimon/data/timestamp.h"
 #include "paimon/defs.h"
 #include "paimon/executor.h"
+#include "paimon/fs/file_system.h"
 #include "paimon/format/file_format.h"
 #include "paimon/memory/memory_pool.h"
 #include "paimon/metrics.h"
@@ -56,6 +57,16 @@ class Schema;
 }  // namespace arrow
 
 namespace paimon::test {
+namespace {
+
+void WriteSchemaFile(const std::shared_ptr<FileSystem>& fs, const std::string& table_path,
+                     int64_t schema_id, const std::string& schema_json) {
+    ASSERT_OK(fs->WriteFile(table_path + "/schema/schema-" + std::to_string(schema_id),
+                            schema_json, /*overwrite=*/false));
+}
+
+}  // namespace
+
 class KeyValueFileStoreScanTest : public testing::Test {
  public:
     void SetUp() override {
@@ -116,6 +127,46 @@ class KeyValueFileStoreScanTest : public testing::Test {
         PAIMON_ASSIGN_OR_RAISE(Snapshot snapshot, snapshot_manager->LoadSnapshot(snapshot_id));
         scan->WithSnapshot(snapshot);
         return scan;
+    }
+
+    Result<std::unique_ptr<KeyValueFileStoreScan>> CreateSchemaOnlyFileStoreScan(
+        const std::string& table_path, int32_t table_schema_id,
+        const std::map<std::string, std::string>& options_map) const {
+        PAIMON_ASSIGN_OR_RAISE(CoreOptions core_options, CoreOptions::FromMap(options_map));
+        auto fs = core_options.GetFileSystem();
+        auto schema_manager = std::make_shared<SchemaManager>(fs, table_path);
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<TableSchema> table_schema,
+                               schema_manager->ReadSchema(table_schema_id));
+        auto arrow_schema = DataField::ConvertDataFieldsToArrowSchema(table_schema->Fields());
+        PAIMON_ASSIGN_OR_RAISE(std::vector<std::string> external_paths,
+                               core_options.CreateExternalPaths());
+        PAIMON_ASSIGN_OR_RAISE(std::optional<std::string> global_index_external_path,
+                               core_options.CreateGlobalIndexExternalPath());
+        PAIMON_ASSIGN_OR_RAISE(
+            std::shared_ptr<FileStorePathFactory> path_factory,
+            FileStorePathFactory::Create(
+                table_path, arrow_schema, table_schema->PartitionKeys(),
+                core_options.GetPartitionDefaultName(), core_options.GetFileFormat()->Identifier(),
+                core_options.DataFilePrefix(), core_options.LegacyPartitionNameEnabled(),
+                external_paths, global_index_external_path, core_options.IndexFileInDataFileDir(),
+                pool_));
+        auto manifest_file_format = core_options.GetManifestFormat();
+        auto snapshot_manager = std::make_shared<SnapshotManager>(fs, table_path);
+        PAIMON_ASSIGN_OR_RAISE(
+            std::shared_ptr<ManifestList> manifest_list,
+            ManifestList::Create(fs, manifest_file_format, core_options.GetManifestCompression(),
+                                 path_factory, pool_));
+        PAIMON_ASSIGN_OR_RAISE(
+            std::shared_ptr<arrow::Schema> partition_schema,
+            FieldMapping::GetPartitionSchema(arrow_schema, table_schema->PartitionKeys()));
+        PAIMON_ASSIGN_OR_RAISE(
+            std::shared_ptr<ManifestFile> manifest_file,
+            ManifestFile::Create(fs, manifest_file_format, core_options.GetManifestCompression(),
+                                 path_factory, core_options.GetManifestTargetFileSize(), pool_,
+                                 core_options, partition_schema));
+        return KeyValueFileStoreScan::Create(
+            snapshot_manager, schema_manager, manifest_list, manifest_file, table_schema,
+            arrow_schema, /*scan_filters=*/nullptr, core_options, CreateDefaultExecutor(), pool_);
     }
 
     static int64_t GetMaxSequenceNumberOfRawPlan(
@@ -242,6 +293,71 @@ TEST_F(KeyValueFileStoreScanTest, TestMaxSequenceNumber) {
         int64_t max_sequence_num = GetMaxSequenceNumberOfRawPlan(raw_plan);
         ASSERT_EQ(max_sequence_num, 7);
     }
+}
+
+TEST_F(KeyValueFileStoreScanTest, TestCreateChecksPKScanSchemaCompatibility) {
+    auto dir = UniqueTestDirectory::Create();
+    const std::string path = dir->Str();
+    const std::string schema0 = R"({
+        "version" : 3,
+        "id" : 0,
+        "fields" : [ {
+                "id" : 0,
+                "name" : "pk",
+                "type" : "INT NOT NULL"
+        }, {
+                "id" : 1,
+                "name" : "v",
+                "type" : "STRING"
+        } ],
+        "highestFieldId" : 1,
+        "partitionKeys" : [],
+        "primaryKeys" : [ "pk" ],
+        "options" : {
+                "bucket" : "1",
+                "file.format" : "orc",
+                "manifest.format" : "orc"
+        },
+        "timeMillis" : 1000
+    })";
+    const std::string schema1_property_changed = R"({
+        "version" : 3,
+        "id" : 1,
+        "fields" : [ {
+                "id" : 0,
+                "name" : "pk",
+                "type" : "INT NOT NULL"
+        }, {
+                "id" : 1,
+                "name" : "v",
+                "type" : "STRING"
+        } ],
+        "highestFieldId" : 1,
+        "partitionKeys" : [],
+        "primaryKeys" : [ "pk" ],
+        "options" : {
+                "bucket" : "1",
+                "file.format" : "orc",
+                "manifest.format" : "orc",
+                "custom.property" : "new-value"
+        },
+        "timeMillis" : 2000
+    })";
+    WriteSchemaFile(dir->GetFileSystem(), path, /*schema_id=*/0, schema0);
+    WriteSchemaFile(dir->GetFileSystem(), path, /*schema_id=*/1, schema1_property_changed);
+
+    std::map<std::string, std::string> options = {{Options::FILE_FORMAT, "orc"},
+                                                  {Options::MANIFEST_FORMAT, "orc"}};
+    ASSERT_NOK_WITH_MSG(CreateSchemaOnlyFileStoreScan(path, /*table_schema_id=*/1, options),
+                        "do not support schema evolution");
+    ASSERT_NOK_WITH_MSG(CreateSchemaOnlyFileStoreScan(path, /*table_schema_id=*/0, options),
+                        "do not support schema evolution");
+
+    options[Options::SCAN_PK_SCHEMA_COMPATIBILITY_IGNORED_OPTIONS] = "custom\\.property";
+    ASSERT_OK_AND_ASSIGN([[maybe_unused]] std::unique_ptr<KeyValueFileStoreScan> scan,
+                         CreateSchemaOnlyFileStoreScan(path, /*table_schema_id=*/1, options));
+    ASSERT_OK_AND_ASSIGN([[maybe_unused]] std::unique_ptr<KeyValueFileStoreScan> scan_from_schema0,
+                         CreateSchemaOnlyFileStoreScan(path, /*table_schema_id=*/0, options));
 }
 
 TEST_F(KeyValueFileStoreScanTest, TestScanDurationMetric) {

--- a/src/paimon/core/schema/schema_manager.cpp
+++ b/src/paimon/core/schema/schema_manager.cpp
@@ -66,16 +66,25 @@ Result<std::optional<std::shared_ptr<TableSchema>>> SchemaManager::Latest() cons
 }
 
 Result<std::shared_ptr<TableSchema>> SchemaManager::ReadSchema(int64_t schema_id) const {
-    auto iter = schema_cache_.find(schema_id);
-    if (iter != schema_cache_.end()) {
-        return iter->second;
+    {
+        std::lock_guard<std::mutex> lock(schema_cache_mutex_);
+        auto iter = schema_cache_.find(schema_id);
+        if (iter != schema_cache_.end()) {
+            return iter->second;
+        }
     }
     auto path = ToSchemaPath(schema_id);
     std::string content;
     PAIMON_RETURN_NOT_OK(file_system_->ReadFile(path, &content));
     PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<TableSchema> schema,
                            TableSchema::CreateFromJson(content));
-    schema_cache_[schema_id] = schema;
+    {
+        std::lock_guard<std::mutex> lock(schema_cache_mutex_);
+        // Another thread may have raced us; either entry is functionally identical so we just
+        // overwrite (or insert) and return the schema we read. Returning the cached entry would
+        // also be correct, but is not necessary for correctness.
+        schema_cache_[schema_id] = schema;
+    }
     return schema;
 }
 
@@ -93,6 +102,25 @@ Result<std::vector<int64_t>> SchemaManager::ListAllIds() const {
     PAIMON_RETURN_NOT_OK(FileUtils::ListVersionedFiles(file_system_, SchemaDirectory(),
                                                        std::string(SCHEMA_PREFIX), &versions));
     return versions;
+}
+
+Result<bool> SchemaManager::IsSchemasCompatibleForPKScan(
+    const TableSchema& table_schema,
+    const std::vector<std::string>& ignored_option_patterns) const {
+    PAIMON_ASSIGN_OR_RAISE(std::vector<int64_t> schema_ids, ListAllIds());
+    for (int64_t schema_id : schema_ids) {
+        // Skip self-compare: comparing a schema against itself is trivially true and would only
+        // waste a file read (or cache lookup). This also keeps the check meaningful in the
+        // common single-schema case.
+        if (schema_id == table_schema.Id()) {
+            continue;
+        }
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<TableSchema> schema, ReadSchema(schema_id));
+        if (!table_schema.IsCompatibleForPKScan(*schema, ignored_option_patterns)) {
+            return false;
+        }
+    }
+    return true;
 }
 
 Result<std::unique_ptr<TableSchema>> SchemaManager::CreateTable(

--- a/src/paimon/core/schema/schema_manager.h
+++ b/src/paimon/core/schema/schema_manager.h
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <vector>
@@ -54,6 +55,14 @@ class SchemaManager {
     std::string SchemaDirectory() const;
     Result<bool> SchemaExists(int64_t id) const;
     Result<std::vector<int64_t>> ListAllIds() const;
+    // This is not schema evolution support. It only verifies that every other schema version is
+    // equivalent to the given schema for primary-key scan, so property-only changes can reuse the
+    // normal read path. The schema with the same id as `table_schema` is skipped (self-compare),
+    // and option keys whose names match any of the regex patterns in `ignored_option_patterns`
+    // are allowed to differ across schema versions.
+    Result<bool> IsSchemasCompatibleForPKScan(
+        const TableSchema& table_schema,
+        const std::vector<std::string>& ignored_option_patterns = {}) const;
 
  private:
     std::string BranchPath() const;
@@ -66,6 +75,10 @@ class SchemaManager {
     std::shared_ptr<FileSystem> file_system_;
     std::string table_root_;
     const std::string branch_;
+    // `schema_cache_` may be queried from parallel scan paths (FileStoreScan executes manifest
+    // reads concurrently via `ReadFileEntries`), so reads / writes must be serialized to avoid
+    // racing on the underlying std::map.
+    mutable std::mutex schema_cache_mutex_;
     mutable std::map<int64_t, std::shared_ptr<TableSchema>> schema_cache_;
 };
 

--- a/src/paimon/core/schema/schema_manager_test.cpp
+++ b/src/paimon/core/schema/schema_manager_test.cpp
@@ -16,16 +16,29 @@
 
 #include "paimon/core/schema/schema_manager.h"
 
+#include <cstdint>
+#include <memory>
 #include <set>
+#include <string>
 #include <utility>
 
 #include "arrow/type.h"
 #include "gtest/gtest.h"
+#include "paimon/fs/file_system.h"
 #include "paimon/fs/local/local_file_system.h"
 #include "paimon/status.h"
 #include "paimon/testing/utils/testharness.h"
 
 namespace paimon::test {
+namespace {
+
+void WriteSchemaFile(const std::shared_ptr<FileSystem>& fs, const std::string& table_path,
+                     int64_t schema_id, const std::string& schema_json) {
+    ASSERT_OK(fs->WriteFile(table_path + "/schema/schema-" + std::to_string(schema_id),
+                            schema_json, /*overwrite=*/false));
+}
+
+}  // namespace
 
 TEST(SchemaManagerTest, TestSimple) {
     auto fs = std::make_shared<LocalFileSystem>();
@@ -196,5 +209,119 @@ TEST(SchemaManagerTest, TestListAllIds) {
     SchemaManager manager(fs, table_root);
     ASSERT_OK_AND_ASSIGN(auto ids, manager.ListAllIds());
     ASSERT_EQ(std::set<int64_t>(ids.begin(), ids.end()), std::set<int64_t>({0, 1, 2, 3, 4}));
+}
+
+TEST(SchemaManagerTest, TestAllSchemasCompatibleForPrimaryKeyScan) {
+    auto dir = UniqueTestDirectory::Create();
+    const std::string path = dir->Str();
+    const std::string schema0 = R"({
+        "version" : 3,
+        "id" : 0,
+        "fields" : [ {
+                "id" : 0,
+                "name" : "pk",
+                "type" : "INT NOT NULL"
+        }, {
+                "id" : 1,
+                "name" : "v",
+                "type" : "STRING"
+        } ],
+        "highestFieldId" : 1,
+        "partitionKeys" : [],
+        "primaryKeys" : [ "pk" ],
+        "options" : {
+                "bucket" : "1",
+                "file.format" : "orc",
+                "manifest.format" : "orc"
+        },
+        "timeMillis" : 1000
+    })";
+    const std::string schema1_property_changed = R"({
+        "version" : 3,
+        "id" : 1,
+        "fields" : [ {
+                "id" : 0,
+                "name" : "pk",
+                "type" : "INT NOT NULL"
+        }, {
+                "id" : 1,
+                "name" : "v",
+                "type" : "STRING"
+        } ],
+        "highestFieldId" : 1,
+        "partitionKeys" : [],
+        "primaryKeys" : [ "pk" ],
+        "options" : {
+                "bucket" : "1",
+                "file.format" : "orc",
+                "manifest.format" : "orc",
+                "custom.property" : "new-value"
+        },
+        "timeMillis" : 2000
+    })";
+    const std::string schema2_field_changed = R"({
+        "version" : 3,
+        "id" : 2,
+        "fields" : [ {
+                "id" : 0,
+                "name" : "pk",
+                "type" : "INT NOT NULL"
+        }, {
+                "id" : 1,
+                "name" : "v",
+                "type" : "STRING"
+        }, {
+                "id" : 2,
+                "name" : "v2",
+                "type" : "STRING"
+        } ],
+        "highestFieldId" : 2,
+        "partitionKeys" : [],
+        "primaryKeys" : [ "pk" ],
+        "options" : {
+                "bucket" : "1",
+                "file.format" : "orc",
+                "manifest.format" : "orc"
+        },
+        "timeMillis" : 3000
+    })";
+
+    WriteSchemaFile(dir->GetFileSystem(), path, /*schema_id=*/0, schema0);
+    WriteSchemaFile(dir->GetFileSystem(), path, /*schema_id=*/1, schema1_property_changed);
+
+    SchemaManager manager(dir->GetFileSystem(), path);
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> compatible_schema,
+                         manager.ReadSchema(/*schema_id=*/1));
+    // Strict default: an unconfigured property change makes the schemas incompatible.
+    ASSERT_OK_AND_ASSIGN(bool default_compatible,
+                         manager.IsSchemasCompatibleForPKScan(*compatible_schema));
+    ASSERT_FALSE(default_compatible);
+
+    // After whitelisting `custom.property` via the ignored-options regex list, the property-only
+    // change is treated as compatible.
+    ASSERT_OK_AND_ASSIGN(bool compatible,
+                         manager.IsSchemasCompatibleForPKScan(
+                             *compatible_schema, {"custom\\.property"}));
+    ASSERT_TRUE(compatible);
+
+    // Self-compare must be skipped: passing schema 0 (which is identical to itself) and asking
+    // it to be compared against schema 1 with `custom.property` in the ignore list should still
+    // succeed without read errors and without the function returning false due to comparing a
+    // schema with itself.
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> base_schema,
+                         manager.ReadSchema(/*schema_id=*/0));
+    ASSERT_OK_AND_ASSIGN(bool self_skip_compatible,
+                         manager.IsSchemasCompatibleForPKScan(
+                             *base_schema, {"custom\\.property"}));
+    ASSERT_TRUE(self_skip_compatible);
+
+    WriteSchemaFile(dir->GetFileSystem(), path, /*schema_id=*/2, schema2_field_changed);
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> incompatible_schema,
+                         manager.ReadSchema(/*schema_id=*/2));
+    // Field-shape changes remain incompatible regardless of the ignored-options config.
+    ASSERT_OK_AND_ASSIGN(bool incompatible,
+                         manager.IsSchemasCompatibleForPKScan(
+                             *incompatible_schema, {".*"}));
+    ASSERT_FALSE(incompatible);
 }
 }  // namespace paimon::test

--- a/src/paimon/core/schema/table_schema.cpp
+++ b/src/paimon/core/schema/table_schema.cpp
@@ -18,6 +18,8 @@
 
 #include <algorithm>
 #include <iterator>
+#include <optional>
+#include <regex>
 #include <set>
 #include <utility>
 
@@ -40,6 +42,50 @@
 #include "rapidjson/rapidjson.h"
 
 namespace paimon {
+namespace {
+
+std::optional<std::string> GetOptionValue(const std::map<std::string, std::string>& options,
+                                          const std::string& key) {
+    auto iter = options.find(key);
+    if (iter == options.end()) {
+        return std::nullopt;
+    }
+    return iter->second;
+}
+
+// Compile a list of regex patterns. Patterns that fail to compile are silently dropped, since the
+// configuration is user-provided and we do not want a single malformed entry to break scans on
+// otherwise compatible PK tables. The compiled regexes are matched against option keys using
+// `std::regex_match` (i.e. full-string match).
+std::vector<std::regex> CompileIgnoredOptionPatterns(
+    const std::vector<std::string>& patterns) {
+    std::vector<std::regex> compiled;
+    compiled.reserve(patterns.size());
+    for (const auto& raw : patterns) {
+        std::string pattern = raw;
+        StringUtils::Trim(&pattern);
+        if (pattern.empty()) {
+            continue;
+        }
+        try {
+            compiled.emplace_back(pattern);
+        } catch (const std::regex_error&) {
+            // Skip invalid patterns; users should rely on tests / logs to discover typos.
+        }
+    }
+    return compiled;
+}
+
+bool IsOptionKeyIgnored(const std::string& key, const std::vector<std::regex>& patterns) {
+    for (const auto& re : patterns) {
+        if (std::regex_match(key, re)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+}  // namespace
 
 Result<std::unique_ptr<TableSchema>> TableSchema::Create(
     int64_t schema_id, const std::shared_ptr<arrow::Schema>& schema,
@@ -312,6 +358,39 @@ Result<std::vector<DataField>> TableSchema::TrimmedPrimaryKeyFields() const {
 Result<std::shared_ptr<arrow::Schema>> TableSchema::TrimmedPrimaryKeySchema() const {
     PAIMON_ASSIGN_OR_RAISE(std::vector<DataField> pk_fields, TrimmedPrimaryKeyFields());
     return DataField::ConvertDataFieldsToArrowSchema(pk_fields);
+}
+
+bool TableSchema::IsCompatibleForPKScan(
+    const TableSchema& data_schema,
+    const std::vector<std::string>& ignored_option_patterns) const {
+    if (fields_ != data_schema.fields_ || highest_field_id_ != data_schema.highest_field_id_ ||
+        partition_keys_ != data_schema.partition_keys_ ||
+        primary_keys_ != data_schema.primary_keys_ || bucket_keys_ != data_schema.bucket_keys_ ||
+        num_bucket_ != data_schema.num_bucket_) {
+        return false;
+    }
+
+    // Blacklist semantics: every option key participates in the equality check by default; only
+    // keys that match one of the user-provided regex patterns are allowed to differ. This keeps
+    // the check conservative for unknown / future options that may affect read semantics, while
+    // letting users opt-in to ignoring write-side / metadata-only properties they know are safe.
+    const std::vector<std::regex> ignored_patterns =
+        CompileIgnoredOptionPatterns(ignored_option_patterns);
+
+    auto compare_against = [&](const std::map<std::string, std::string>& lhs,
+                               const std::map<std::string, std::string>& rhs) {
+        for (const auto& [key, value] : lhs) {
+            if (IsOptionKeyIgnored(key, ignored_patterns)) {
+                continue;
+            }
+            if (GetOptionValue(rhs, key) != value) {
+                return false;
+            }
+        }
+        return true;
+    };
+    return compare_against(options_, data_schema.options_) &&
+           compare_against(data_schema.options_, options_);
 }
 
 /// Original bucket keys, maybe empty.

--- a/src/paimon/core/schema/table_schema.h
+++ b/src/paimon/core/schema/table_schema.h
@@ -104,6 +104,18 @@ class TableSchema : public DataSchema, public Jsonizable<TableSchema> {
     Result<std::vector<DataField>> TrimmedPrimaryKeyFields() const;
     Result<std::shared_ptr<arrow::Schema>> TrimmedPrimaryKeySchema() const;
 
+    // This is not schema evolution support. It only checks whether two schema versions are
+    // equivalent for primary-key scan, so property-only changes can reuse the normal read path.
+    //
+    // Compatibility model: The two schemas must agree on every aspect that affects PK read
+    // semantics (fields, ids, partition / primary / bucket keys, num_bucket and ALL options).
+    // The only allowed differences are in option keys whose names match one of the regular
+    // expressions provided in `ignored_option_patterns` (full match), which lets users opt-in
+    // to ignoring a known set of write-side / metadata-only properties.
+    bool IsCompatibleForPKScan(
+        const TableSchema& data_schema,
+        const std::vector<std::string>& ignored_option_patterns = {}) const;
+
     std::optional<std::string> Comment() const override {
         return comment_;
     }

--- a/src/paimon/core/schema/table_schema_test.cpp
+++ b/src/paimon/core/schema/table_schema_test.cpp
@@ -429,6 +429,146 @@ TEST_F(TableSchemaTest, TestEmptyBucketKey) {
     }
 }
 
+TEST_F(TableSchemaTest, TestPrimaryKeyScanSchemaCompatibility) {
+    std::string schema0 = R"({
+        "version" : 3,
+        "id" : 0,
+        "fields" : [ {
+                "id" : 0,
+                "name" : "pk",
+                "type" : "INT NOT NULL"
+        }, {
+                "id" : 1,
+                "name" : "v",
+                "type" : "STRING"
+        } ],
+        "highestFieldId" : 1,
+        "partitionKeys" : [],
+        "primaryKeys" : [ "pk" ],
+        "options" : {
+                "bucket" : "2",
+                "file.format" : "orc",
+                "manifest.format" : "orc"
+        },
+        "timeMillis" : 1000
+    })";
+    std::string schema1_only_property_changed = R"({
+        "version" : 3,
+        "id" : 1,
+        "fields" : [ {
+                "id" : 0,
+                "name" : "pk",
+                "type" : "INT NOT NULL"
+        }, {
+                "id" : 1,
+                "name" : "v",
+                "type" : "STRING"
+        } ],
+        "highestFieldId" : 1,
+        "partitionKeys" : [],
+        "primaryKeys" : [ "pk" ],
+        "options" : {
+                "bucket" : "2",
+                "file.format" : "orc",
+                "manifest.format" : "orc",
+                "user.property" : "new-value"
+        },
+        "timeMillis" : 2000
+    })";
+    std::string schema1_field_changed = R"({
+        "version" : 3,
+        "id" : 1,
+        "fields" : [ {
+                "id" : 0,
+                "name" : "pk",
+                "type" : "INT NOT NULL"
+        }, {
+                "id" : 1,
+                "name" : "v",
+                "type" : "STRING"
+        }, {
+                "id" : 2,
+                "name" : "v2",
+                "type" : "STRING"
+        } ],
+        "highestFieldId" : 2,
+        "partitionKeys" : [],
+        "primaryKeys" : [ "pk" ],
+        "options" : {
+                "bucket" : "2",
+                "file.format" : "orc",
+                "manifest.format" : "orc"
+        },
+        "timeMillis" : 2000
+    })";
+    std::string schema1_read_option_changed = R"({
+        "version" : 3,
+        "id" : 1,
+        "fields" : [ {
+                "id" : 0,
+                "name" : "pk",
+                "type" : "INT NOT NULL"
+        }, {
+                "id" : 1,
+                "name" : "v",
+                "type" : "STRING"
+        } ],
+        "highestFieldId" : 1,
+        "partitionKeys" : [],
+        "primaryKeys" : [ "pk" ],
+        "options" : {
+                "bucket" : "2",
+                "file.format" : "orc",
+                "manifest.format" : "orc",
+                "merge-engine" : "partial-update"
+        },
+        "timeMillis" : 2000
+    })";
+
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<TableSchema> base_schema,
+                         TableSchema::CreateFromJson(schema0));
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<TableSchema> property_changed,
+                         TableSchema::CreateFromJson(schema1_only_property_changed));
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<TableSchema> field_changed,
+                         TableSchema::CreateFromJson(schema1_field_changed));
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<TableSchema> read_option_changed,
+                         TableSchema::CreateFromJson(schema1_read_option_changed));
+
+    // Default behavior is a strict blacklist: ANY option-key difference is incompatible.
+    ASSERT_FALSE(property_changed->IsCompatibleForPKScan(*base_schema));
+    ASSERT_FALSE(base_schema->IsCompatibleForPKScan(*property_changed));
+    ASSERT_FALSE(field_changed->IsCompatibleForPKScan(*base_schema));
+    ASSERT_FALSE(read_option_changed->IsCompatibleForPKScan(*base_schema));
+
+    // Users may opt-in to ignoring specific option keys via regex patterns; once
+    // `user.property` is whitelisted, the property-only change becomes compatible. Field changes
+    // remain incompatible regardless of the ignored-options config.
+    const std::vector<std::string> ignore_user_property = {"user\\.property"};
+    ASSERT_TRUE(property_changed->IsCompatibleForPKScan(*base_schema,
+                                                                ignore_user_property));
+    ASSERT_TRUE(base_schema->IsCompatibleForPKScan(*property_changed,
+                                                           ignore_user_property));
+    ASSERT_FALSE(field_changed->IsCompatibleForPKScan(*base_schema,
+                                                              ignore_user_property));
+    // Read-relevant options (e.g. merge-engine) are still considered incompatible even if the
+    // ignore list does not cover them.
+    ASSERT_FALSE(read_option_changed->IsCompatibleForPKScan(*base_schema,
+                                                                    ignore_user_property));
+
+    // A wildcard regex matches any key, so all property-only differences are ignored. Read
+    // option changes therefore become compatible too — this is intentional: users opting-in
+    // to such broad patterns explicitly take responsibility.
+    const std::vector<std::string> ignore_all = {".*"};
+    ASSERT_TRUE(read_option_changed->IsCompatibleForPKScan(*base_schema, ignore_all));
+    // Field-level changes are still always incompatible since they are checked before options.
+    ASSERT_FALSE(field_changed->IsCompatibleForPKScan(*base_schema, ignore_all));
+
+    // Invalid regex patterns are silently ignored, so a malformed entry must not cause the
+    // function to crash or to suddenly accept previously-rejected schemas.
+    const std::vector<std::string> only_invalid = {"["};
+    ASSERT_FALSE(property_changed->IsCompatibleForPKScan(*base_schema, only_invalid));
+}
+
 TEST_F(TableSchemaTest, TestToJson) {
     auto field1 = DataField(0, arrow::field("f0", arrow::utf8()));
     auto field2 = DataField(1, arrow::field("f1", arrow::int32()));

--- a/src/paimon/core/table/source/table_scan.cpp
+++ b/src/paimon/core/table/source/table_scan.cpp
@@ -54,6 +54,7 @@
 #include "paimon/core/utils/file_store_path_factory.h"
 #include "paimon/core/utils/index_file_path_factories.h"
 #include "paimon/core/utils/snapshot_manager.h"
+#include "paimon/defs.h"
 #include "paimon/format/file_format.h"
 #include "paimon/result.h"
 #include "paimon/scan_context.h"
@@ -201,11 +202,6 @@ Result<std::unique_ptr<TableScan>> NewDataTableScan(const std::shared_ptr<ScanCo
         return Status::Invalid("not found latest schema");
     }
     const auto& table_schema = latest_table_schema.value();
-    if (table_schema->Id() != TableSchema::FIRST_SCHEMA_ID &&
-        !table_schema->PrimaryKeys().empty()) {
-        return Status::NotImplemented(
-            "do not support schema evolution in pk table while scan process");
-    }
     // merge options
     auto options = table_schema->Options();
     for (const auto& [key, value] : context->GetOptions()) {

--- a/src/paimon/core/table/source/table_scan_test.cpp
+++ b/src/paimon/core/table/source/table_scan_test.cpp
@@ -16,17 +16,30 @@
 
 #include "paimon/table/source/table_scan.h"
 
+#include <cstdint>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "gtest/gtest.h"
 #include "paimon/defs.h"
+#include "paimon/fs/file_system.h"
 #include "paimon/scan_context.h"
 #include "paimon/status.h"
 #include "paimon/testing/utils/testharness.h"
 
 namespace paimon::test {
+namespace {
+
+void WriteSchemaFile(const std::shared_ptr<FileSystem>& fs, const std::string& table_path,
+                     int64_t schema_id, const std::string& schema_json) {
+    ASSERT_OK(fs->WriteFile(table_path + "/schema/schema-" + std::to_string(schema_id),
+                            schema_json, /*overwrite=*/false));
+}
+
+}  // namespace
+
 TEST(TableScanTest, TestNoSnapshot) {
     std::string path = paimon::test::GetDataDir() +
                        "/orc/append_table_with_nested_type.db/append_table_with_nested_type/";
@@ -48,9 +61,164 @@ TEST(TableScanTest, TestNonExistTable) {
 }
 
 TEST(TableScanTest, TestNoSchemaEvolution) {
-    // do not bear schema evolution in scan
     std::string path =
         paimon::test::GetDataDir() + "/orc/pk_table_with_alter_table.db/pk_table_with_alter_table/";
+    ScanContextBuilder builder(path);
+    builder.AddOption(Options::FILE_FORMAT, "orc");
+    ASSERT_OK_AND_ASSIGN(auto context, builder.Finish());
+    ASSERT_NOK_WITH_MSG(TableScan::Create(std::move(context)), "do not support schema evolution");
+}
+
+TEST(TableScanTest, TestPkPropertyOnlySchemaChange) {
+    auto dir = UniqueTestDirectory::Create();
+    const std::string path = dir->Str();
+    const std::string schema0 = R"({
+        "version" : 3,
+        "id" : 0,
+        "fields" : [ {
+                "id" : 0,
+                "name" : "pk",
+                "type" : "INT NOT NULL"
+        }, {
+                "id" : 1,
+                "name" : "v",
+                "type" : "STRING"
+        } ],
+        "highestFieldId" : 1,
+        "partitionKeys" : [],
+        "primaryKeys" : [ "pk" ],
+        "options" : {
+                "bucket" : "1",
+                "file.format" : "orc",
+                "manifest.format" : "orc"
+        },
+        "timeMillis" : 1000
+    })";
+    const std::string schema1 = R"({
+        "version" : 3,
+        "id" : 1,
+        "fields" : [ {
+                "id" : 0,
+                "name" : "pk",
+                "type" : "INT NOT NULL"
+        }, {
+                "id" : 1,
+                "name" : "v",
+                "type" : "STRING"
+        } ],
+        "highestFieldId" : 1,
+        "partitionKeys" : [],
+        "primaryKeys" : [ "pk" ],
+        "options" : {
+                "bucket" : "1",
+                "file.format" : "orc",
+                "manifest.format" : "orc",
+                "custom.property" : "new-value"
+        },
+        "timeMillis" : 2000
+    })";
+    WriteSchemaFile(dir->GetFileSystem(), path, /*schema_id=*/0, schema0);
+    WriteSchemaFile(dir->GetFileSystem(), path, /*schema_id=*/1, schema1);
+
+    // Without explicit opt-in, the strict default rejects any cross-schema option diff.
+    {
+        ScanContextBuilder builder(path);
+        builder.AddOption(Options::FILE_FORMAT, "orc");
+        ASSERT_OK_AND_ASSIGN(auto context, builder.Finish());
+        ASSERT_NOK_WITH_MSG(TableScan::Create(std::move(context)),
+                            "do not support schema evolution");
+    }
+
+    // Users opt-in to ignoring `custom.property` across schema versions via the regex list, so
+    // the property-only schema change is accepted for PK scan.
+    ScanContextBuilder builder(path);
+    builder.AddOption(Options::FILE_FORMAT, "orc");
+    builder.AddOption(Options::SCAN_PK_SCHEMA_COMPATIBILITY_IGNORED_OPTIONS, "custom\\.property");
+    ASSERT_OK_AND_ASSIGN(auto context, builder.Finish());
+    ASSERT_OK_AND_ASSIGN(auto table_scan, TableScan::Create(std::move(context)));
+    ASSERT_OK_AND_ASSIGN(auto plan, table_scan->CreatePlan());
+    ASSERT_FALSE(plan->SnapshotId());
+    ASSERT_TRUE(plan->Splits().empty());
+}
+
+TEST(TableScanTest, TestPkSchemaChangeChecksAllSchemas) {
+    auto dir = UniqueTestDirectory::Create();
+    const std::string path = dir->Str();
+    const std::string schema0 = R"({
+        "version" : 3,
+        "id" : 0,
+        "fields" : [ {
+                "id" : 0,
+                "name" : "pk",
+                "type" : "INT NOT NULL"
+        }, {
+                "id" : 1,
+                "name" : "v",
+                "type" : "STRING"
+        } ],
+        "highestFieldId" : 1,
+        "partitionKeys" : [],
+        "primaryKeys" : [ "pk" ],
+        "options" : {
+                "bucket" : "1",
+                "file.format" : "orc",
+                "manifest.format" : "orc"
+        },
+        "timeMillis" : 1000
+    })";
+    const std::string schema1_field_changed = R"({
+        "version" : 3,
+        "id" : 1,
+        "fields" : [ {
+                "id" : 0,
+                "name" : "pk",
+                "type" : "INT NOT NULL"
+        }, {
+                "id" : 1,
+                "name" : "v",
+                "type" : "STRING"
+        }, {
+                "id" : 2,
+                "name" : "v2",
+                "type" : "STRING"
+        } ],
+        "highestFieldId" : 2,
+        "partitionKeys" : [],
+        "primaryKeys" : [ "pk" ],
+        "options" : {
+                "bucket" : "1",
+                "file.format" : "orc",
+                "manifest.format" : "orc"
+        },
+        "timeMillis" : 2000
+    })";
+    const std::string schema2_property_changed = R"({
+        "version" : 3,
+        "id" : 2,
+        "fields" : [ {
+                "id" : 0,
+                "name" : "pk",
+                "type" : "INT NOT NULL"
+        }, {
+                "id" : 1,
+                "name" : "v",
+                "type" : "STRING"
+        } ],
+        "highestFieldId" : 1,
+        "partitionKeys" : [],
+        "primaryKeys" : [ "pk" ],
+        "options" : {
+                "bucket" : "1",
+                "file.format" : "orc",
+                "manifest.format" : "orc",
+                "custom.property" : "new-value"
+        },
+        "timeMillis" : 3000
+    })";
+    WriteSchemaFile(dir->GetFileSystem(), path, /*schema_id=*/0, schema0);
+    WriteSchemaFile(dir->GetFileSystem(), path, /*schema_id=*/1, schema1_field_changed);
+    WriteSchemaFile(dir->GetFileSystem(), path, /*schema_id=*/2, schema2_property_changed);
+
     ScanContextBuilder builder(path);
     builder.AddOption(Options::FILE_FORMAT, "orc");
     ASSERT_OK_AND_ASSIGN(auto context, builder.Finish());


### PR DESCRIPTION
### Purpose

When unrelated table-level properties are tweaked on a Paimon PK table, a new schema version is generated. The new and old schemas are read-compatible (field shape, ids and PK layout do not change), but paimon-cpp currently rejects any non-zero schema id on PK tables with `do not support schema evolution in pk table while scan process`, because full PK schema evolution is not implemented.

This PR narrows that restriction. It does NOT add general PK schema-evolution support; instead it lets the scan path accept multiple schema versions on a PK table when those versions differ only in option keys that the user has explicitly whitelisted as safe to ignore.

Key changes:

- New public option `scan.pk.schema-compatibility.ignored-options` in  `include/paimon/defs.h`, a comma-separated list of regex patterns  full-matched against option keys allowed to differ across schema versions.  Default is empty (strict, same behavior as before).
- `TableSchema::IsCompatibleForPKScan` performs a conservative blacklist  comparison: fields, field ids, `highestFieldId`, partition / primary /  bucket keys and `numBucket` must be identical, and every option key must  be equal unless it matches one of the user-supplied regex patterns.  Invalid regex patterns are silently dropped so a single malformed entry cannot block scans.
- `SchemaManager::IsSchemasCompatibleForPKScan` iterates every schema id of  the table, skipping self-compare, and checks compatibility against the  current `TableSchema`. `schema_cache_` is now protected by a `mutex`  because parallel scan paths may query it concurrently.
- `NewDataTableScan` invokes the compatibility check once at scan-creation  time. If all other schema versions are PK-scan-compatible with the latest  schema the scan proceeds; otherwise it still returns `NotImplemented`  with the original message, preserving the existing failure behavior.
- `KeyValueFileStoreScan::FilterByValueFilter` no longer hard-fails when a  manifest entry's `schema_id` differs from the current table schema id.  It resolves the data file's own schema via `SchemaManager::ReadSchema`  and builds the `SimpleStatsEvolution` against it. Cross-schema  compatibility is already verified once at scan-creation time, so this  hot path stays cheap.

### Tests

New unit tests:

- `src/paimon/core/schema/table_schema_test.cpp`
  - `TableSchemaTest.TestPrimaryKeyScanSchemaCompatibility`: covers the    strict default, opt-in via regex, field-shape changes always rejected,    wildcard `.*` accepting read-side option changes, and invalid regex patterns being silently ignored without altering correctness.
- `src/paimon/core/schema/schema_manager_test.cpp`
  - `SchemaManagerTest.TestAllSchemasCompatibleForPrimaryKeyScan`: verifies multi-version iteration, self-compare skipping, opt-in compatibility for property-only changes, and field-shape changes still rejected even with `.*` configured.
- `src/paimon/core/table/source/table_scan_test.cpp`
  - `TableScanTest.TestPkPropertyOnlySchemaChange`: end-to-end check that without the option a PK property-only schema change is rejected, and with `scan.pk.schema-compatibility.ignored-options` set the scan plan is created successfully.
  - `TableScanTest.TestPkSchemaChangeChecksAllSchemas`: ensures every schema version is checked, so a field-level change anywhere in history still fails the scan.

### API and Format

- Adds a new public option key constant `Options::SCAN_PK_SCHEMA_COMPATIBILITY_IGNORED_OPTIONS`  (literal `scan.pk.schema-compatibility.ignored-options`) in `include/paimon/defs.h`.
- No on-disk storage format or wire-protocol changes.

### Documentation

No standalone documentation is required; this is a narrow relaxation of an existing restriction rather than a new feature surface. The new option's semantics are documented inline as a doxygen comment on `Options::SCAN_PK_SCHEMA_COMPATIBILITY_IGNORED_OPTIONS`.

### Generative AI tooling

Generated-by: OpenAI Codex
