### PR TITLE
fix: isolate external projects from host toolchain library paths

### DIFF
--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -377,7 +377,14 @@ set(EP_COMMON_CMAKE_ARGS
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
     -DCMAKE_CXX_FLAGS=${EP_CXX_FLAGS}
     -DCMAKE_C_FLAGS=${EP_C_FLAGS}
-    -DCMAKE_INSTALL_LIBDIR=lib)
+    -DCMAKE_INSTALL_LIBDIR=lib
+    # Prevent leaking host toolchain library/include paths into external
+    # project builds. Without these, cmake may find incompatible libraries
+    # (e.g. a partial libunwind.so from a toolchain) that cause runtime
+    # symbol lookup errors. All external project dependencies are passed
+    # explicitly via xxx_ROOT/xxx_HOME variables.
+    -DCMAKE_LIBRARY_PATH=
+    -DCMAKE_PREFIX_PATH=)
 
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.30")
     list(APPEND EP_COMMON_CMAKE_ARGS -DCMAKE_POLICY_VERSION_MINIMUM=3.5)


### PR DESCRIPTION
## Problem

When building paimon-cpp on a Fedora machine with a non-system LLVM toolchain (ldb_toolchain) on PATH, all tests crash with:

```
symbol lookup error: undefined symbol: _Unwind_RaiseException
```

Root cause: cmake derives implicit library search paths from the compiler location. When ldb_toolchain is on PATH, Arrow find_library(unwind) finds libunwind.so under the toolchain directory. However, this toolchain-provided libunwind lacks the _Unwind_RaiseException symbol, which is actually provided by libgcc_s.so.1.

Why CI passes: GitHub Actions Ubuntu runners have no non-system toolchain and no unversioned libunwind.so (only libunwind.so.8). Arrow cannot find libunwind, falls back to libgcc_s, and works correctly.

## Fix

Add -DCMAKE_LIBRARY_PATH= and -DCMAKE_PREFIX_PATH= to EP_COMMON_CMAKE_ARGS, which are passed to every external project cmake configure step. This blocks host toolchain library paths from leaking into external project builds (Arrow, ORC, etc.).

All external project dependencies are already passed explicitly via xxx_ROOT/xxx_HOME/xxx_DIR variables, so clearing these search paths is safe.

## Files Changed

 cmake_modules/ThirdpartyToolchain.cmake | 9 ++++++++-
 1 file changed, 8 insertions(+), 1 deletion(-)

## Verification

Fedora x86_64, GCC 16 + ldb_toolchain:
- ldd paimon-core-test shows no libunwind dependency
- 38/42 tests pass (4 failures are pre-existing test data issues)
- No more _Unwind_RaiseException crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)
