### PR TITLE
fix: canonicalize NaN for Hive bucket hash

### DIFF
--- a/src/paimon/core/bucket/default_bucket_function_test.cpp
+++ b/src/paimon/core/bucket/default_bucket_function_test.cpp
@@ -16,13 +16,27 @@
 
 #include "paimon/core/bucket/default_bucket_function.h"
 
+#include <limits>
+
 #include "gtest/gtest.h"
 #include "paimon/common/data/binary_row.h"
 #include "paimon/common/data/binary_row_writer.h"
 #include "paimon/memory/memory_pool.h"
+#include "paimon/testing/utils/binary_row_generator.h"
 #include "paimon/testing/utils/testharness.h"
 
 namespace paimon::test {
+
+namespace {
+
+void CheckDefaultBucket(const DefaultBucketFunction& func, const BinaryRow& row,
+                        int32_t expected_hash, int32_t expected_bucket) {
+    constexpr int32_t kNumBuckets = 1000;
+    ASSERT_EQ(expected_hash, row.HashCode());
+    ASSERT_EQ(expected_bucket, func.Bucket(row, kNumBuckets));
+}
+
+}  // namespace
 
 TEST(DefaultBucketFunctionTest, TestBasicHashMod) {
     auto pool = GetDefaultPool();
@@ -77,6 +91,47 @@ TEST(DefaultBucketFunctionTest, TestMultiFieldRow) {
     ASSERT_GE(bucket, 0);
     ASSERT_LT(bucket, num_buckets);
     ASSERT_EQ(std::abs(row.HashCode() % num_buckets), bucket);
+}
+
+TEST(DefaultBucketFunctionTest, TestFloatSpecialValuesCompatibleWithJava) {
+    auto pool = GetDefaultPool();
+    DefaultBucketFunction func;
+
+    // Verified with Java DefaultBucketFunction and NUM_BUCKETS = 1000.
+    CheckDefaultBucket(
+        func,
+        BinaryRowGenerator::GenerateRow({std::numeric_limits<float>::quiet_NaN()}, pool.get()),
+        -2039172089, 89);
+    CheckDefaultBucket(
+        func, BinaryRowGenerator::GenerateRow({std::numeric_limits<float>::infinity()}, pool.get()),
+        2139216202, 202);
+    CheckDefaultBucket(
+        func,
+        BinaryRowGenerator::GenerateRow({-std::numeric_limits<float>::infinity()}, pool.get()),
+        -106221671, 671);
+    CheckDefaultBucket(func, BinaryRowGenerator::GenerateRow({0.0f}, pool.get()), -300363099, 99);
+    CheckDefaultBucket(func, BinaryRowGenerator::GenerateRow({-0.0f}, pool.get()), 916225219, 219);
+}
+
+TEST(DefaultBucketFunctionTest, TestDoubleSpecialValuesCompatibleWithJava) {
+    auto pool = GetDefaultPool();
+    DefaultBucketFunction func;
+
+    // Verified with Java DefaultBucketFunction and NUM_BUCKETS = 1000.
+    CheckDefaultBucket(
+        func,
+        BinaryRowGenerator::GenerateRow({std::numeric_limits<double>::quiet_NaN()}, pool.get()),
+        -1323214697, 697);
+    CheckDefaultBucket(
+        func,
+        BinaryRowGenerator::GenerateRow({std::numeric_limits<double>::infinity()}, pool.get()),
+        -1556713404, 404);
+    CheckDefaultBucket(
+        func,
+        BinaryRowGenerator::GenerateRow({-std::numeric_limits<double>::infinity()}, pool.get()),
+        -2079171840, 840);
+    CheckDefaultBucket(func, BinaryRowGenerator::GenerateRow({0.0}, pool.get()), -300363099, 99);
+    CheckDefaultBucket(func, BinaryRowGenerator::GenerateRow({-0.0}, pool.get()), 302122119, 119);
 }
 
 }  // namespace paimon::test

--- a/src/paimon/core/bucket/hive_bucket_function.cpp
+++ b/src/paimon/core/bucket/hive_bucket_function.cpp
@@ -103,6 +103,8 @@ uint32_t HiveBucketFunction::ComputeHash(const BinaryRow& row, int32_t field_ind
             uint32_t bits;
             if (float_value == -0.0f) {
                 bits = 0;
+            } else if (std::isnan(float_value)) {
+                bits = 0x7FC00000U;
             } else {
                 std::memcpy(&bits, &float_value, sizeof(bits));
             }
@@ -113,6 +115,8 @@ uint32_t HiveBucketFunction::ComputeHash(const BinaryRow& row, int32_t field_ind
             uint64_t bits;
             if (double_value == -0.0) {
                 bits = 0;
+            } else if (std::isnan(double_value)) {
+                bits = 0x7FF8000000000000ULL;
             } else {
                 std::memcpy(&bits, &double_value, sizeof(bits));
             }

--- a/src/paimon/core/bucket/hive_bucket_function_test.cpp
+++ b/src/paimon/core/bucket/hive_bucket_function_test.cpp
@@ -16,6 +16,7 @@
 
 #include "paimon/core/bucket/hive_bucket_function.h"
 
+#include <cstring>
 #include <limits>
 
 #include "gtest/gtest.h"
@@ -97,6 +98,23 @@ class HiveBucketFunctionTest : public ::testing::Test {
     BinaryRow CreateStringRow(const std::string& value) {
         auto pool = GetDefaultPool();
         return BinaryRowGenerator::GenerateRow({value}, pool.get());
+    }
+
+    BinaryRow CreateByteRow(int8_t value) {
+        auto pool = GetDefaultPool();
+        return BinaryRowGenerator::GenerateRow({value}, pool.get());
+    }
+
+    float FloatFromBits(uint32_t bits) {
+        float value;
+        std::memcpy(&value, &bits, sizeof(value));
+        return value;
+    }
+
+    double DoubleFromBits(uint64_t bits) {
+        double value;
+        std::memcpy(&value, &bits, sizeof(value));
+        return value;
     }
 };
 
@@ -203,6 +221,39 @@ TEST_F(HiveBucketFunctionTest, TestDoubleNegativeZero) {
 
     // -0.0 should be treated as 0L => hashLong(0) = 0
     ASSERT_EQ(func->Bucket(CreateDoubleRow(0.0), 5), func->Bucket(CreateDoubleRow(-0.0), 5));
+}
+
+TEST_F(HiveBucketFunctionTest, TestFloatNaNCanonicalizationCompatibleWithJava) {
+    std::vector<FieldType> field_types = {FieldType::FLOAT};
+    ASSERT_OK_AND_ASSIGN(auto func, HiveBucketFunction::Create(field_types));
+
+    // Verified with Java HiveBucketFunction:
+    // Float.NaN, Float.intBitsToFloat(0x7fa12345), and Float.intBitsToFloat(0x7fc00000)
+    // all hash through Float.floatToIntBits(...) = 0x7fc00000.
+    ASSERT_EQ(344, func->Bucket(CreateFloatRow(std::numeric_limits<float>::quiet_NaN()), 1000));
+    ASSERT_EQ(344, func->Bucket(CreateFloatRow(FloatFromBits(0x7FA12345U)), 1000));
+    ASSERT_EQ(344, func->Bucket(CreateFloatRow(FloatFromBits(0x7FC00000U)), 1000));
+}
+
+TEST_F(HiveBucketFunctionTest, TestDoubleNaNCanonicalizationCompatibleWithJava) {
+    std::vector<FieldType> field_types = {FieldType::DOUBLE};
+    ASSERT_OK_AND_ASSIGN(auto func, HiveBucketFunction::Create(field_types));
+
+    // Verified with Java HiveBucketFunction:
+    // Double.NaN, Double.longBitsToDouble(0x7ff123456789abcd), and canonical NaN
+    // all hash through Double.doubleToLongBits(...) = 0x7ff8000000000000.
+    ASSERT_EQ(360, func->Bucket(CreateDoubleRow(std::numeric_limits<double>::quiet_NaN()), 1000));
+    ASSERT_EQ(360, func->Bucket(CreateDoubleRow(DoubleFromBits(0x7FF123456789ABCDULL)), 1000));
+    ASSERT_EQ(360, func->Bucket(CreateDoubleRow(DoubleFromBits(0x7FF8000000000000ULL)), 1000));
+}
+
+TEST_F(HiveBucketFunctionTest, TestTinyintNegativeValuesCompatibleWithJava) {
+    std::vector<FieldType> field_types = {FieldType::TINYINT};
+    ASSERT_OK_AND_ASSIGN(auto func, HiveBucketFunction::Create(field_types));
+
+    // Verified with Java HiveBucketFunction using DataTypes.TINYINT().
+    ASSERT_EQ(647, func->Bucket(CreateByteRow(static_cast<int8_t>(-1)), 1000));
+    ASSERT_EQ(520, func->Bucket(CreateByteRow(std::numeric_limits<int8_t>::min()), 1000));
 }
 
 /// Test STRING field


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
No Linked issue.
This change fixes Hive bucket hash compatibility with Java for FLOAT and DOUBLE NaN values.

Java `Float.floatToIntBits` and `Double.doubleToLongBits` canonicalize all NaN bit patterns before hashing. The C++ Hive bucket implementation previously hashed the raw in-memory bit pattern via `std::memcpy`, so non-canonical NaN values could be assigned to a different bucket than Java.

This patch:
- canonicalizes FLOAT NaN to `0x7FC00000`
- canonicalizes DOUBLE NaN to `0x7FF8000000000000`
- adds compatibility tests for canonical and non-canonical NaN values
- adds compatibility tests for negative TINYINT values

<!-- What is the purpose of the change -->

### Tests
Added unit coverage in `hive_bucket_function_test.cpp`:
- `TestFloatNaNCanonicalizationCompatibleWithJava`
- `TestDoubleNaNCanonicalizationCompatibleWithJava`
- `TestTinyintNegativeValuesCompatibleWithJava`
<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling
Generated-by: OpenAI Codex (GPT-5)
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
