### PR TITLE
fix: fix min/max row id serialize bug

### DIFF
--- a/src/paimon/core/manifest/manifest_file_meta_serializer.cpp
+++ b/src/paimon/core/manifest/manifest_file_meta_serializer.cpp
@@ -71,14 +71,14 @@ Result<BinaryRow> ManifestFileMetaSerializer::ToRow(const ManifestFileMeta& reco
     if (!min_row_id) {
         writer.SetNullAt(11);
     } else {
-        writer.WriteInt(11, min_row_id.value());
+        writer.WriteLong(11, min_row_id.value());
     }
 
     auto max_row_id = record.MaxRowId();
     if (!max_row_id) {
         writer.SetNullAt(12);
     } else {
-        writer.WriteInt(12, max_row_id.value());
+        writer.WriteLong(12, max_row_id.value());
     }
     writer.Complete();
     return row;


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
No Linked issue.

Fix incorrect serialization of manifest metadata `min_row_id` and `max_row_id` by writing them as 64-bit longs to prevent truncation or overflow for large row IDs.
<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
