### PR TITLE
Refactor Arrow memory pool lifetime to TableRead

### DIFF
--- a/docs/source/user_guide/arrow.rst
+++ b/docs/source/user_guide/arrow.rst
@@ -120,3 +120,35 @@ Conversion boundaries
   * Export/import data to other Arrow-compatible engines with zero or minimal copies.
 
 - Keep these adapters independent from heavy Arrow C++ SDK dependencies.
+
+TableRead-scoped Arrow memory pool lifetime
+-------------------------------------------
+
+Reader components can allocate Arrow buffers through an adaptor from the Paimon
+memory pool to ``arrow::MemoryPool``. Arrays returned through the Arrow C Data
+Interface may keep buffers that reference this adaptor during release.
+
+The table read path therefore scopes the Arrow memory-pool adaptor to a
+``TableRead`` session instead of an individual ``BatchReader``. A ``TableRead``
+creates one adaptor and shares it with the readers and reader wrappers created
+for that read session.
+
+This ownership model keeps the adaptor alive while the owning ``TableRead`` is
+alive, even if an individual ``BatchReader`` has been closed or destroyed. It
+allows callers to release Arrow C Data objects returned by ``NextBatch()`` after
+the corresponding reader is closed, as long as the ``TableRead`` session still
+owns the shared pool.
+
+The lifetime guarantee is intentionally scoped:
+
+- Returned Arrow arrays may outlive an individual ``BatchReader``.
+- Returned Arrow arrays are not guaranteed to outlive the owning ``TableRead``.
+- Different ``TableRead`` instances use distinct Arrow memory-pool adaptors,
+  even when they are created from the same Paimon memory pool.
+- Standalone format readers, writers, metadata readers, and other paths not
+  created through ``TableRead`` may still manage their own adaptors.
+
+Components in the ``TableRead`` construction path must use the supplied shared
+Arrow memory pool instead of constructing another adaptor from the same Paimon
+memory pool. This keeps ownership explicit and avoids mixing statistics or
+lifetime state across independent table read sessions.

--- a/include/paimon/format/reader_builder.h
+++ b/include/paimon/format/reader_builder.h
@@ -23,6 +23,10 @@
 #include "paimon/reader/file_batch_reader.h"
 #include "paimon/type_fwd.h"
 
+namespace arrow {
+class MemoryPool;
+}  // namespace arrow
+
 namespace paimon {
 
 /// Create a file batch reader based on the file path. Allows you to specify memory pool.
@@ -30,8 +34,14 @@ class PAIMON_EXPORT ReaderBuilder {
  public:
     virtual ~ReaderBuilder() = default;
 
-    /// Set memory pool to use.
+    /// Set Paimon memory pool to use.
     virtual ReaderBuilder* WithMemoryPool(const std::shared_ptr<MemoryPool>& pool) = 0;
+
+    /// Set Paimon memory pool and its shared Arrow adaptor.
+    virtual ReaderBuilder* WithMemoryPool(const std::shared_ptr<MemoryPool>& pool,
+                                          const std::shared_ptr<arrow::MemoryPool>&) {
+        return WithMemoryPool(pool);
+    }
 
     /// Build a file batch reader based on the created `InputStream`.
     virtual Result<std::unique_ptr<FileBatchReader>> Build(

--- a/include/paimon/table/source/table_read.h
+++ b/include/paimon/table/source/table_read.h
@@ -27,6 +27,10 @@
 #include "paimon/table/source/split.h"
 #include "paimon/visibility.h"
 
+namespace arrow {
+class MemoryPool;
+}
+
 namespace paimon {
 class MemoryPool;
 class ReadContext;
@@ -64,9 +68,11 @@ class PAIMON_EXPORT TableRead {
         const std::shared_ptr<Split>& split) = 0;
 
  protected:
-    explicit TableRead(const std::shared_ptr<MemoryPool>& memory_pool);
+    TableRead(const std::shared_ptr<MemoryPool>& memory_pool,
+              const std::shared_ptr<arrow::MemoryPool>& arrow_pool);
 
  private:
     std::shared_ptr<MemoryPool> pool_;
+    std::shared_ptr<arrow::MemoryPool> arrow_pool_;
 };
 }  // namespace paimon

--- a/src/paimon/common/global_index/complete_index_score_batch_reader.cpp
+++ b/src/paimon/common/global_index/complete_index_score_batch_reader.cpp
@@ -28,14 +28,13 @@
 #include "paimon/common/reader/reader_utils.h"
 #include "paimon/common/table/special_fields.h"
 #include "paimon/common/types/row_kind.h"
-#include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/common/utils/arrow/status_utils.h"
 #include "paimon/status.h"
 namespace paimon {
 CompleteIndexScoreBatchReader::CompleteIndexScoreBatchReader(
     std::unique_ptr<BatchReader>&& reader, const std::vector<float>& scores,
-    const std::shared_ptr<MemoryPool>& pool)
-    : arrow_pool_(GetArrowPool(pool)), reader_(std::move(reader)), scores_(scores) {}
+    const std::shared_ptr<arrow::MemoryPool>& arrow_pool)
+    : arrow_pool_(arrow_pool), reader_(std::move(reader)), scores_(scores) {}
 
 Result<BatchReader::ReadBatch> CompleteIndexScoreBatchReader::NextBatch() {
     PAIMON_ASSIGN_OR_RAISE(BatchReader::ReadBatchWithBitmap batch_with_bitmap,

--- a/src/paimon/common/global_index/complete_index_score_batch_reader.h
+++ b/src/paimon/common/global_index/complete_index_score_batch_reader.h
@@ -39,7 +39,7 @@ class CompleteIndexScoreBatchReader : public BatchReader {
  public:
     CompleteIndexScoreBatchReader(std::unique_ptr<BatchReader>&& reader,
                                   const std::vector<float>& scores,
-                                  const std::shared_ptr<MemoryPool>& pool);
+                                  const std::shared_ptr<arrow::MemoryPool>& arrow_pool);
 
     Result<ReadBatch> NextBatch() override;
 
@@ -60,7 +60,7 @@ class CompleteIndexScoreBatchReader : public BatchReader {
     size_t score_cursor_ = 0;
     int32_t index_score_field_idx_ = -1;
     std::vector<std::string> field_names_with_score_;
-    std::unique_ptr<arrow::MemoryPool> arrow_pool_;
+    std::shared_ptr<arrow::MemoryPool> arrow_pool_;
     std::unique_ptr<BatchReader> reader_;
     std::vector<float> scores_;
 };

--- a/src/paimon/common/global_index/complete_index_score_batch_reader_test.cpp
+++ b/src/paimon/common/global_index/complete_index_score_batch_reader_test.cpp
@@ -24,6 +24,7 @@
 #include "gtest/gtest.h"
 #include "paimon/common/table/special_fields.h"
 #include "paimon/common/types/data_field.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/format/file_format.h"
 #include "paimon/format/file_format_factory.h"
 #include "paimon/memory/memory_pool.h"
@@ -37,6 +38,7 @@ class CompleteIndexScoreBatchReaderTest : public ::testing::Test {
  public:
     void SetUp() override {
         pool_ = GetDefaultPool();
+        arrow_pool_ = GetArrowPool(pool_);
     }
     void TearDown() override {
         pool_.reset();
@@ -47,8 +49,10 @@ class CompleteIndexScoreBatchReaderTest : public ::testing::Test {
         const std::vector<float>& scores, int32_t batch_size) const {
         auto file_batch_reader = std::make_unique<MockFileBatchReader>(src_array, src_array->type(),
                                                                        selected_bitmap, batch_size);
-        return std::make_unique<CompleteIndexScoreBatchReader>(std::move(file_batch_reader), scores,
-                                                               pool_);
+        auto reader = std::make_unique<CompleteIndexScoreBatchReader>(std::move(file_batch_reader),
+                                                                      scores, arrow_pool_);
+        EXPECT_EQ(arrow_pool_.get(), reader->arrow_pool_.get());
+        return reader;
     }
 
     std::unique_ptr<BatchReader> PrepareCompleteIndexScoreBatchReader(
@@ -56,12 +60,15 @@ class CompleteIndexScoreBatchReaderTest : public ::testing::Test {
         int32_t batch_size) const {
         auto file_batch_reader =
             std::make_unique<MockFileBatchReader>(src_array, src_array->type(), batch_size);
-        return std::make_unique<CompleteIndexScoreBatchReader>(std::move(file_batch_reader), scores,
-                                                               pool_);
+        auto reader = std::make_unique<CompleteIndexScoreBatchReader>(std::move(file_batch_reader),
+                                                                      scores, arrow_pool_);
+        EXPECT_EQ(arrow_pool_.get(), reader->arrow_pool_.get());
+        return reader;
     }
 
  private:
     std::shared_ptr<MemoryPool> pool_;
+    std::shared_ptr<arrow::MemoryPool> arrow_pool_;
 };
 
 TEST_F(CompleteIndexScoreBatchReaderTest, TestSimple) {

--- a/src/paimon/common/reader/complete_row_kind_batch_reader.h
+++ b/src/paimon/common/reader/complete_row_kind_batch_reader.h
@@ -24,7 +24,6 @@
 
 #include "arrow/api.h"
 #include "arrow/array/array_base.h"
-#include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/reader/batch_reader.h"
 #include "paimon/result.h"
 
@@ -39,8 +38,8 @@ class Metrics;
 class CompleteRowKindBatchReader : public BatchReader {
  public:
     CompleteRowKindBatchReader(std::unique_ptr<BatchReader>&& reader,
-                               const std::shared_ptr<MemoryPool>& pool)
-        : arrow_pool_(GetArrowPool(pool)), reader_(std::move(reader)) {}
+                               const std::shared_ptr<arrow::MemoryPool>& arrow_pool)
+        : arrow_pool_(arrow_pool), reader_(std::move(reader)) {}
 
     Result<ReadBatch> NextBatch() override;
 
@@ -62,7 +61,7 @@ class CompleteRowKindBatchReader : public BatchReader {
     void UpdateFieldNamesWithRowKind(const std::shared_ptr<arrow::StructArray>& struct_array);
 
  private:
-    std::unique_ptr<arrow::MemoryPool> arrow_pool_;
+    std::shared_ptr<arrow::MemoryPool> arrow_pool_;
     std::unique_ptr<BatchReader> reader_;
     std::shared_ptr<arrow::Array> row_kind_array_;
     std::vector<std::string> field_names_with_row_kind_;

--- a/src/paimon/common/reader/complete_row_kind_batch_reader_test.cpp
+++ b/src/paimon/common/reader/complete_row_kind_batch_reader_test.cpp
@@ -27,6 +27,7 @@
 #include "gtest/gtest.h"
 #include "paimon/common/table/special_fields.h"
 #include "paimon/common/types/data_field.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/format/file_format.h"
 #include "paimon/format/file_format_factory.h"
 #include "paimon/fs/file_system.h"
@@ -43,6 +44,7 @@ class CompleteRowKindBatchReaderTest : public ::testing::Test {
  public:
     void SetUp() override {
         pool_ = GetDefaultPool();
+        arrow_pool_ = GetArrowPool(pool_);
     }
 
     void TearDown() override {
@@ -64,18 +66,25 @@ class CompleteRowKindBatchReaderTest : public ::testing::Test {
         EXPECT_TRUE(arrow_status.ok());
         EXPECT_OK(orc_batch_reader->SetReadSchema(c_schema.get(), /*predicate=*/nullptr,
                                                   /*selection_bitmap=*/std::nullopt));
-        return std::make_unique<CompleteRowKindBatchReader>(std::move(orc_batch_reader), pool_);
+        auto reader =
+            std::make_unique<CompleteRowKindBatchReader>(std::move(orc_batch_reader), arrow_pool_);
+        EXPECT_EQ(arrow_pool_.get(), reader->arrow_pool_.get());
+        return reader;
     }
 
     std::unique_ptr<BatchReader> PrepareCompleteRowKindBatchReader(
         const std::shared_ptr<arrow::Array>& src_array, int32_t batch_size) const {
         auto file_batch_reader =
             std::make_unique<MockFileBatchReader>(src_array, src_array->type(), batch_size);
-        return std::make_unique<CompleteRowKindBatchReader>(std::move(file_batch_reader), pool_);
+        auto reader =
+            std::make_unique<CompleteRowKindBatchReader>(std::move(file_batch_reader), arrow_pool_);
+        EXPECT_EQ(arrow_pool_.get(), reader->arrow_pool_.get());
+        return reader;
     }
 
  private:
     std::shared_ptr<MemoryPool> pool_;
+    std::shared_ptr<arrow::MemoryPool> arrow_pool_;
 };
 
 TEST_F(CompleteRowKindBatchReaderTest, TestSimple) {

--- a/src/paimon/common/reader/concat_batch_reader.cpp
+++ b/src/paimon/common/reader/concat_batch_reader.cpp
@@ -21,14 +21,13 @@
 #include "arrow/c/abi.h"
 #include "paimon/common/metrics/metrics_impl.h"
 #include "paimon/common/reader/reader_utils.h"
-#include "paimon/common/utils/arrow/mem_utils.h"
 
 namespace paimon {
 class MemoryPool;
 
 ConcatBatchReader::ConcatBatchReader(std::vector<std::unique_ptr<BatchReader>>&& readers,
-                                     const std::shared_ptr<MemoryPool>& pool)
-    : arrow_pool_(GetArrowPool(pool)), readers_(std::move(readers)), current_(0) {}
+                                     const std::shared_ptr<arrow::MemoryPool>& arrow_pool)
+    : arrow_pool_(arrow_pool), readers_(std::move(readers)), current_(0) {}
 
 Result<BatchReader::ReadBatch> ConcatBatchReader::NextBatch() {
     PAIMON_ASSIGN_OR_RAISE(BatchReader::ReadBatchWithBitmap batch_with_bitmap,

--- a/src/paimon/common/reader/concat_batch_reader.h
+++ b/src/paimon/common/reader/concat_batch_reader.h
@@ -33,7 +33,7 @@ class MemoryPool;
 class ConcatBatchReader : public BatchReader {
  public:
     ConcatBatchReader(std::vector<std::unique_ptr<BatchReader>>&& readers,
-                      const std::shared_ptr<MemoryPool>& pool);
+                      const std::shared_ptr<arrow::MemoryPool>& arrow_pool);
 
     Result<ReadBatch> NextBatch() override;
     Result<ReadBatchWithBitmap> NextBatchWithBitmap() override;
@@ -41,7 +41,7 @@ class ConcatBatchReader : public BatchReader {
     std::shared_ptr<Metrics> GetReaderMetrics() const override;
 
  private:
-    std::unique_ptr<arrow::MemoryPool> arrow_pool_;
+    std::shared_ptr<arrow::MemoryPool> arrow_pool_;
     std::vector<std::unique_ptr<BatchReader>> readers_;
     size_t current_;
 };

--- a/src/paimon/common/reader/concat_batch_reader_test.cpp
+++ b/src/paimon/common/reader/concat_batch_reader_test.cpp
@@ -26,6 +26,7 @@
 #include "arrow/array/array_nested.h"
 #include "arrow/ipc/json_simple.h"
 #include "gtest/gtest.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/memory/memory_pool.h"
 #include "paimon/status.h"
 #include "paimon/testing/mock/mock_file_batch_reader.h"
@@ -37,6 +38,7 @@ namespace paimon::test {
 class ConcatBatchReaderTest : public ::testing::Test {
     void SetUp() override {
         pool_ = GetDefaultPool();
+        arrow_pool_ = GetArrowPool(pool_);
     }
     void CheckResult(const std::vector<std::string>& batches, const std::string& expected) {
         std::vector<std::pair<std::string, std::vector<int32_t>>> batches_with_bitmap;
@@ -68,7 +70,9 @@ class ConcatBatchReaderTest : public ::testing::Test {
                     data, data->type(), RoaringBitmap32::From(bitmap_data), batch_size);
                 readers.push_back(std::move(reader));
             }
-            auto concat_reader = std::make_unique<ConcatBatchReader>(std::move(readers), pool_);
+            auto concat_reader =
+                std::make_unique<ConcatBatchReader>(std::move(readers), arrow_pool_);
+            ASSERT_EQ(arrow_pool_.get(), concat_reader->arrow_pool_.get());
             ASSERT_OK_AND_ASSIGN(auto result_chunk_array,
                                  ReadResultCollector::CollectResult(concat_reader.get()));
             if (expected.empty()) {
@@ -88,6 +92,7 @@ class ConcatBatchReaderTest : public ::testing::Test {
 
  private:
     std::shared_ptr<MemoryPool> pool_;
+    std::shared_ptr<arrow::MemoryPool> arrow_pool_;
 };
 TEST_F(ConcatBatchReaderTest, TestSimple) {
     CheckResult({"[10, 11, 12, 13, 14]"}, "[10, 11, 12, 13, 14]");

--- a/src/paimon/common/reader/data_evolution_file_reader.cpp
+++ b/src/paimon/common/reader/data_evolution_file_reader.cpp
@@ -21,14 +21,13 @@
 #include "fmt/format.h"
 #include "paimon/common/metrics/metrics_impl.h"
 #include "paimon/common/reader/reader_utils.h"
-#include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/common/utils/arrow/status_utils.h"
 namespace paimon {
 Result<std::unique_ptr<DataEvolutionFileReader>> DataEvolutionFileReader::Create(
     std::vector<std::unique_ptr<BatchReader>>&& readers,
     const std::shared_ptr<arrow::Schema>& read_schema, int32_t read_batch_size,
     const std::vector<int32_t>& reader_offsets, const std::vector<int32_t>& field_offsets,
-    const std::shared_ptr<MemoryPool>& pool) {
+    const std::shared_ptr<arrow::MemoryPool>& arrow_pool) {
     if (read_schema->num_fields() == 0) {
         return Status::Invalid("read schema must not be empty");
     }
@@ -42,7 +41,7 @@ Result<std::unique_ptr<DataEvolutionFileReader>> DataEvolutionFileReader::Create
     }
     return std::unique_ptr<DataEvolutionFileReader>(
         new DataEvolutionFileReader(std::move(readers), read_schema, read_batch_size,
-                                    reader_offsets, field_offsets, GetArrowPool(pool)));
+                                    reader_offsets, field_offsets, arrow_pool));
 }
 
 Result<BatchReader::ReadBatchWithBitmap> DataEvolutionFileReader::NextBatchWithBitmap() {

--- a/src/paimon/common/reader/data_evolution_file_reader.h
+++ b/src/paimon/common/reader/data_evolution_file_reader.h
@@ -54,7 +54,7 @@ class DataEvolutionFileReader : public BatchReader {
         std::vector<std::unique_ptr<BatchReader>>&& readers,
         const std::shared_ptr<arrow::Schema>& read_schema, int32_t read_batch_size,
         const std::vector<int32_t>& reader_offsets, const std::vector<int32_t>& field_offsets,
-        const std::shared_ptr<MemoryPool>& pool);
+        const std::shared_ptr<arrow::MemoryPool>& arrow_pool);
 
     Result<ReadBatch> NextBatch() override {
         return Status::Invalid(

--- a/src/paimon/common/reader/data_evolution_file_reader_test.cpp
+++ b/src/paimon/common/reader/data_evolution_file_reader_test.cpp
@@ -37,6 +37,7 @@ class DataEvolutionFileReaderTest : public ::testing::Test,
  public:
     void SetUp() override {
         pool_ = GetDefaultPool();
+        arrow_pool_ = GetArrowPool(pool_);
     }
 
     void TearDown() override {
@@ -74,7 +75,8 @@ class DataEvolutionFileReaderTest : public ::testing::Test,
             ASSERT_OK_AND_ASSIGN(
                 auto data_evolution_file_reader,
                 DataEvolutionFileReader::Create(std::move(readers), read_schema, batch_size,
-                                                reader_offsets, field_offsets, pool_));
+                                                reader_offsets, field_offsets, arrow_pool_));
+            ASSERT_EQ(arrow_pool_.get(), data_evolution_file_reader->arrow_pool_.get());
             // check metrics, data_evolution_file_reader collects all row of each
             // MockFileBatchReader
             auto metrics = data_evolution_file_reader->GetReaderMetrics();
@@ -109,7 +111,8 @@ class DataEvolutionFileReaderTest : public ::testing::Test,
         readers.push_back(std::move(file_batch_reader));
         DataEvolutionFileReader fake_data_evolution_reader(
             std::move(readers), /*read_schema=*/arrow::schema({}), read_batch_size,
-            /*reader_offsets=*/{}, /*field_offsets=*/{}, GetArrowPool(pool_));
+            /*reader_offsets=*/{}, /*field_offsets=*/{}, arrow_pool_);
+        ASSERT_EQ(arrow_pool_.get(), fake_data_evolution_reader.arrow_pool_.get());
         arrow::ArrayVector result_array_vec;
         while (true) {
             ASSERT_OK_AND_ASSIGN(auto result_array,
@@ -138,15 +141,16 @@ class DataEvolutionFileReaderTest : public ::testing::Test,
 
  private:
     std::shared_ptr<MemoryPool> pool_;
+    std::shared_ptr<arrow::MemoryPool> arrow_pool_;
 };
 
 TEST_F(DataEvolutionFileReaderTest, TestInvalid) {
     {
         arrow::FieldVector read_fields;
         auto read_schema = arrow::schema(read_fields);
-        ASSERT_NOK_WITH_MSG(
-            DataEvolutionFileReader::Create({}, read_schema, /*read_batch_size=*/10, {}, {}, pool_),
-            "read schema must not be empty");
+        ASSERT_NOK_WITH_MSG(DataEvolutionFileReader::Create({}, read_schema, /*read_batch_size=*/10,
+                                                            {}, {}, arrow_pool_),
+                            "read schema must not be empty");
     }
     {
         arrow::FieldVector read_fields = {
@@ -158,9 +162,10 @@ TEST_F(DataEvolutionFileReaderTest, TestInvalid) {
         auto read_schema = arrow::schema(read_fields);
         std::vector<int32_t> reader_offsets = {0, 0, 1};
         std::vector<int32_t> field_offsets = {0, 1, 0};
-        ASSERT_NOK_WITH_MSG(DataEvolutionFileReader::Create({}, read_schema, /*read_batch_size=*/10,
-                                                            reader_offsets, field_offsets, pool_),
-                            "read schema, row offsets and field offsets must have the same size");
+        ASSERT_NOK_WITH_MSG(
+            DataEvolutionFileReader::Create({}, read_schema, /*read_batch_size=*/10, reader_offsets,
+                                            field_offsets, arrow_pool_),
+            "read schema, row offsets and field offsets must have the same size");
     }
     {
         std::vector<std::unique_ptr<BatchReader>> readers;
@@ -177,7 +182,7 @@ TEST_F(DataEvolutionFileReaderTest, TestInvalid) {
         std::vector<int32_t> field_offsets = {0, 1, 1, 0};
         ASSERT_NOK_WITH_MSG(
             DataEvolutionFileReader::Create(std::move(readers), read_schema, /*read_batch_size=*/10,
-                                            reader_offsets, field_offsets, pool_),
+                                            reader_offsets, field_offsets, arrow_pool_),
             "readers size is supposed to be more than 1");
     }
 }
@@ -619,7 +624,8 @@ TEST_P(DataEvolutionFileReaderTest, TestSingleReaderRowCountMismatch) {
     ASSERT_OK_AND_ASSIGN(
         auto data_evolution_file_reader,
         DataEvolutionFileReader::Create(std::move(readers), read_schema, /*read_batch_size=*/10,
-                                        reader_offsets, field_offsets, pool_));
+                                        reader_offsets, field_offsets, arrow_pool_));
+    ASSERT_EQ(arrow_pool_.get(), data_evolution_file_reader->arrow_pool_.get());
     // array0 has 6 rows but array1 only has 5 rows
     ASSERT_NOK_WITH_MSG(
         paimon::test::ReadResultCollector::CollectResult(data_evolution_file_reader.get()),

--- a/src/paimon/common/reader/predicate_batch_reader.cpp
+++ b/src/paimon/common/reader/predicate_batch_reader.cpp
@@ -30,7 +30,6 @@
 #include "fmt/format.h"
 #include "paimon/common/predicate/predicate_filter.h"
 #include "paimon/common/reader/reader_utils.h"
-#include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/common/utils/arrow/status_utils.h"
 #include "paimon/predicate/predicate.h"
 #include "paimon/status.h"
@@ -40,14 +39,12 @@ class MemoryPool;
 
 PredicateBatchReader::PredicateBatchReader(std::unique_ptr<BatchReader>&& reader,
                                            const std::shared_ptr<PredicateFilter>& predicate_filter,
-                                           const std::shared_ptr<MemoryPool>& pool)
-    : arrow_pool_(GetArrowPool(pool)),
-      reader_(std::move(reader)),
-      predicate_filter_(predicate_filter) {}
+                                           const std::shared_ptr<arrow::MemoryPool>& arrow_pool)
+    : arrow_pool_(arrow_pool), reader_(std::move(reader)), predicate_filter_(predicate_filter) {}
 
 Result<std::unique_ptr<PredicateBatchReader>> PredicateBatchReader::Create(
     std::unique_ptr<BatchReader>&& reader, const std::shared_ptr<Predicate>& predicate,
-    const std::shared_ptr<MemoryPool>& pool) {
+    const std::shared_ptr<arrow::MemoryPool>& arrow_pool) {
     if (!predicate) {
         return Status::Invalid("create predicate batch reader failed. predicate is nullptr");
     }
@@ -57,7 +54,7 @@ Result<std::unique_ptr<PredicateBatchReader>> PredicateBatchReader::Create(
             fmt::format("predicate {} does not support Test", predicate->ToString()));
     }
     return std::unique_ptr<PredicateBatchReader>(
-        new PredicateBatchReader(std::move(reader), predicate_filter, pool));
+        new PredicateBatchReader(std::move(reader), predicate_filter, arrow_pool));
 }
 
 Result<BatchReader::ReadBatch> PredicateBatchReader::NextBatch() {

--- a/src/paimon/common/reader/predicate_batch_reader.h
+++ b/src/paimon/common/reader/predicate_batch_reader.h
@@ -37,7 +37,7 @@ class PredicateBatchReader : public BatchReader {
  public:
     static Result<std::unique_ptr<PredicateBatchReader>> Create(
         std::unique_ptr<BatchReader>&& reader, const std::shared_ptr<Predicate>& predicate,
-        const std::shared_ptr<MemoryPool>& pool);
+        const std::shared_ptr<arrow::MemoryPool>& arrow_pool);
 
     ~PredicateBatchReader() override = default;
 
@@ -56,11 +56,11 @@ class PredicateBatchReader : public BatchReader {
  private:
     PredicateBatchReader(std::unique_ptr<BatchReader>&& reader,
                          const std::shared_ptr<PredicateFilter>& predicate_filter,
-                         const std::shared_ptr<MemoryPool>& pool);
+                         const std::shared_ptr<arrow::MemoryPool>& arrow_pool);
     Result<RoaringBitmap32> Filter(const std::shared_ptr<arrow::Array>& array) const;
 
  private:
-    std::unique_ptr<arrow::MemoryPool> arrow_pool_;
+    std::shared_ptr<arrow::MemoryPool> arrow_pool_;
     std::unique_ptr<BatchReader> reader_;
     std::shared_ptr<PredicateFilter> predicate_filter_;
 };

--- a/src/paimon/common/reader/predicate_batch_reader_test.cpp
+++ b/src/paimon/common/reader/predicate_batch_reader_test.cpp
@@ -28,6 +28,7 @@
 #include "arrow/array/builder_primitive.h"
 #include "arrow/ipc/json_simple.h"
 #include "gtest/gtest.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/defs.h"
 #include "paimon/memory/memory_pool.h"
 #include "paimon/predicate/literal.h"
@@ -45,6 +46,8 @@ namespace paimon::test {
 class PredicateBatchReaderTest : public ::testing::Test {
  public:
     void SetUp() override {
+        pool_ = GetDefaultPool();
+        arrow_pool_ = GetArrowPool(pool_);
         fields_ = {arrow::field("f0", arrow::utf8()), arrow::field("f1", arrow::int64()),
                    arrow::field("f2", arrow::boolean())};
         data_type_ = arrow::struct_(fields_);
@@ -74,9 +77,9 @@ class PredicateBatchReaderTest : public ::testing::Test {
     void CheckResult(std::unique_ptr<BatchReader>&& reader,
                      const std::shared_ptr<Predicate>& predicate,
                      const std::shared_ptr<arrow::ChunkedArray>& expected_array) const {
-        ASSERT_OK_AND_ASSIGN(
-            auto predicate_reader,
-            PredicateBatchReader::Create(std::move(reader), predicate, GetDefaultPool()));
+        ASSERT_OK_AND_ASSIGN(auto predicate_reader, PredicateBatchReader::Create(
+                                                        std::move(reader), predicate, arrow_pool_));
+        ASSERT_EQ(arrow_pool_.get(), predicate_reader->arrow_pool_.get());
         ASSERT_OK_AND_ASSIGN(std::shared_ptr<arrow::ChunkedArray> result_array,
                              ReadResultCollector::CollectResult(predicate_reader.get()));
         if (expected_array) {
@@ -89,6 +92,8 @@ class PredicateBatchReaderTest : public ::testing::Test {
  private:
     arrow::FieldVector fields_;
     std::shared_ptr<arrow::DataType> data_type_;
+    std::shared_ptr<MemoryPool> pool_;
+    std::shared_ptr<arrow::MemoryPool> arrow_pool_;
 };
 
 TEST_F(PredicateBatchReaderTest, TestSimple) {
@@ -191,7 +196,7 @@ TEST_F(PredicateBatchReaderTest, TestFullAndEmptyCase) {
 TEST_F(PredicateBatchReaderTest, TestInvalidInput) {
     auto data_array = PrepareArray(8);
     auto reader = std::make_unique<MockFileBatchReader>(data_array, data_type_, /*batch_size=*/10);
-    ASSERT_NOK_WITH_MSG(PredicateBatchReader::Create(std::move(reader), nullptr, GetDefaultPool()),
+    ASSERT_NOK_WITH_MSG(PredicateBatchReader::Create(std::move(reader), nullptr, arrow_pool_),
                         "create predicate batch reader failed. predicate is nullptr");
 }
 

--- a/src/paimon/core/io/async_key_value_projection_reader.h
+++ b/src/paimon/core/io/async_key_value_projection_reader.h
@@ -31,10 +31,12 @@ class AsyncKeyValueProjectionReader : public BatchReader {
                                   const std::shared_ptr<arrow::Schema>& target_schema,
                                   const std::vector<int32_t>& target_to_src_mapping,
                                   int32_t batch_size, int32_t projection_thread_num,
-                                  const std::shared_ptr<MemoryPool>& pool) {
-        auto create_consumer = [target_schema, target_to_src_mapping, pool]()
+                                  const std::shared_ptr<MemoryPool>& pool,
+                                  const std::shared_ptr<arrow::MemoryPool>& arrow_pool) {
+        auto create_consumer = [target_schema, target_to_src_mapping, arrow_pool]()
             -> Result<std::unique_ptr<RowToArrowArrayConverter<KeyValue, BatchReader::ReadBatch>>> {
-            return KeyValueProjectionConsumer::Create(target_schema, target_to_src_mapping, pool);
+            return KeyValueProjectionConsumer::Create(target_schema, target_to_src_mapping,
+                                                      arrow_pool);
         };
         producer_and_consumer_ =
             std::make_unique<AsyncKeyValueProducerAndConsumer<KeyValue, BatchReader::ReadBatch>>(

--- a/src/paimon/core/io/complete_row_tracking_fields_reader.cpp
+++ b/src/paimon/core/io/complete_row_tracking_fields_reader.cpp
@@ -24,16 +24,15 @@
 #include "arrow/c/abi.h"
 #include "arrow/c/bridge.h"
 #include "paimon/common/table/special_fields.h"
-#include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/common/utils/arrow/status_utils.h"
 
 namespace paimon {
 CompleteRowTrackingFieldsBatchReader::CompleteRowTrackingFieldsBatchReader(
     std::unique_ptr<FileBatchReader>&& reader, const std::optional<int64_t>& first_row_id,
-    int64_t snapshot_id, const std::shared_ptr<MemoryPool>& pool)
+    int64_t snapshot_id, const std::shared_ptr<arrow::MemoryPool>& arrow_pool)
     : first_row_id_(first_row_id),
       snapshot_id_(snapshot_id),
-      arrow_pool_(GetArrowPool(pool)),
+      arrow_pool_(arrow_pool),
       reader_(std::move(reader)) {}
 
 Status CompleteRowTrackingFieldsBatchReader::SetReadSchema(

--- a/src/paimon/core/io/complete_row_tracking_fields_reader.h
+++ b/src/paimon/core/io/complete_row_tracking_fields_reader.h
@@ -34,7 +34,7 @@ class CompleteRowTrackingFieldsBatchReader : public FileBatchReader {
     CompleteRowTrackingFieldsBatchReader(std::unique_ptr<FileBatchReader>&& reader,
                                          const std::optional<int64_t>& first_row_id,
                                          int64_t snapshot_id,
-                                         const std::shared_ptr<MemoryPool>& pool);
+                                         const std::shared_ptr<arrow::MemoryPool>& arrow_pool);
 
     Result<std::unique_ptr<::ArrowSchema>> GetFileSchema() const override {
         return Status::Invalid(

--- a/src/paimon/core/io/complete_row_tracking_fields_reader_test.cpp
+++ b/src/paimon/core/io/complete_row_tracking_fields_reader_test.cpp
@@ -24,6 +24,7 @@
 #include "arrow/array/array_nested.h"
 #include "arrow/ipc/json_simple.h"
 #include "gtest/gtest.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/memory/memory_pool.h"
 #include "paimon/status.h"
 #include "paimon/testing/mock/mock_file_batch_reader.h"
@@ -34,6 +35,7 @@ class CompleteRowTrackingFieldsBatchReaderTest : public testing::Test {
  public:
     void SetUp() override {
         pool_ = GetDefaultPool();
+        arrow_pool_ = GetArrowPool(pool_);
     }
 
     void CheckResult(const std::shared_ptr<arrow::Array>& src_array, int64_t first_row_id,
@@ -44,7 +46,8 @@ class CompleteRowTrackingFieldsBatchReaderTest : public testing::Test {
                 std::make_unique<MockFileBatchReader>(src_array, src_array->type(), batch_size);
             auto complete_row_tracking_fields_reader =
                 std::make_shared<CompleteRowTrackingFieldsBatchReader>(
-                    std::move(file_batch_reader), first_row_id, snapshot_id, pool_);
+                    std::move(file_batch_reader), first_row_id, snapshot_id, arrow_pool_);
+            ASSERT_EQ(arrow_pool_.get(), complete_row_tracking_fields_reader->arrow_pool_.get());
             ArrowSchema c_read_schema;
             ASSERT_TRUE(arrow::ExportSchema(*read_schema, &c_read_schema).ok());
             ASSERT_OK(complete_row_tracking_fields_reader->SetReadSchema(
@@ -68,7 +71,8 @@ class CompleteRowTrackingFieldsBatchReaderTest : public testing::Test {
             /*data=*/nullptr, arrow::struct_(file_schema->fields()), /*read_batch_size=*/1);
         auto complete_row_tracking_fields_reader =
             std::make_shared<CompleteRowTrackingFieldsBatchReader>(
-                std::move(file_batch_reader), /*first_row_id=*/10, /*snapshot_id=*/1, pool_);
+                std::move(file_batch_reader), /*first_row_id=*/10, /*snapshot_id=*/1, arrow_pool_);
+        ASSERT_EQ(arrow_pool_.get(), complete_row_tracking_fields_reader->arrow_pool_.get());
         ArrowSchema c_read_schema;
         ASSERT_TRUE(arrow::ExportSchema(*read_schema, &c_read_schema).ok());
         ASSERT_OK(
@@ -84,6 +88,7 @@ class CompleteRowTrackingFieldsBatchReaderTest : public testing::Test {
 
  private:
     std::shared_ptr<MemoryPool> pool_;
+    std::shared_ptr<arrow::MemoryPool> arrow_pool_;
 };
 
 TEST_F(CompleteRowTrackingFieldsBatchReaderTest, TestSetReadSchema) {
@@ -342,7 +347,8 @@ TEST_F(CompleteRowTrackingFieldsBatchReaderTest, TestInvalidWithReadNonExistFiel
 
     auto complete_row_tracking_fields_reader =
         std::make_shared<CompleteRowTrackingFieldsBatchReader>(
-            std::move(file_batch_reader), /*first_row_id=*/100, /*snapshot_id=*/8, pool_);
+            std::move(file_batch_reader), /*first_row_id=*/100, /*snapshot_id=*/8, arrow_pool_);
+    ASSERT_EQ(arrow_pool_.get(), complete_row_tracking_fields_reader->arrow_pool_.get());
     ArrowSchema c_read_schema;
     ASSERT_TRUE(arrow::ExportSchema(*read_schema, &c_read_schema).ok());
     ASSERT_OK(
@@ -378,7 +384,8 @@ TEST_F(CompleteRowTrackingFieldsBatchReaderTest, TestInvalidNextBatchBeforeSetRe
 
     auto complete_row_tracking_fields_reader =
         std::make_shared<CompleteRowTrackingFieldsBatchReader>(
-            std::move(file_batch_reader), /*first_row_id=*/100, /*snapshot_id=*/8, pool_);
+            std::move(file_batch_reader), /*first_row_id=*/100, /*snapshot_id=*/8, arrow_pool_);
+    ASSERT_EQ(arrow_pool_.get(), complete_row_tracking_fields_reader->arrow_pool_.get());
     ASSERT_NOK_WITH_MSG(complete_row_tracking_fields_reader->NextBatchWithBitmap(),
                         "in CompleteRowTrackingFieldsBatchReader SetReadSchema is supposed to be "
                         "called before NextBatch");
@@ -407,8 +414,10 @@ TEST_F(CompleteRowTrackingFieldsBatchReaderTest, TestInvalidNullFirstRowId) {
         std::make_unique<MockFileBatchReader>(src_array, file_type, /*batch_size=*/10);
 
     auto complete_row_tracking_fields_reader =
-        std::make_shared<CompleteRowTrackingFieldsBatchReader>(
-            std::move(file_batch_reader), /*first_row_id=*/std::nullopt, /*snapshot_id=*/8, pool_);
+        std::make_shared<CompleteRowTrackingFieldsBatchReader>(std::move(file_batch_reader),
+                                                               /*first_row_id=*/std::nullopt,
+                                                               /*snapshot_id=*/8, arrow_pool_);
+    ASSERT_EQ(arrow_pool_.get(), complete_row_tracking_fields_reader->arrow_pool_.get());
     ArrowSchema c_read_schema;
     ASSERT_TRUE(arrow::ExportSchema(*read_schema, &c_read_schema).ok());
     ASSERT_OK(

--- a/src/paimon/core/io/field_mapping_reader.cpp
+++ b/src/paimon/core/io/field_mapping_reader.cpp
@@ -30,7 +30,6 @@
 #include "fmt/format.h"
 #include "paimon/common/data/binary_string.h"
 #include "paimon/common/types/data_field.h"
-#include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/common/utils/arrow/status_utils.h"
 #include "paimon/core/casting/cast_executor.h"
 #include "paimon/core/casting/casting_utils.h"
@@ -45,9 +44,9 @@ FieldMappingReader::FieldMappingReader(int32_t field_count,
                                        std::unique_ptr<FileBatchReader>&& reader,
                                        const BinaryRow& partition,
                                        std::unique_ptr<FieldMapping>&& mapping,
-                                       const std::shared_ptr<MemoryPool>& pool)
+                                       const std::shared_ptr<arrow::MemoryPool>& arrow_pool)
     : field_count_(field_count),
-      arrow_pool_(GetArrowPool(pool)),
+      arrow_pool_(arrow_pool),
       reader_(std::move(reader)),
       partition_(partition),
       partition_info_(mapping->partition_info),

--- a/src/paimon/core/io/field_mapping_reader.h
+++ b/src/paimon/core/io/field_mapping_reader.h
@@ -27,7 +27,6 @@
 #include "arrow/c/abi.h"
 #include "arrow/c/bridge.h"
 #include "paimon/common/data/binary_row.h"
-#include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/core/partition/partition_info.h"
 #include "paimon/core/utils/field_mapping.h"
 #include "paimon/reader/file_batch_reader.h"
@@ -48,7 +47,7 @@ class FieldMappingReader : public FileBatchReader {
  public:
     FieldMappingReader(int32_t field_count, std::unique_ptr<FileBatchReader>&& reader,
                        const BinaryRow& partition, std::unique_ptr<FieldMapping>&& mapping,
-                       const std::shared_ptr<MemoryPool>& pool);
+                       const std::shared_ptr<arrow::MemoryPool>& arrow_pool);
 
     Result<ReadBatch> NextBatch() override {
         return Status::Invalid(

--- a/src/paimon/core/io/field_mapping_reader_test.cpp
+++ b/src/paimon/core/io/field_mapping_reader_test.cpp
@@ -33,6 +33,7 @@
 #include "arrow/util/checked_cast.h"
 #include "gtest/gtest.h"
 #include "paimon/common/types/data_field.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/core/utils/field_mapping.h"
 #include "paimon/defs.h"
 #include "paimon/format/file_format.h"
@@ -56,6 +57,7 @@ namespace paimon::test {
 class FieldMappingReaderTest : public ::testing::Test {
  public:
     void SetUp() override {
+        arrow_pool_ = GetArrowPool(pool_);
         partition_ = BinaryRowGenerator::GenerateRow({10, 0}, pool_.get());
     }
     void TearDown() override {}
@@ -133,7 +135,8 @@ class FieldMappingReaderTest : public ::testing::Test {
 
         auto reader = std::make_shared<FieldMappingReader>(
             /*field_count=*/read_schema->num_fields(), std::move(orc_batch_reader), partition_,
-            std::move(mapping), pool_);
+            std::move(mapping), arrow_pool_);
+        ASSERT_EQ(arrow_pool_.get(), reader->arrow_pool_.get());
         ASSERT_OK_AND_ASSIGN(auto result_array, ReadResultCollector::CollectResult(reader.get()));
         if (expect_array == nullptr && result_array == nullptr) {
             // expect empty result
@@ -172,7 +175,8 @@ class FieldMappingReaderTest : public ::testing::Test {
 
         auto reader = std::make_shared<FieldMappingReader>(
             /*field_count=*/read_schema->num_fields(), std::move(orc_batch_reader), partition,
-            std::move(mapping), pool_);
+            std::move(mapping), arrow_pool_);
+        ASSERT_EQ(arrow_pool_.get(), reader->arrow_pool_.get());
         ASSERT_OK_AND_ASSIGN(auto result_array, ReadResultCollector::CollectResult(reader.get()));
         if (expect_array == nullptr && result_array == nullptr) {
             // expect empty result
@@ -187,6 +191,7 @@ class FieldMappingReaderTest : public ::testing::Test {
 
  private:
     std::shared_ptr<MemoryPool> pool_ = GetDefaultPool();
+    std::shared_ptr<arrow::MemoryPool> arrow_pool_;
     std::vector<DataField> data_fields_ = {DataField(0, arrow::field("f0", arrow::utf8())),
                                            DataField(1, arrow::field("f1", arrow::int32())),
                                            DataField(2, arrow::field("f2", arrow::int32())),
@@ -231,7 +236,8 @@ TEST_F(FieldMappingReaderTest, TestGenerateSinglePartitionArray) {
          std::make_shared<Bytes>("8", pool_.get()), 100},
         pool_.get());
     auto mapping_reader = std::make_unique<FieldMappingReader>(
-        /*field_count=*/10, /*reader=*/nullptr, partition, std::move(field_mapping), pool_);
+        /*field_count=*/10, /*reader=*/nullptr, partition, std::move(field_mapping), arrow_pool_);
+    ASSERT_EQ(arrow_pool_.get(), mapping_reader->arrow_pool_.get());
 
     {
         ASSERT_OK_AND_ASSIGN(auto p9_array, mapping_reader->GenerateSinglePartitionArray(

--- a/src/paimon/core/io/key_value_projection_consumer.cpp
+++ b/src/paimon/core/io/key_value_projection_consumer.cpp
@@ -26,7 +26,6 @@
 #include "arrow/c/abi.h"
 #include "arrow/util/checked_cast.h"
 #include "paimon/common/data/internal_row.h"
-#include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/common/utils/arrow/status_utils.h"
 #include "paimon/core/key_value.h"
 #include "paimon/status.h"
@@ -36,12 +35,12 @@ class MemoryPool;
 
 Result<std::unique_ptr<KeyValueProjectionConsumer>> KeyValueProjectionConsumer::Create(
     const std::shared_ptr<arrow::Schema>& target_schema,
-    const std::vector<int32_t>& target_to_src_mapping, const std::shared_ptr<MemoryPool>& pool) {
+    const std::vector<int32_t>& target_to_src_mapping,
+    const std::shared_ptr<arrow::MemoryPool>& arrow_pool) {
     if (static_cast<size_t>(target_schema->num_fields()) != target_to_src_mapping.size()) {
         return Status::Invalid(
             "target_schema and target_to_src_mapping mismatch in KeyValueProjectionConsumer");
     }
-    auto arrow_pool = GetArrowPool(pool);
     std::unique_ptr<arrow::ArrayBuilder> array_builder;
     PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::MakeBuilder(
         arrow_pool.get(), std::make_shared<arrow::StructType>(target_schema->fields()),
@@ -61,7 +60,7 @@ Result<std::unique_ptr<KeyValueProjectionConsumer>> KeyValueProjectionConsumer::
         appenders.emplace_back(func);
     }
     return std::unique_ptr<KeyValueProjectionConsumer>(new KeyValueProjectionConsumer(
-        reserve_count, std::move(appenders), std::move(struct_builder), std::move(arrow_pool),
+        reserve_count, std::move(appenders), std::move(struct_builder), arrow_pool,
         target_to_src_mapping));
 }
 

--- a/src/paimon/core/io/key_value_projection_consumer.h
+++ b/src/paimon/core/io/key_value_projection_consumer.h
@@ -42,7 +42,8 @@ class KeyValueProjectionConsumer
  public:
     static Result<std::unique_ptr<KeyValueProjectionConsumer>> Create(
         const std::shared_ptr<arrow::Schema>& target_schema,
-        const std::vector<int32_t>& target_to_src_mapping, const std::shared_ptr<MemoryPool>& pool);
+        const std::vector<int32_t>& target_to_src_mapping,
+        const std::shared_ptr<arrow::MemoryPool>& arrow_pool);
 
     Result<BatchReader::ReadBatch> NextBatch(const std::vector<KeyValue>& key_value_vec) override;
 
@@ -51,10 +52,10 @@ class KeyValueProjectionConsumer
  private:
     KeyValueProjectionConsumer(int32_t reserve_count, std::vector<AppendValueFunc>&& appenders,
                                std::unique_ptr<arrow::StructBuilder>&& array_builder,
-                               std::unique_ptr<arrow::MemoryPool>&& arrow_pool,
+                               const std::shared_ptr<arrow::MemoryPool>& arrow_pool,
                                const std::vector<int32_t>& target_to_src_mapping)
         : RowToArrowArrayConverter(reserve_count, std::move(appenders), std::move(array_builder),
-                                   std::move(arrow_pool)),
+                                   arrow_pool),
           target_to_src_mapping_(target_to_src_mapping) {}
 
     std::vector<int32_t> target_to_src_mapping_;

--- a/src/paimon/core/io/key_value_projection_reader.cpp
+++ b/src/paimon/core/io/key_value_projection_reader.cpp
@@ -34,10 +34,11 @@ Result<std::unique_ptr<KeyValueProjectionReader>> KeyValueProjectionReader::Crea
     std::unique_ptr<SortMergeReader>&& sort_merge_reader,
     const std::shared_ptr<arrow::Schema>& target_schema,
     const std::vector<int32_t>& target_to_src_mapping, int32_t batch_size,
-    const std::shared_ptr<MemoryPool>& pool) {
+    const std::shared_ptr<arrow::MemoryPool>& arrow_pool) {
     std::unique_ptr<RowToArrowArrayConverter<KeyValue, BatchReader::ReadBatch>> projection_consumer;
-    PAIMON_ASSIGN_OR_RAISE(projection_consumer, KeyValueProjectionConsumer::Create(
-                                                    target_schema, target_to_src_mapping, pool));
+    PAIMON_ASSIGN_OR_RAISE(
+        projection_consumer,
+        KeyValueProjectionConsumer::Create(target_schema, target_to_src_mapping, arrow_pool));
     return std::unique_ptr<KeyValueProjectionReader>(new KeyValueProjectionReader(
         batch_size, std::move(sort_merge_reader), std::move(projection_consumer)));
 }

--- a/src/paimon/core/io/key_value_projection_reader.h
+++ b/src/paimon/core/io/key_value_projection_reader.h
@@ -27,6 +27,7 @@
 #include "paimon/result.h"
 
 namespace arrow {
+class MemoryPool;
 class Schema;
 }  // namespace arrow
 
@@ -42,7 +43,7 @@ class KeyValueProjectionReader : public BatchReader {
         std::unique_ptr<SortMergeReader>&& sort_merge_reader,
         const std::shared_ptr<arrow::Schema>& target_schema,
         const std::vector<int32_t>& target_to_src_mapping, int32_t batch_size,
-        const std::shared_ptr<MemoryPool>& pool);
+        const std::shared_ptr<arrow::MemoryPool>& arrow_pool);
 
     Result<ReadBatch> NextBatch() override;
 

--- a/src/paimon/core/io/key_value_projection_reader_test.cpp
+++ b/src/paimon/core/io/key_value_projection_reader_test.cpp
@@ -55,6 +55,7 @@ class KeyValueProjectionReaderTest : public testing::Test,
  public:
     void SetUp() override {
         pool_ = GetDefaultPool();
+        arrow_pool_ = GetArrowPool(pool_);
     }
 
     std::unique_ptr<BatchReader> GenerateProjectionReader(
@@ -91,15 +92,16 @@ class KeyValueProjectionReaderTest : public testing::Test,
             std::move(concat_readers), user_key_comparator,
             /*user_defined_seq_comparator=*/nullptr, merge_function_wrapper);
         if (!multi_thread_row_to_batch) {
-            EXPECT_OK_AND_ASSIGN(auto projection_reader, KeyValueProjectionReader::Create(
-                                                             std::move(sort_merge_reader),
-                                                             target_schema, target_to_src_mapping,
-                                                             /*batch_size=*/batch_size, pool_));
+            EXPECT_OK_AND_ASSIGN(
+                auto projection_reader,
+                KeyValueProjectionReader::Create(std::move(sort_merge_reader), target_schema,
+                                                 target_to_src_mapping,
+                                                 /*batch_size=*/batch_size, arrow_pool_));
             return std::move(projection_reader);
         } else {
             return std::make_unique<AsyncKeyValueProjectionReader>(
                 std::move(sort_merge_reader), target_schema, target_to_src_mapping, batch_size,
-                /*projection_thread_num=*/3, pool_);
+                /*projection_thread_num=*/3, pool_, arrow_pool_);
         }
     }
 
@@ -144,6 +146,7 @@ class KeyValueProjectionReaderTest : public testing::Test,
                     dynamic_cast<KeyValueProjectionReader*>(projection_reader.get());
                 ASSERT_TRUE(typed_projection_reader);
                 auto& consumer = typed_projection_reader->key_value_consumer_;
+                ASSERT_EQ(arrow_pool_.get(), consumer->arrow_pool_.get());
                 ASSERT_EQ(consumer->reserved_sizes_.size(), expected_reserve_count);
                 for (const auto& reserved_size : consumer->reserved_sizes_) {
                     ASSERT_GT(reserved_size, 0);
@@ -154,6 +157,7 @@ class KeyValueProjectionReaderTest : public testing::Test,
 
  private:
     std::shared_ptr<MemoryPool> pool_;
+    std::shared_ptr<arrow::MemoryPool> arrow_pool_;
 };
 
 TEST_P(KeyValueProjectionReaderTest, TestBulkData) {

--- a/src/paimon/core/io/row_to_arrow_array_converter.h
+++ b/src/paimon/core/io/row_to_arrow_array_converter.h
@@ -50,6 +50,9 @@ class RowToArrowArrayConverter {
     RowToArrowArrayConverter(int32_t reserve_count, std::vector<AppendValueFunc>&& appenders,
                              std::unique_ptr<arrow::StructBuilder>&& array_builder,
                              std::unique_ptr<arrow::MemoryPool>&& arrow_pool);
+    RowToArrowArrayConverter(int32_t reserve_count, std::vector<AppendValueFunc>&& appenders,
+                             std::unique_ptr<arrow::StructBuilder>&& array_builder,
+                             const std::shared_ptr<arrow::MemoryPool>& arrow_pool);
 
     static Result<AppendValueFunc> AppendField(bool use_view, arrow::ArrayBuilder* array_builder,
                                                int32_t* reserve_count);
@@ -69,7 +72,7 @@ class RowToArrowArrayConverter {
 
  protected:
     std::vector<int32_t> reserved_sizes_;
-    std::unique_ptr<arrow::MemoryPool> arrow_pool_;
+    std::shared_ptr<arrow::MemoryPool> arrow_pool_;
     std::vector<AppendValueFunc> appenders_;
     std::unique_ptr<arrow::StructBuilder> array_builder_;
 };
@@ -84,8 +87,16 @@ RowToArrowArrayConverter<T, R>::RowToArrowArrayConverter(
     int32_t reserve_count, std::vector<RowToArrowArrayConverter<T, R>::AppendValueFunc>&& appenders,
     std::unique_ptr<arrow::StructBuilder>&& array_builder,
     std::unique_ptr<arrow::MemoryPool>&& arrow_pool)
+    : RowToArrowArrayConverter(reserve_count, std::move(appenders), std::move(array_builder),
+                               std::shared_ptr<arrow::MemoryPool>(std::move(arrow_pool))) {}
+
+template <typename T, typename R>
+RowToArrowArrayConverter<T, R>::RowToArrowArrayConverter(
+    int32_t reserve_count, std::vector<RowToArrowArrayConverter<T, R>::AppendValueFunc>&& appenders,
+    std::unique_ptr<arrow::StructBuilder>&& array_builder,
+    const std::shared_ptr<arrow::MemoryPool>& arrow_pool)
     : reserved_sizes_(reserve_count, -1),
-      arrow_pool_(std::move(arrow_pool)),
+      arrow_pool_(arrow_pool),
       appenders_(std::move(appenders)),
       array_builder_(std::move(array_builder)) {}
 

--- a/src/paimon/core/operation/abstract_split_read.cpp
+++ b/src/paimon/core/operation/abstract_split_read.cpp
@@ -52,8 +52,10 @@ AbstractSplitRead::AbstractSplitRead(const std::shared_ptr<FileStorePathFactory>
                                      const std::shared_ptr<InternalReadContext>& context,
                                      std::unique_ptr<SchemaManager>&& schema_manager,
                                      const std::shared_ptr<MemoryPool>& memory_pool,
+                                     const std::shared_ptr<arrow::MemoryPool>& arrow_pool,
                                      const std::shared_ptr<Executor>& executor)
     : pool_(memory_pool),
+      arrow_pool_(arrow_pool),
       executor_(executor),
       path_factory_(path_factory),
       options_(context->GetCoreOptions()),
@@ -129,7 +131,7 @@ Result<std::unique_ptr<BatchReader>> AbstractSplitRead::ApplyPredicateFilterIfNe
     if (!context_->EnablePredicateFilter() || predicate == nullptr) {
         return std::move(reader);
     }
-    return PredicateBatchReader::Create(std::move(reader), predicate, pool_);
+    return PredicateBatchReader::Create(std::move(reader), predicate, arrow_pool_);
 }
 
 Result<std::unique_ptr<ReaderBuilder>> AbstractSplitRead::PrepareReaderBuilder(
@@ -138,7 +140,7 @@ Result<std::unique_ptr<ReaderBuilder>> AbstractSplitRead::PrepareReaderBuilder(
                            FileFormatFactory::Get(format_identifier, options_.ToMap()));
     PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<ReaderBuilder> reader_builder,
                            file_format->CreateReaderBuilder(options_.GetReadBatchSize()));
-    reader_builder->WithMemoryPool(pool_);
+    reader_builder->WithMemoryPool(pool_, arrow_pool_);
     return reader_builder;
 }
 
@@ -206,7 +208,8 @@ Result<std::unique_ptr<FileBatchReader>> AbstractSplitRead::CreateFieldMappingRe
                            CreateFileBatchReader(file_meta, data_file_path, reader_builder));
     if (NeedCompleteRowTrackingFields(options_.RowTrackingEnabled(), read_schema)) {
         file_reader = std::make_unique<CompleteRowTrackingFieldsBatchReader>(
-            std::move(file_reader), file_meta->first_row_id, file_meta->max_sequence_number, pool_);
+            std::move(file_reader), file_meta->first_row_id, file_meta->max_sequence_number,
+            arrow_pool_);
     }
 
     const auto& predicate = field_mapping->non_partition_info.non_partition_filter;
@@ -222,7 +225,7 @@ Result<std::unique_ptr<FileBatchReader>> AbstractSplitRead::CreateFieldMappingRe
 
     return std::make_unique<FieldMappingReader>(field_mapping_builder->GetReadFieldCount(),
                                                 std::move(final_reader), partition,
-                                                std::move(field_mapping), pool_);
+                                                std::move(field_mapping), arrow_pool_);
 }
 
 Result<std::vector<DataField>> AbstractSplitRead::ProjectFieldsForRowTrackingAndDataEvolution(

--- a/src/paimon/core/operation/abstract_split_read.h
+++ b/src/paimon/core/operation/abstract_split_read.h
@@ -39,6 +39,7 @@
 #include "paimon/status.h"
 
 namespace arrow {
+class MemoryPool;
 class Schema;
 }  // namespace arrow
 
@@ -72,6 +73,7 @@ class AbstractSplitRead : public SplitRead {
                       const std::shared_ptr<InternalReadContext>& context,
                       std::unique_ptr<SchemaManager>&& schema_manager,
                       const std::shared_ptr<MemoryPool>& memory_pool,
+                      const std::shared_ptr<arrow::MemoryPool>& arrow_pool,
                       const std::shared_ptr<Executor>& executor);
 
     static std::unordered_map<std::string, DeletionFile> CreateDeletionFileMap(
@@ -122,6 +124,7 @@ class AbstractSplitRead : public SplitRead {
 
  protected:
     std::shared_ptr<MemoryPool> pool_;
+    std::shared_ptr<arrow::MemoryPool> arrow_pool_;
     std::shared_ptr<Executor> executor_;
     std::shared_ptr<FileStorePathFactory> path_factory_;
     CoreOptions options_;

--- a/src/paimon/core/operation/data_evolution_split_read.cpp
+++ b/src/paimon/core/operation/data_evolution_split_read.cpp
@@ -102,12 +102,13 @@ Status DataEvolutionSplitRead::BlobBunch::Add(const std::shared_ptr<DataFileMeta
 DataEvolutionSplitRead::DataEvolutionSplitRead(
     const std::shared_ptr<FileStorePathFactory>& path_factory,
     const std::shared_ptr<InternalReadContext>& context,
-    const std::shared_ptr<MemoryPool>& memory_pool, const std::shared_ptr<Executor>& executor)
+    const std::shared_ptr<MemoryPool>& memory_pool,
+    const std::shared_ptr<arrow::MemoryPool>& arrow_pool, const std::shared_ptr<Executor>& executor)
     : AbstractSplitRead(path_factory, context,
                         std::make_unique<SchemaManager>(context->GetCoreOptions().GetFileSystem(),
                                                         context->GetPath(),
                                                         context->GetCoreOptions().GetBranch()),
-                        memory_pool, executor) {}
+                        memory_pool, arrow_pool, executor) {}
 
 bool DataEvolutionSplitRead::HasIndexScoreField(const std::shared_ptr<arrow::Schema>& read_schema) {
     return read_schema->GetFieldIndex(SpecialFields::IndexScore().Name()) != -1;
@@ -121,8 +122,8 @@ Result<std::unique_ptr<BatchReader>> DataEvolutionSplitRead::CreateReader(
             std::unique_ptr<BatchReader> batch_reader,
             InnerCreateReader(indexed_split->GetDataSplit(), indexed_split->RowRanges()));
         if (HasIndexScoreField(raw_read_schema_)) {
-            return std::make_unique<CompleteIndexScoreBatchReader>(std::move(batch_reader),
-                                                                   indexed_split->Scores(), pool_);
+            return std::make_unique<CompleteIndexScoreBatchReader>(
+                std::move(batch_reader), indexed_split->Scores(), arrow_pool_);
         }
         return batch_reader;
     } else if (auto data_split = std::dynamic_pointer_cast<DataSplit>(split)) {
@@ -168,11 +169,12 @@ Result<std::unique_ptr<BatchReader>> DataEvolutionSplitRead::InnerCreateReader(
             sub_readers.push_back(std::move(evolution_reader));
         }
     }
-    auto concat_batch_reader = std::make_unique<ConcatBatchReader>(std::move(sub_readers), pool_);
+    auto concat_batch_reader =
+        std::make_unique<ConcatBatchReader>(std::move(sub_readers), arrow_pool_);
     PAIMON_ASSIGN_OR_RAISE(
         std::unique_ptr<BatchReader> batch_reader,
         ApplyPredicateFilterIfNeeded(std::move(concat_batch_reader), context_->GetPredicate()));
-    return std::make_unique<CompleteRowKindBatchReader>(std::move(batch_reader), pool_);
+    return std::make_unique<CompleteRowKindBatchReader>(std::move(batch_reader), arrow_pool_);
 }
 Result<std::unique_ptr<FileBatchReader>> DataEvolutionSplitRead::ApplyIndexAndDvReaderIfNeeded(
     std::unique_ptr<FileBatchReader>&& file_reader, const std::shared_ptr<DataFileMeta>& file,
@@ -344,14 +346,14 @@ Result<std::unique_ptr<DataEvolutionFileReader>> DataEvolutionSplitRead::CreateU
                     ObjectUtils::MoveVector<std::unique_ptr<BatchReader>>(std::move(file_readers));
                 // Concat multiple blob files that map to the same data file.
                 file_batch_readers[file_idx] =
-                    std::make_unique<ConcatBatchReader>(std::move(raw_readers), pool_);
+                    std::make_unique<ConcatBatchReader>(std::move(raw_readers), arrow_pool_);
             }
         }
     }
     // TODO(xinyu.lxy): check nullable when reader_offsets[read_field_idx] = -1
     return DataEvolutionFileReader::Create(std::move(file_batch_readers), raw_read_schema_,
                                            options_.GetReadBatchSize(), reader_offsets,
-                                           field_offsets, pool_);
+                                           field_offsets, arrow_pool_);
 }
 
 Result<bool> DataEvolutionSplitRead::Match(const std::shared_ptr<Split>& split,

--- a/src/paimon/core/operation/data_evolution_split_read.h
+++ b/src/paimon/core/operation/data_evolution_split_read.h
@@ -65,6 +65,7 @@ class DataEvolutionSplitRead : public AbstractSplitRead {
     DataEvolutionSplitRead(const std::shared_ptr<FileStorePathFactory>& path_factory,
                            const std::shared_ptr<InternalReadContext>& context,
                            const std::shared_ptr<MemoryPool>& memory_pool,
+                           const std::shared_ptr<arrow::MemoryPool>& arrow_pool,
                            const std::shared_ptr<Executor>& executor);
 
     Result<std::unique_ptr<BatchReader>> CreateReader(const std::shared_ptr<Split>& split) override;

--- a/src/paimon/core/operation/merge_file_split_read.cpp
+++ b/src/paimon/core/operation/merge_file_split_read.cpp
@@ -32,6 +32,7 @@
 #include "paimon/common/table/special_fields.h"
 #include "paimon/common/types/data_field.h"
 #include "paimon/common/utils/arrow/arrow_utils.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/common/utils/arrow/status_utils.h"
 #include "paimon/common/utils/object_utils.h"
 #include "paimon/core/core_options.h"
@@ -79,6 +80,16 @@ Result<std::unique_ptr<MergeFileSplitRead>> MergeFileSplitRead::Create(
     const std::shared_ptr<FileStorePathFactory>& path_factory,
     const std::shared_ptr<InternalReadContext>& context,
     const std::shared_ptr<MemoryPool>& memory_pool, const std::shared_ptr<Executor>& executor) {
+    return Create(path_factory, context, memory_pool,
+                  std::shared_ptr<arrow::MemoryPool>(GetArrowPool(memory_pool)), executor);
+}
+
+Result<std::unique_ptr<MergeFileSplitRead>> MergeFileSplitRead::Create(
+    const std::shared_ptr<FileStorePathFactory>& path_factory,
+    const std::shared_ptr<InternalReadContext>& context,
+    const std::shared_ptr<MemoryPool>& memory_pool,
+    const std::shared_ptr<arrow::MemoryPool>& arrow_pool,
+    const std::shared_ptr<Executor>& executor) {
     const auto& core_options = context->GetCoreOptions();
     const auto& table_schema = context->GetTableSchema();
     assert(table_schema);
@@ -111,7 +122,7 @@ Result<std::unique_ptr<MergeFileSplitRead>> MergeFileSplitRead::Create(
         std::make_unique<SchemaManager>(core_options.GetFileSystem(), context->GetPath(),
                                         context->GetCoreOptions().GetBranch()),
         key_schema, value_schema, read_schema, projection, key_comparator,
-        user_defined_seq_comparator, predicate_for_keys, memory_pool, executor));
+        user_defined_seq_comparator, predicate_for_keys, memory_pool, arrow_pool, executor));
 }
 
 Result<std::unique_ptr<BatchReader>> MergeFileSplitRead::CreateReader(
@@ -135,7 +146,7 @@ Result<std::unique_ptr<BatchReader>> MergeFileSplitRead::CreateReader(
     } else {
         PAIMON_ASSIGN_OR_RAISE(batch_reader, CreateMergeReader(data_split, data_file_path_factory));
     }
-    return std::make_unique<CompleteRowKindBatchReader>(std::move(batch_reader), pool_);
+    return std::make_unique<CompleteRowKindBatchReader>(std::move(batch_reader), arrow_pool_);
 }
 
 void MergeFileSplitRead::SetMergeFunctionWrapper(
@@ -229,7 +240,8 @@ Result<std::unique_ptr<BatchReader>> MergeFileSplitRead::CreateMergeReader(
                                                       data_file_path_factory));
         batch_readers.push_back(std::move(projection_reader));
     }
-    auto concat_batch_reader = std::make_unique<ConcatBatchReader>(std::move(batch_readers), pool_);
+    auto concat_batch_reader =
+        std::make_unique<ConcatBatchReader>(std::move(batch_readers), arrow_pool_);
     return AbstractSplitRead::ApplyPredicateFilterIfNeeded(std::move(concat_batch_reader),
                                                            context_->GetPredicate());
 }
@@ -253,7 +265,8 @@ Result<std::unique_ptr<BatchReader>> MergeFileSplitRead::CreateNoMergeReader(
 
     auto raw_readers =
         ObjectUtils::MoveVector<std::unique_ptr<BatchReader>>(std::move(raw_file_readers));
-    auto concat_batch_reader = std::make_unique<ConcatBatchReader>(std::move(raw_readers), pool_);
+    auto concat_batch_reader =
+        std::make_unique<ConcatBatchReader>(std::move(raw_readers), arrow_pool_);
     return AbstractSplitRead::ApplyPredicateFilterIfNeeded(std::move(concat_batch_reader),
                                                            context_->GetPredicate());
 }
@@ -268,8 +281,10 @@ MergeFileSplitRead::MergeFileSplitRead(
     const std::shared_ptr<FieldsComparator>& key_comparator,
     const std::shared_ptr<FieldsComparator>& user_defined_seq_comparator,
     const std::shared_ptr<Predicate>& predicate_for_keys,
-    const std::shared_ptr<MemoryPool>& memory_pool, const std::shared_ptr<Executor>& executor)
-    : AbstractSplitRead(path_factory, context, std::move(schema_manager), memory_pool, executor),
+    const std::shared_ptr<MemoryPool>& memory_pool,
+    const std::shared_ptr<arrow::MemoryPool>& arrow_pool, const std::shared_ptr<Executor>& executor)
+    : AbstractSplitRead(path_factory, context, std::move(schema_manager), memory_pool, arrow_pool,
+                        executor),
       key_schema_(key_schema),
       value_schema_(value_schema),
       read_schema_(read_schema),
@@ -416,13 +431,14 @@ Result<std::unique_ptr<BatchReader>> MergeFileSplitRead::CreateReaderForSection(
     // KeyValueProjectionReader converts KeyValue objects to arrow array according to projection
     if (!context_->EnableMultiThreadRowToBatch()) {
         return KeyValueProjectionReader::Create(std::move(sort_merge_reader), raw_read_schema_,
-                                                projection_, options_.GetReadBatchSize(), pool_);
+                                                projection_, options_.GetReadBatchSize(),
+                                                arrow_pool_);
     }
     int32_t thread_number = context_->GetRowToBatchThreadNumber();
     assert(thread_number > 0);
     return std::make_unique<AsyncKeyValueProjectionReader>(
         std::move(sort_merge_reader), raw_read_schema_, projection_, options_.GetReadBatchSize(),
-        thread_number, pool_);
+        thread_number, pool_, arrow_pool_);
 }
 
 Result<std::unique_ptr<SortMergeReader>> MergeFileSplitRead::CreateSortMergeReaderForSection(

--- a/src/paimon/core/operation/merge_file_split_read.h
+++ b/src/paimon/core/operation/merge_file_split_read.h
@@ -38,6 +38,7 @@
 #include "paimon/status.h"
 
 namespace arrow {
+class MemoryPool;
 class Schema;
 }  // namespace arrow
 
@@ -79,6 +80,13 @@ class MergeFileSplitRead : public AbstractSplitRead {
         const std::shared_ptr<FileStorePathFactory>& path_factory,
         const std::shared_ptr<InternalReadContext>& context,
         const std::shared_ptr<MemoryPool>& memory_pool, const std::shared_ptr<Executor>& executor);
+
+    static Result<std::unique_ptr<MergeFileSplitRead>> Create(
+        const std::shared_ptr<FileStorePathFactory>& path_factory,
+        const std::shared_ptr<InternalReadContext>& context,
+        const std::shared_ptr<MemoryPool>& memory_pool,
+        const std::shared_ptr<arrow::MemoryPool>& arrow_pool,
+        const std::shared_ptr<Executor>& executor);
 
     Result<std::unique_ptr<BatchReader>> CreateReader(const std::shared_ptr<Split>& split) override;
 
@@ -143,6 +151,7 @@ class MergeFileSplitRead : public AbstractSplitRead {
                        const std::shared_ptr<FieldsComparator>& user_defined_seq_comparator,
                        const std::shared_ptr<Predicate>& predicate_for_keys,
                        const std::shared_ptr<MemoryPool>& memory_pool,
+                       const std::shared_ptr<arrow::MemoryPool>& arrow_pool,
                        const std::shared_ptr<Executor>& executor);
 
     static Result<std::shared_ptr<MergeFunctionWrapper<KeyValue>>> CreateMergeFunctionWrapper(

--- a/src/paimon/core/operation/merge_file_split_read_test.cpp
+++ b/src/paimon/core/operation/merge_file_split_read_test.cpp
@@ -31,9 +31,11 @@
 #include "gtest/gtest.h"
 #include "paimon/common/data/binary_row.h"
 #include "paimon/common/factories/io_hook.h"
+#include "paimon/common/reader/complete_row_kind_batch_reader.h"
 #include "paimon/common/reader/concat_batch_reader.h"
 #include "paimon/common/table/special_fields.h"
 #include "paimon/common/types/data_field.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/common/utils/fields_comparator.h"
 #include "paimon/common/utils/scope_guard.h"
 #include "paimon/core/core_options.h"
@@ -347,19 +349,26 @@ class MergeFileSplitReadTest : public ::testing::Test,
                 pool_));
         PAIMON_ASSIGN_OR_RAISE(auto split_read,
                                MergeFileSplitRead::Create(path_factory, std::move(internal_context),
-                                                          pool_, executor_));
+                                                          pool_, arrow_pool_, executor_));
         std::vector<std::unique_ptr<BatchReader>> batch_readers;
         batch_readers.reserve(data_splits.size());
         for (const auto& split : data_splits) {
             PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<BatchReader> reader,
                                    split_read->CreateReader(split));
+            auto* row_kind_reader = dynamic_cast<CompleteRowKindBatchReader*>(reader.get());
+            EXPECT_NE(nullptr, row_kind_reader);
+            EXPECT_EQ(arrow_pool_.get(), row_kind_reader->arrow_pool_.get());
             batch_readers.emplace_back(std::move(reader));
         }
-        return std::make_unique<ConcatBatchReader>(std::move(batch_readers), pool_);
+        auto concat_reader =
+            std::make_unique<ConcatBatchReader>(std::move(batch_readers), arrow_pool_);
+        EXPECT_EQ(arrow_pool_.get(), concat_reader->arrow_pool_.get());
+        return concat_reader;
     }
 
  private:
     std::shared_ptr<MemoryPool> pool_ = GetDefaultPool();
+    std::shared_ptr<arrow::MemoryPool> arrow_pool_ = GetArrowPool(pool_);
     std::shared_ptr<FileSystem> fs_ = std::make_shared<LocalFileSystem>();
     std::shared_ptr<Executor> executor_ = CreateDefaultExecutor(/*thread_count=*/4);
 };
@@ -620,9 +629,9 @@ TEST_P(MergeFileSplitReadTest, TestSimple) {
 
     auto internal_context = CreateInternalReadContext(read_context);
 
-    ASSERT_OK_AND_ASSIGN(
-        std::unique_ptr<MergeFileSplitRead> split_read,
-        MergeFileSplitRead::Create(/*path_factory=*/nullptr, internal_context, pool_, executor_));
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<MergeFileSplitRead> split_read,
+                         MergeFileSplitRead::Create(/*path_factory=*/nullptr, internal_context,
+                                                    pool_, arrow_pool_, executor_));
     auto data_splits = PrepareDataSplit();
 
     // test split read match

--- a/src/paimon/core/operation/raw_file_split_read.cpp
+++ b/src/paimon/core/operation/raw_file_split_read.cpp
@@ -25,6 +25,7 @@
 #include "paimon/common/file_index/bitmap/apply_bitmap_index_batch_reader.h"
 #include "paimon/common/reader/complete_row_kind_batch_reader.h"
 #include "paimon/common/reader/concat_batch_reader.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/common/utils/arrow/status_utils.h"
 #include "paimon/common/utils/object_utils.h"
 #include "paimon/core/core_options.h"
@@ -54,11 +55,20 @@ RawFileSplitRead::RawFileSplitRead(const std::shared_ptr<FileStorePathFactory>& 
                                    const std::shared_ptr<InternalReadContext>& context,
                                    const std::shared_ptr<MemoryPool>& memory_pool,
                                    const std::shared_ptr<Executor>& executor)
+    : RawFileSplitRead(
+          path_factory, context, memory_pool,
+          std::shared_ptr<arrow::MemoryPool>(GetArrowPool(memory_pool)), executor) {}
+
+RawFileSplitRead::RawFileSplitRead(const std::shared_ptr<FileStorePathFactory>& path_factory,
+                                   const std::shared_ptr<InternalReadContext>& context,
+                                   const std::shared_ptr<MemoryPool>& memory_pool,
+                                   const std::shared_ptr<arrow::MemoryPool>& arrow_pool,
+                                   const std::shared_ptr<Executor>& executor)
     : AbstractSplitRead(path_factory, context,
                         std::make_unique<SchemaManager>(context->GetCoreOptions().GetFileSystem(),
                                                         context->GetPath(),
                                                         context->GetCoreOptions().GetBranch()),
-                        memory_pool, executor) {}
+                        memory_pool, arrow_pool, executor) {}
 
 Result<std::unique_ptr<BatchReader>> RawFileSplitRead::CreateReader(
     const std::shared_ptr<Split>& split) {
@@ -85,10 +95,11 @@ Result<std::unique_ptr<BatchReader>> RawFileSplitRead::CreateReader(
 
     auto raw_readers =
         ObjectUtils::MoveVector<std::unique_ptr<BatchReader>>(std::move(raw_file_readers));
-    auto concat_batch_reader = std::make_unique<ConcatBatchReader>(std::move(raw_readers), pool_);
+    auto concat_batch_reader =
+        std::make_unique<ConcatBatchReader>(std::move(raw_readers), arrow_pool_);
     PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<BatchReader> batch_reader,
                            ApplyPredicateFilterIfNeeded(std::move(concat_batch_reader), predicate));
-    return std::make_unique<CompleteRowKindBatchReader>(std::move(batch_reader), pool_);
+    return std::make_unique<CompleteRowKindBatchReader>(std::move(batch_reader), arrow_pool_);
 }
 
 Result<std::unique_ptr<BatchReader>> RawFileSplitRead::CreateReader(

--- a/src/paimon/core/operation/raw_file_split_read.h
+++ b/src/paimon/core/operation/raw_file_split_read.h
@@ -62,6 +62,12 @@ class RawFileSplitRead : public AbstractSplitRead {
                      const std::shared_ptr<MemoryPool>& memory_pool,
                      const std::shared_ptr<Executor>& executor);
 
+    RawFileSplitRead(const std::shared_ptr<FileStorePathFactory>& path_factory,
+                     const std::shared_ptr<InternalReadContext>& context,
+                     const std::shared_ptr<MemoryPool>& memory_pool,
+                     const std::shared_ptr<arrow::MemoryPool>& arrow_pool,
+                     const std::shared_ptr<Executor>& executor);
+
     Result<std::unique_ptr<BatchReader>> CreateReader(const std::shared_ptr<Split>& split) override;
     Result<std::unique_ptr<BatchReader>> CreateReader(
         const BinaryRow& partition, int32_t bucket,

--- a/src/paimon/core/operation/raw_file_split_read_test.cpp
+++ b/src/paimon/core/operation/raw_file_split_read_test.cpp
@@ -25,8 +25,10 @@
 #include "arrow/ipc/json_simple.h"
 #include "gtest/gtest.h"
 #include "paimon/common/data/binary_row.h"
+#include "paimon/common/reader/complete_row_kind_batch_reader.h"
 #include "paimon/common/reader/concat_batch_reader.h"
 #include "paimon/common/types/data_field.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/core/core_options.h"
 #include "paimon/core/io/data_file_meta.h"
 #include "paimon/core/manifest/file_source.h"
@@ -157,18 +159,23 @@ class RawFileSplitReadTest : public ::testing::Test {
                 core_options.DataFilePrefix(), core_options.LegacyPartitionNameEnabled(),
                 external_paths, global_index_external_path, core_options.IndexFileInDataFileDir(),
                 pool_));
-        auto split_read =
-            std::make_unique<RawFileSplitRead>(path_factory, std::move(internal_context), pool_,
-                                               CreateDefaultExecutor(/*thread_count=*/2));
+        auto split_read = std::make_unique<RawFileSplitRead>(
+            path_factory, std::move(internal_context), pool_, arrow_pool_,
+            CreateDefaultExecutor(/*thread_count=*/2));
 
         std::vector<std::unique_ptr<BatchReader>> batch_readers;
         batch_readers.reserve(data_splits.size());
         for (const auto& split : data_splits) {
             ASSERT_OK_AND_ASSIGN(std::unique_ptr<BatchReader> reader,
                                  split_read->CreateReader(split));
+            auto* row_kind_reader = dynamic_cast<CompleteRowKindBatchReader*>(reader.get());
+            ASSERT_NE(nullptr, row_kind_reader);
+            ASSERT_EQ(arrow_pool_.get(), row_kind_reader->arrow_pool_.get());
             batch_readers.emplace_back(std::move(reader));
         }
-        auto batch_reader = std::make_unique<ConcatBatchReader>(std::move(batch_readers), pool_);
+        auto batch_reader =
+            std::make_unique<ConcatBatchReader>(std::move(batch_readers), arrow_pool_);
+        ASSERT_EQ(arrow_pool_.get(), batch_reader->arrow_pool_.get());
         ASSERT_OK_AND_ASSIGN(auto result_array,
                              ReadResultCollector::CollectResult(batch_reader.get()));
         ASSERT_TRUE(result_array->Equals(expected_array));
@@ -176,6 +183,7 @@ class RawFileSplitReadTest : public ::testing::Test {
 
  private:
     std::shared_ptr<MemoryPool> pool_ = GetDefaultPool();
+    std::shared_ptr<arrow::MemoryPool> arrow_pool_ = GetArrowPool(pool_);
 };
 
 // test simple, recall all columns with sequence in data
@@ -404,7 +412,7 @@ TEST_F(RawFileSplitReadTest, TestEmptyPlan) {
 
     auto split_read =
         std::make_unique<RawFileSplitRead>(path_factory, std::move(internal_context), pool_,
-                                           CreateDefaultExecutor(/*thread_count=*/2));
+                                           arrow_pool_, CreateDefaultExecutor(/*thread_count=*/2));
     DataSplitImpl::Builder builder(BinaryRowGenerator::GenerateRow({10, 0}, pool_.get()),
                                    /*bucket=*/0, /*bucket_path=*/
                                    paimon::test::GetDataDir() +
@@ -416,8 +424,12 @@ TEST_F(RawFileSplitReadTest, TestEmptyPlan) {
 
     std::vector<std::unique_ptr<BatchReader>> batch_readers;
     ASSERT_OK_AND_ASSIGN(std::unique_ptr<BatchReader> reader, split_read->CreateReader(data_split));
+    auto* row_kind_reader = dynamic_cast<CompleteRowKindBatchReader*>(reader.get());
+    ASSERT_NE(nullptr, row_kind_reader);
+    ASSERT_EQ(arrow_pool_.get(), row_kind_reader->arrow_pool_.get());
     batch_readers.push_back(std::move(reader));
-    auto batch_reader = std::make_unique<ConcatBatchReader>(std::move(batch_readers), pool_);
+    auto batch_reader = std::make_unique<ConcatBatchReader>(std::move(batch_readers), arrow_pool_);
+    ASSERT_EQ(arrow_pool_.get(), batch_reader->arrow_pool_.get());
     ASSERT_OK_AND_ASSIGN(auto result_array, ReadResultCollector::CollectResult(batch_reader.get()));
     ASSERT_EQ(result_array, nullptr);
 }
@@ -433,9 +445,9 @@ TEST_F(RawFileSplitReadTest, TestMatch) {
     ASSERT_OK_AND_ASSIGN(std::shared_ptr<InternalReadContext> internal_context,
                          InternalReadContext::Create(std::move(read_context), table_schema,
                                                      table_schema->Options()));
-    auto split_read =
-        std::make_unique<RawFileSplitRead>(/*path_factory=*/nullptr, std::move(internal_context),
-                                           pool_, CreateDefaultExecutor(/*thread_count=*/2));
+    auto split_read = std::make_unique<RawFileSplitRead>(
+        /*path_factory=*/nullptr, std::move(internal_context), pool_, arrow_pool_,
+        CreateDefaultExecutor(/*thread_count=*/2));
     auto create_data_split = [this](bool is_streaming,
                                     bool raw_convertible) -> std::shared_ptr<DataSplit> {
         auto meta = std::make_shared<DataFileMeta>(

--- a/src/paimon/core/table/source/append_only_table_read.cpp
+++ b/src/paimon/core/table/source/append_only_table_read.cpp
@@ -31,16 +31,17 @@ class MemoryPool;
 AppendOnlyTableRead::AppendOnlyTableRead(const std::shared_ptr<FileStorePathFactory>& path_factory,
                                          const std::shared_ptr<InternalReadContext>& context,
                                          const std::shared_ptr<MemoryPool>& memory_pool,
+                                         const std::shared_ptr<arrow::MemoryPool>& arrow_pool,
                                          const std::shared_ptr<Executor>& executor)
-    : TableRead(memory_pool) {
+    : TableRead(memory_pool, arrow_pool) {
     const auto& core_options = context->GetCoreOptions();
     if (core_options.DataEvolutionEnabled()) {
         // add data evolution first
-        split_reads_.push_back(
-            std::make_unique<DataEvolutionSplitRead>(path_factory, context, memory_pool, executor));
+        split_reads_.push_back(std::make_unique<DataEvolutionSplitRead>(
+            path_factory, context, memory_pool, arrow_pool, executor));
     } else {
-        split_reads_.push_back(
-            std::make_unique<RawFileSplitRead>(path_factory, context, memory_pool, executor));
+        split_reads_.push_back(std::make_unique<RawFileSplitRead>(
+            path_factory, context, memory_pool, arrow_pool, executor));
     }
 }
 

--- a/src/paimon/core/table/source/append_only_table_read.h
+++ b/src/paimon/core/table/source/append_only_table_read.h
@@ -39,6 +39,7 @@ class AppendOnlyTableRead : public TableRead {
     AppendOnlyTableRead(const std::shared_ptr<FileStorePathFactory>& path_factory,
                         const std::shared_ptr<InternalReadContext>& context,
                         const std::shared_ptr<MemoryPool>& memory_pool,
+                        const std::shared_ptr<arrow::MemoryPool>& arrow_pool,
                         const std::shared_ptr<Executor>& executor);
 
     Result<std::unique_ptr<BatchReader>> CreateReader(

--- a/src/paimon/core/table/source/fallback_table_read.h
+++ b/src/paimon/core/table/source/fallback_table_read.h
@@ -31,8 +31,9 @@ class FallbackTableRead : public TableRead {
  public:
     FallbackTableRead(std::unique_ptr<TableRead> main_table,
                       std::unique_ptr<TableRead> fallback_table,
-                      const std::shared_ptr<MemoryPool>& memory_pool)
-        : TableRead(memory_pool),
+                      const std::shared_ptr<MemoryPool>& memory_pool,
+                      const std::shared_ptr<arrow::MemoryPool>& arrow_pool)
+        : TableRead(memory_pool, arrow_pool),
           main_table_(std::move(main_table)),
           fallback_table_(std::move(fallback_table)) {}
 

--- a/src/paimon/core/table/source/key_value_table_read.cpp
+++ b/src/paimon/core/table/source/key_value_table_read.cpp
@@ -30,23 +30,27 @@ class InternalReadContext;
 class MemoryPool;
 
 KeyValueTableRead::KeyValueTableRead(std::vector<std::unique_ptr<SplitRead>>&& split_reads,
-                                     const std::shared_ptr<MemoryPool>& memory_pool)
-    : TableRead(memory_pool), split_reads_(std::move(split_reads)) {}
+                                     const std::shared_ptr<MemoryPool>& memory_pool,
+                                     const std::shared_ptr<arrow::MemoryPool>& arrow_pool)
+    : TableRead(memory_pool, arrow_pool), split_reads_(std::move(split_reads)) {}
 
 Result<std::unique_ptr<TableRead>> KeyValueTableRead::Create(
     const std::shared_ptr<FileStorePathFactory>& path_factory,
     const std::shared_ptr<InternalReadContext>& context,
-    const std::shared_ptr<MemoryPool>& memory_pool, const std::shared_ptr<Executor>& executor) {
-    auto raw_file_split_read =
-        std::make_unique<RawFileSplitRead>(path_factory, context, memory_pool, executor);
+    const std::shared_ptr<MemoryPool>& memory_pool,
+    const std::shared_ptr<arrow::MemoryPool>& arrow_pool,
+    const std::shared_ptr<Executor>& executor) {
+    auto raw_file_split_read = std::make_unique<RawFileSplitRead>(
+        path_factory, context, memory_pool, arrow_pool, executor);
     std::vector<std::unique_ptr<SplitRead>> split_reads;
     split_reads.emplace_back(std::move(raw_file_split_read));
     PAIMON_ASSIGN_OR_RAISE(
         std::unique_ptr<MergeFileSplitRead> merge_file_split_read,
-        MergeFileSplitRead::Create(path_factory, context, memory_pool, executor));
+        MergeFileSplitRead::Create(path_factory, context, memory_pool, arrow_pool, executor));
     split_reads.emplace_back(std::move(merge_file_split_read));
 
-    return std::unique_ptr<TableRead>(new KeyValueTableRead(std::move(split_reads), memory_pool));
+    return std::unique_ptr<TableRead>(
+        new KeyValueTableRead(std::move(split_reads), memory_pool, arrow_pool));
 }
 
 Result<std::unique_ptr<BatchReader>> KeyValueTableRead::CreateReader(

--- a/src/paimon/core/table/source/key_value_table_read.h
+++ b/src/paimon/core/table/source/key_value_table_read.h
@@ -38,13 +38,16 @@ class KeyValueTableRead : public TableRead {
     static Result<std::unique_ptr<TableRead>> Create(
         const std::shared_ptr<FileStorePathFactory>& path_factory,
         const std::shared_ptr<InternalReadContext>& context,
-        const std::shared_ptr<MemoryPool>& memory_pool, const std::shared_ptr<Executor>& executor);
+        const std::shared_ptr<MemoryPool>& memory_pool,
+        const std::shared_ptr<arrow::MemoryPool>& arrow_pool,
+        const std::shared_ptr<Executor>& executor);
 
     Result<std::unique_ptr<BatchReader>> CreateReader(const std::shared_ptr<Split>& split) override;
 
  private:
     KeyValueTableRead(std::vector<std::unique_ptr<SplitRead>>&& split_reads,
-                      const std::shared_ptr<MemoryPool>& memory_pool);
+                      const std::shared_ptr<MemoryPool>& memory_pool,
+                      const std::shared_ptr<arrow::MemoryPool>& arrow_pool);
 
     std::vector<std::unique_ptr<SplitRead>> split_reads_;
     bool force_keep_delete_ = false;

--- a/src/paimon/core/table/source/table_read.cpp
+++ b/src/paimon/core/table/source/table_read.cpp
@@ -25,6 +25,7 @@
 #include "fmt/format.h"
 #include "paimon/common/reader/concat_batch_reader.h"
 #include "paimon/common/types/data_field.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/common/utils/string_utils.h"
 #include "paimon/core/core_options.h"
 #include "paimon/core/operation/internal_read_context.h"
@@ -82,7 +83,9 @@ Result<std::unique_ptr<InternalReadContext>> CreateInternalReadContext(
 
 Result<std::unique_ptr<TableRead>> CreateTableRead(
     const std::shared_ptr<InternalReadContext>& internal_context,
-    const std::shared_ptr<MemoryPool>& memory_pool, const std::shared_ptr<Executor>& executor) {
+    const std::shared_ptr<MemoryPool>& memory_pool,
+    const std::shared_ptr<arrow::MemoryPool>& arrow_pool,
+    const std::shared_ptr<Executor>& executor) {
     const auto& core_options = internal_context->GetCoreOptions();
     const auto& table_schema = internal_context->GetTableSchema();
     auto arrow_schema = DataField::ConvertDataFieldsToArrowSchema(table_schema->Fields());
@@ -102,13 +105,16 @@ Result<std::unique_ptr<TableRead>> CreateTableRead(
 
     if (internal_context->GetPrimaryKeys().empty()) {
         return std::make_unique<AppendOnlyTableRead>(path_factory, internal_context, memory_pool,
-                                                     executor);
+                                                     arrow_pool, executor);
     }
-    return KeyValueTableRead::Create(path_factory, internal_context, memory_pool, executor);
+    return KeyValueTableRead::Create(path_factory, internal_context, memory_pool, arrow_pool,
+                                     executor);
 }
 }  // namespace
 
-TableRead::TableRead(const std::shared_ptr<MemoryPool>& memory_pool) : pool_(memory_pool) {}
+TableRead::TableRead(const std::shared_ptr<MemoryPool>& memory_pool,
+                     const std::shared_ptr<arrow::MemoryPool>& arrow_pool)
+    : pool_(memory_pool), arrow_pool_(arrow_pool) {}
 
 Result<std::unique_ptr<TableRead>> TableRead::Create(std::unique_ptr<ReadContext> ctx) {
     std::shared_ptr<ReadContext> context = std::move(ctx);
@@ -122,13 +128,14 @@ Result<std::unique_ptr<TableRead>> TableRead::Create(std::unique_ptr<ReadContext
         return Status::Invalid("executor is null pointer");
     }
     auto memory_pool = context->GetMemoryPool();
+    std::shared_ptr<arrow::MemoryPool> arrow_pool = GetArrowPool(memory_pool);
     auto executor = context->GetExecutor();
 
     PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<InternalReadContext> internal_context,
                            CreateInternalReadContext(context, context->GetBranch()));
 
     PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<TableRead> table_read,
-                           CreateTableRead(internal_context, memory_pool, executor));
+                           CreateTableRead(internal_context, memory_pool, arrow_pool, executor));
 
     std::optional<std::string> scan_fallback_branch =
         internal_context->GetCoreOptions().GetScanFallbackBranch();
@@ -142,9 +149,9 @@ Result<std::unique_ptr<TableRead>> TableRead::Create(std::unique_ptr<ReadContext
         CreateInternalReadContext(context, /*branch=*/scan_fallback_branch.value()));
 
     PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<TableRead> fallback_table_read,
-                           CreateTableRead(fallback_context, memory_pool, executor));
-    return std::make_unique<FallbackTableRead>(std::move(table_read),
-                                               std::move(fallback_table_read), memory_pool);
+                           CreateTableRead(fallback_context, memory_pool, arrow_pool, executor));
+    return std::make_unique<FallbackTableRead>(
+        std::move(table_read), std::move(fallback_table_read), memory_pool, arrow_pool);
 }
 
 Result<std::unique_ptr<BatchReader>> TableRead::CreateReader(
@@ -155,7 +162,7 @@ Result<std::unique_ptr<BatchReader>> TableRead::CreateReader(
         PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<BatchReader> reader, CreateReader(split));
         batch_readers.emplace_back(std::move(reader));
     }
-    return std::make_unique<ConcatBatchReader>(std::move(batch_readers), pool_);
+    return std::make_unique<ConcatBatchReader>(std::move(batch_readers), arrow_pool_);
 }
 
 }  // namespace paimon

--- a/src/paimon/core/table/source/table_read_test.cpp
+++ b/src/paimon/core/table/source/table_read_test.cpp
@@ -21,16 +21,23 @@
 #include <utility>
 
 #include "gtest/gtest.h"
+#include "paimon/common/reader/complete_row_kind_batch_reader.h"
+#include "paimon/common/reader/concat_batch_reader.h"
 #include "paimon/core/core_options.h"
 #include "paimon/core/operation/abstract_split_read.h"
 #include "paimon/core/operation/split_read.h"
 #include "paimon/core/table/source/append_only_table_read.h"
+#include "paimon/core/table/source/fallback_table_read.h"
 #include "paimon/core/table/source/key_value_table_read.h"
 #include "paimon/defs.h"
+#include "paimon/memory/memory_pool.h"
 #include "paimon/predicate/literal.h"
 #include "paimon/predicate/predicate_builder.h"
 #include "paimon/read_context.h"
+#include "paimon/scan_context.h"
 #include "paimon/status.h"
+#include "paimon/table/source/plan.h"
+#include "paimon/table/source/table_scan.h"
 #include "paimon/testing/utils/testharness.h"
 
 namespace paimon::test {
@@ -129,6 +136,84 @@ TEST(TableReadTest, TestCreateAppendOnlyTableRead) {
     ASSERT_OK_AND_ASSIGN(auto table_read, TableRead::Create(std::move(read_context)));
     auto append_only_table_read = dynamic_cast<AppendOnlyTableRead*>(table_read.get());
     ASSERT_TRUE(append_only_table_read);
+}
+
+TEST(TableReadTest, TestArrowPoolScopedPerTableRead) {
+    const std::string path = test::GetDataDir() + "/orc/append_09.db/append_09";
+    auto paimon_pool = GetDefaultPool();
+
+    ReadContextBuilder first_builder(path);
+    first_builder.WithMemoryPool(paimon_pool);
+    ASSERT_OK_AND_ASSIGN(auto first_context, first_builder.Finish());
+    ASSERT_OK_AND_ASSIGN(auto first, TableRead::Create(std::move(first_context)));
+
+    ReadContextBuilder second_builder(path);
+    second_builder.WithMemoryPool(paimon_pool);
+    ASSERT_OK_AND_ASSIGN(auto second_context, second_builder.Finish());
+    ASSERT_OK_AND_ASSIGN(auto second, TableRead::Create(std::move(second_context)));
+
+    ASSERT_NE(nullptr, first->arrow_pool_);
+    ASSERT_NE(nullptr, second->arrow_pool_);
+    ASSERT_NE(first->arrow_pool_.get(), second->arrow_pool_.get());
+}
+
+TEST(TableReadTest, TestFallbackSharesArrowPool) {
+    const std::string path =
+        test::GetDataDir() + "/orc/append_table_with_rt_branch.db/append_table_with_rt_branch";
+    auto pool = GetDefaultPool();
+    ReadContextBuilder context_builder(path);
+    context_builder.WithMemoryPool(pool);
+    ASSERT_OK_AND_ASSIGN(auto read_context, context_builder.Finish());
+    ASSERT_OK_AND_ASSIGN(auto table_read, TableRead::Create(std::move(read_context)));
+
+    auto fallback_table_read = dynamic_cast<FallbackTableRead*>(table_read.get());
+    ASSERT_NE(nullptr, fallback_table_read);
+    ASSERT_NE(nullptr, fallback_table_read->arrow_pool_);
+    ASSERT_EQ(fallback_table_read->arrow_pool_.get(),
+              fallback_table_read->main_table_->arrow_pool_.get());
+    ASSERT_EQ(fallback_table_read->arrow_pool_.get(),
+              fallback_table_read->fallback_table_->arrow_pool_.get());
+}
+
+TEST(TableReadTest, TestBatchReadersShareArrowPoolAndCanOutliveTableRead) {
+    const std::string path = test::GetDataDir() + "/orc/append_09.db/append_09";
+    auto pool = GetDefaultPool();
+
+    ScanContextBuilder scan_context_builder(path);
+    scan_context_builder.WithMemoryPool(pool);
+    ASSERT_OK_AND_ASSIGN(auto scan_context, scan_context_builder.Finish());
+    ASSERT_OK_AND_ASSIGN(auto table_scan, TableScan::Create(std::move(scan_context)));
+    ASSERT_OK_AND_ASSIGN(auto plan, table_scan->CreatePlan());
+    ASSERT_FALSE(plan->Splits().empty());
+
+    ReadContextBuilder read_context_builder(path);
+    read_context_builder.WithMemoryPool(pool);
+    ASSERT_OK_AND_ASSIGN(auto read_context, read_context_builder.Finish());
+    ASSERT_OK_AND_ASSIGN(auto table_read, TableRead::Create(std::move(read_context)));
+    auto* table_arrow_pool = table_read->arrow_pool_.get();
+    ASSERT_NE(nullptr, table_arrow_pool);
+
+    std::vector<std::shared_ptr<Split>> single_split = {plan->Splits().front()};
+    ASSERT_OK_AND_ASSIGN(auto first_reader, table_read->CreateReader(single_split));
+    ASSERT_OK_AND_ASSIGN(auto second_reader, table_read->CreateReader(single_split));
+
+    auto* first_concat = dynamic_cast<ConcatBatchReader*>(first_reader.get());
+    auto* second_concat = dynamic_cast<ConcatBatchReader*>(second_reader.get());
+    ASSERT_NE(nullptr, first_concat);
+    ASSERT_NE(nullptr, second_concat);
+    ASSERT_EQ(table_arrow_pool, first_concat->arrow_pool_.get());
+    ASSERT_EQ(table_arrow_pool, second_concat->arrow_pool_.get());
+
+    ASSERT_EQ(1, first_concat->readers_.size());
+    auto* first_inner = dynamic_cast<CompleteRowKindBatchReader*>(first_concat->readers_[0].get());
+    ASSERT_NE(nullptr, first_inner);
+    ASSERT_EQ(table_arrow_pool, first_inner->arrow_pool_.get());
+
+    table_read.reset();
+    first_reader->Close();
+    second_reader->Close();
+    first_reader.reset();
+    second_reader.reset();
 }
 
 TEST(TableReadTest, TestMergeOptions) {

--- a/src/paimon/format/avro/avro_file_batch_reader.cpp
+++ b/src/paimon/format/avro/avro_file_batch_reader.cpp
@@ -36,11 +36,11 @@ AvroFileBatchReader::AvroFileBatchReader(const std::shared_ptr<InputStream>& inp
                                          const std::shared_ptr<::arrow::DataType>& file_data_type,
                                          std::unique_ptr<::avro::DataFileReaderBase>&& reader,
                                          std::unique_ptr<arrow::ArrayBuilder>&& array_builder,
-                                         std::unique_ptr<arrow::MemoryPool>&& arrow_pool,
+                                         const std::shared_ptr<arrow::MemoryPool>& arrow_pool,
                                          int32_t batch_size,
                                          const std::shared_ptr<MemoryPool>& pool)
     : pool_(pool),
-      arrow_pool_(std::move(arrow_pool)),
+      arrow_pool_(arrow_pool),
       input_stream_(input_stream),
       file_data_type_(file_data_type),
       reader_(std::move(reader)),
@@ -62,6 +62,13 @@ void AvroFileBatchReader::DoClose() {
 Result<std::unique_ptr<AvroFileBatchReader>> AvroFileBatchReader::Create(
     const std::shared_ptr<InputStream>& input_stream, int32_t batch_size,
     const std::shared_ptr<MemoryPool>& pool) {
+    std::shared_ptr<arrow::MemoryPool> arrow_pool = GetArrowPool(pool);
+    return Create(input_stream, batch_size, pool, arrow_pool);
+}
+
+Result<std::unique_ptr<AvroFileBatchReader>> AvroFileBatchReader::Create(
+    const std::shared_ptr<InputStream>& input_stream, int32_t batch_size,
+    const std::shared_ptr<MemoryPool>& pool, const std::shared_ptr<arrow::MemoryPool>& arrow_pool) {
     if (batch_size <= 0) {
         return Status::Invalid(
             fmt::format("invalid batch size {}, must be larger than 0", batch_size));
@@ -71,12 +78,11 @@ Result<std::unique_ptr<AvroFileBatchReader>> AvroFileBatchReader::Create(
     const auto& avro_file_schema = reader->dataSchema();
     PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<::arrow::DataType> file_data_type,
                            AvroSchemaConverter::AvroSchemaToArrowDataType(avro_file_schema));
-    auto arrow_pool = GetArrowPool(pool);
     PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::unique_ptr<arrow::ArrayBuilder> array_builder,
                                       arrow::MakeBuilder(file_data_type, arrow_pool.get()));
     return std::unique_ptr<AvroFileBatchReader>(
         new AvroFileBatchReader(input_stream, file_data_type, std::move(reader),
-                                std::move(array_builder), std::move(arrow_pool), batch_size, pool));
+                                std::move(array_builder), arrow_pool, batch_size, pool));
 }
 
 Result<std::unique_ptr<::avro::DataFileReaderBase>> AvroFileBatchReader::CreateDataFileReader(

--- a/src/paimon/format/avro/avro_file_batch_reader.h
+++ b/src/paimon/format/avro/avro_file_batch_reader.h
@@ -28,10 +28,18 @@
 #include "paimon/reader/file_batch_reader.h"
 #include "paimon/result.h"
 
+namespace arrow {
+class MemoryPool;
+}  // namespace arrow
+
 namespace paimon::avro {
 
 class AvroFileBatchReader : public FileBatchReader {
  public:
+    static Result<std::unique_ptr<AvroFileBatchReader>> Create(
+        const std::shared_ptr<InputStream>& input_stream, int32_t batch_size,
+        const std::shared_ptr<MemoryPool>& pool,
+        const std::shared_ptr<arrow::MemoryPool>& arrow_pool);
     static Result<std::unique_ptr<AvroFileBatchReader>> Create(
         const std::shared_ptr<InputStream>& input_stream, int32_t batch_size,
         const std::shared_ptr<MemoryPool>& pool);
@@ -76,13 +84,13 @@ class AvroFileBatchReader : public FileBatchReader {
                         const std::shared_ptr<::arrow::DataType>& file_data_type,
                         std::unique_ptr<::avro::DataFileReaderBase>&& reader,
                         std::unique_ptr<arrow::ArrayBuilder>&& array_builder,
-                        std::unique_ptr<arrow::MemoryPool>&& arrow_pool, int32_t batch_size,
+                        const std::shared_ptr<arrow::MemoryPool>& arrow_pool, int32_t batch_size,
                         const std::shared_ptr<MemoryPool>& pool);
 
     static constexpr size_t BUFFER_SIZE = 1024 * 1024;  // 1M
 
     std::shared_ptr<MemoryPool> pool_;
-    std::unique_ptr<arrow::MemoryPool> arrow_pool_;
+    std::shared_ptr<arrow::MemoryPool> arrow_pool_;
     std::shared_ptr<InputStream> input_stream_;
     std::shared_ptr<::arrow::DataType> file_data_type_;
     std::unique_ptr<::avro::DataFileReaderBase> reader_;

--- a/src/paimon/format/avro/avro_file_batch_reader_test.cpp
+++ b/src/paimon/format/avro/avro_file_batch_reader_test.cpp
@@ -24,6 +24,7 @@
 #include "arrow/c/bridge.h"
 #include "arrow/ipc/api.h"
 #include "gtest/gtest.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/common/utils/path_util.h"
 #include "paimon/core/manifest/manifest_file.h"
 #include "paimon/core/manifest/manifest_list.h"
@@ -113,6 +114,19 @@ TEST_F(AvroFileBatchReaderTest, TestReadDataWithNull) {
     ASSERT_TRUE(expected_array->Equals(result_array));
     auto read_metrics = reader_holder->GetReaderMetrics();
     ASSERT_TRUE(read_metrics);
+}
+
+TEST_F(AvroFileBatchReaderTest, TestReaderBuilderUsesInjectedArrowPool) {
+    std::string path = paimon::test::GetDataDir() + "/avro/data/avro_with_null";
+    std::shared_ptr<arrow::MemoryPool> arrow_pool = GetArrowPool(pool_);
+    ASSERT_OK_AND_ASSIGN(auto reader_builder, file_format_->CreateReaderBuilder(1024));
+    reader_builder->WithMemoryPool(pool_, arrow_pool);
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<InputStream> in, fs_->Open(path));
+    ASSERT_OK_AND_ASSIGN(auto reader, reader_builder->Build(in));
+
+    auto* avro_reader = dynamic_cast<AvroFileBatchReader*>(reader.get());
+    ASSERT_NE(nullptr, avro_reader);
+    ASSERT_EQ(arrow_pool.get(), avro_reader->arrow_pool_.get());
 }
 
 TEST_F(AvroFileBatchReaderTest, TestReadWithDifferentBatchSize) {

--- a/src/paimon/format/avro/avro_reader_builder.h
+++ b/src/paimon/format/avro/avro_reader_builder.h
@@ -22,6 +22,7 @@
 #include <utility>
 
 #include "avro/DataFile.hh"
+#include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/format/avro/avro_file_batch_reader.h"
 #include "paimon/format/avro/avro_input_stream_impl.h"
 #include "paimon/format/reader_builder.h"
@@ -37,12 +38,22 @@ class AvroReaderBuilder : public ReaderBuilder {
 
     ReaderBuilder* WithMemoryPool(const std::shared_ptr<MemoryPool>& pool) override {
         pool_ = pool;
+        arrow_pool_.reset();
+        return this;
+    }
+
+    ReaderBuilder* WithMemoryPool(const std::shared_ptr<MemoryPool>& pool,
+                                  const std::shared_ptr<arrow::MemoryPool>& arrow_pool) override {
+        pool_ = pool;
+        arrow_pool_ = arrow_pool;
         return this;
     }
 
     Result<std::unique_ptr<FileBatchReader>> Build(
         const std::shared_ptr<InputStream>& path) const override {
-        return AvroFileBatchReader::Create(path, batch_size_, pool_);
+        std::shared_ptr<arrow::MemoryPool> arrow_pool =
+            arrow_pool_ ? arrow_pool_ : std::shared_ptr<arrow::MemoryPool>(GetArrowPool(pool_));
+        return AvroFileBatchReader::Create(path, batch_size_, pool_, arrow_pool);
     }
 
     Result<std::unique_ptr<FileBatchReader>> Build(const std::string& path) const override {
@@ -52,6 +63,7 @@ class AvroReaderBuilder : public ReaderBuilder {
  private:
     const int32_t batch_size_;
     std::shared_ptr<MemoryPool> pool_;
+    std::shared_ptr<arrow::MemoryPool> arrow_pool_;
     const std::map<std::string, std::string> options_;
 };
 

--- a/src/paimon/format/blob/blob_file_batch_reader.cpp
+++ b/src/paimon/format/blob/blob_file_batch_reader.cpp
@@ -40,6 +40,13 @@ namespace paimon::blob {
 Result<std::unique_ptr<BlobFileBatchReader>> BlobFileBatchReader::Create(
     const std::shared_ptr<InputStream>& input_stream, int32_t batch_size, bool blob_as_descriptor,
     const std::shared_ptr<MemoryPool>& pool) {
+    std::shared_ptr<arrow::MemoryPool> arrow_pool = GetArrowPool(pool);
+    return Create(input_stream, batch_size, blob_as_descriptor, pool, arrow_pool);
+}
+
+Result<std::unique_ptr<BlobFileBatchReader>> BlobFileBatchReader::Create(
+    const std::shared_ptr<InputStream>& input_stream, int32_t batch_size, bool blob_as_descriptor,
+    const std::shared_ptr<MemoryPool>& pool, const std::shared_ptr<arrow::MemoryPool>& arrow_pool) {
     if (input_stream == nullptr) {
         return Status::Invalid("blob file batch reader create failed: input stream is nullptr");
     }
@@ -85,8 +92,9 @@ Result<std::unique_ptr<BlobFileBatchReader>> BlobFileBatchReader::Create(
         offset += blob_length;
     }
     PAIMON_ASSIGN_OR_RAISE(std::string file_path, input_stream->GetUri());
-    auto reader = std::unique_ptr<BlobFileBatchReader>(new BlobFileBatchReader(
-        input_stream, file_path, blob_lengths, blob_offsets, batch_size, blob_as_descriptor, pool));
+    auto reader = std::unique_ptr<BlobFileBatchReader>(
+        new BlobFileBatchReader(input_stream, file_path, blob_lengths, blob_offsets, batch_size,
+                                blob_as_descriptor, pool, arrow_pool));
     return reader;
 }
 
@@ -95,7 +103,8 @@ BlobFileBatchReader::BlobFileBatchReader(const std::shared_ptr<InputStream>& inp
                                          const std::vector<int64_t>& blob_lengths,
                                          const std::vector<int64_t>& blob_offsets,
                                          int32_t batch_size, bool blob_as_descriptor,
-                                         const std::shared_ptr<MemoryPool>& pool)
+                                         const std::shared_ptr<MemoryPool>& pool,
+                                         const std::shared_ptr<arrow::MemoryPool>& arrow_pool)
     : input_stream_(input_stream),
       file_path_(file_path),
       all_blob_lengths_(blob_lengths),
@@ -105,7 +114,7 @@ BlobFileBatchReader::BlobFileBatchReader(const std::shared_ptr<InputStream>& inp
       batch_size_(batch_size),
       blob_as_descriptor_(blob_as_descriptor),
       pool_(pool),
-      arrow_pool_(GetArrowPool(pool_)),
+      arrow_pool_(arrow_pool),
       metrics_(std::make_shared<MetricsImpl>()) {
     target_blob_row_indexes_.resize(target_blob_lengths_.size());
     std::iota(target_blob_row_indexes_.begin(), target_blob_row_indexes_.end(), 0);

--- a/src/paimon/format/blob/blob_file_batch_reader.h
+++ b/src/paimon/format/blob/blob_file_batch_reader.h
@@ -89,6 +89,10 @@ class BlobFileBatchReader : public FileBatchReader {
 
     static Result<std::unique_ptr<BlobFileBatchReader>> Create(
         const std::shared_ptr<InputStream>& input_stream, int32_t batch_size,
+        bool blob_as_descriptor, const std::shared_ptr<MemoryPool>& pool,
+        const std::shared_ptr<arrow::MemoryPool>& arrow_pool);
+    static Result<std::unique_ptr<BlobFileBatchReader>> Create(
+        const std::shared_ptr<InputStream>& input_stream, int32_t batch_size,
         bool blob_as_descriptor, const std::shared_ptr<MemoryPool>& pool);
 
     Result<std::unique_ptr<::ArrowSchema>> GetFileSchema() const override;
@@ -134,7 +138,8 @@ class BlobFileBatchReader : public FileBatchReader {
     BlobFileBatchReader(const std::shared_ptr<InputStream>& input_stream,
                         const std::string& file_path, const std::vector<int64_t>& blob_lengths,
                         const std::vector<int64_t>& blob_offsets, int32_t batch_size,
-                        bool blob_as_descriptor, const std::shared_ptr<MemoryPool>& pool);
+                        bool blob_as_descriptor, const std::shared_ptr<MemoryPool>& pool,
+                        const std::shared_ptr<arrow::MemoryPool>& arrow_pool);
 
     Result<std::shared_ptr<arrow::Array>> ToArrowArray(
         const std::vector<PAIMON_UNIQUE_PTR<Bytes>>& blobs) const;

--- a/src/paimon/format/blob/blob_file_batch_reader_test.cpp
+++ b/src/paimon/format/blob/blob_file_batch_reader_test.cpp
@@ -20,8 +20,10 @@
 #include "arrow/c/helpers.h"
 #include "gtest/gtest.h"
 #include "paimon/common/data/blob_utils.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/data/blob.h"
 #include "paimon/format/blob/blob_format_writer.h"
+#include "paimon/format/blob/blob_reader_builder.h"
 #include "paimon/fs/local/local_file_system.h"
 #include "paimon/memory/memory_pool.h"
 #include "paimon/testing/utils/read_result_collector.h"
@@ -146,6 +148,28 @@ TEST_P(BlobFileBatchReaderTest, TestPushdownBitmap) {
     RoaringBitmap32 roaring_3;
     CheckResult(table_path, "data-d7816e8e-6c6d-4e28-9137-837cdf706350-4.blob", {},
                 blob_as_descriptor, roaring_3);
+}
+
+TEST_F(BlobFileBatchReaderTest, TestReaderBuilderUsesInjectedArrowPool) {
+    auto dir = paimon::test::UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+    std::string test_data_path = paimon::test::GetDataDir() + "/db_with_blob.db/table_with_blob/";
+    std::string table_path = dir->Str();
+    ASSERT_TRUE(paimon::test::TestUtil::CopyDirectory(test_data_path, table_path));
+
+    std::shared_ptr<arrow::MemoryPool> arrow_pool = GetArrowPool(pool_);
+    std::shared_ptr<FileSystem> fs = std::make_shared<LocalFileSystem>();
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<InputStream> input_stream,
+        fs->Open(table_path + "/bucket-0/data-d7816e8e-6c6d-4e28-9137-837cdf706350-1.blob"));
+
+    BlobReaderBuilder builder(/*batch_size=*/1024, /*options=*/{});
+    builder.WithMemoryPool(pool_, arrow_pool);
+    ASSERT_OK_AND_ASSIGN(auto reader, builder.Build(input_stream));
+
+    auto* blob_reader = dynamic_cast<BlobFileBatchReader*>(reader.get());
+    ASSERT_NE(nullptr, blob_reader);
+    ASSERT_EQ(arrow_pool.get(), blob_reader->arrow_pool_.get());
 }
 
 TEST_F(BlobFileBatchReaderTest, TestRowNumbers) {

--- a/src/paimon/format/blob/blob_reader_builder.h
+++ b/src/paimon/format/blob/blob_reader_builder.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <string>
 
+#include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/common/utils/options_utils.h"
 #include "paimon/format/blob/blob_file_batch_reader.h"
 #include "paimon/format/reader_builder.h"
@@ -35,6 +36,14 @@ class BlobReaderBuilder : public ReaderBuilder {
 
     ReaderBuilder* WithMemoryPool(const std::shared_ptr<MemoryPool>& pool) override {
         pool_ = pool;
+        arrow_pool_.reset();
+        return this;
+    }
+
+    ReaderBuilder* WithMemoryPool(const std::shared_ptr<MemoryPool>& pool,
+                                  const std::shared_ptr<arrow::MemoryPool>& arrow_pool) override {
+        pool_ = pool;
+        arrow_pool_ = arrow_pool;
         return this;
     }
 
@@ -43,7 +52,10 @@ class BlobReaderBuilder : public ReaderBuilder {
         PAIMON_ASSIGN_OR_RAISE(
             bool blob_as_descriptor,
             OptionsUtils::GetValueFromMap<bool>(options_, Options::BLOB_AS_DESCRIPTOR, false));
-        return BlobFileBatchReader::Create(input_stream, batch_size_, blob_as_descriptor, pool_);
+        std::shared_ptr<arrow::MemoryPool> arrow_pool =
+            arrow_pool_ ? arrow_pool_ : std::shared_ptr<arrow::MemoryPool>(GetArrowPool(pool_));
+        return BlobFileBatchReader::Create(input_stream, batch_size_, blob_as_descriptor, pool_,
+                                           arrow_pool);
     }
 
     Result<std::unique_ptr<FileBatchReader>> Build(const std::string& path) const override {
@@ -53,6 +65,7 @@ class BlobReaderBuilder : public ReaderBuilder {
  private:
     int32_t batch_size_;
     std::shared_ptr<MemoryPool> pool_;
+    std::shared_ptr<arrow::MemoryPool> arrow_pool_;
     std::map<std::string, std::string> options_;
 };
 

--- a/src/paimon/format/orc/orc_file_batch_reader.cpp
+++ b/src/paimon/format/orc/orc_file_batch_reader.cpp
@@ -56,6 +56,14 @@ OrcFileBatchReader::OrcFileBatchReader(std::unique_ptr<::orc::ReaderMetrics>&& r
 Result<std::unique_ptr<OrcFileBatchReader>> OrcFileBatchReader::Create(
     std::unique_ptr<::orc::InputStream>&& input_stream, const std::shared_ptr<MemoryPool>& pool,
     const std::map<std::string, std::string>& options, int32_t batch_size) {
+    std::shared_ptr<arrow::MemoryPool> arrow_pool = GetArrowPool(pool);
+    return Create(std::move(input_stream), pool, arrow_pool, options, batch_size);
+}
+
+Result<std::unique_ptr<OrcFileBatchReader>> OrcFileBatchReader::Create(
+    std::unique_ptr<::orc::InputStream>&& input_stream, const std::shared_ptr<MemoryPool>& pool,
+    const std::shared_ptr<arrow::MemoryPool>& arrow_pool,
+    const std::map<std::string, std::string>& options, int32_t batch_size) {
     assert(input_stream);
     std::string file_name = input_stream->getName();
     try {
@@ -65,7 +73,6 @@ Result<std::unique_ptr<OrcFileBatchReader>> OrcFileBatchReader::Create(
         }
         uint64_t natural_read_size = input_stream->getNaturalReadSize();
         auto orc_pool = std::make_shared<OrcMemoryPool>(pool);
-        std::shared_ptr<arrow::MemoryPool> arrow_pool = GetArrowPool(pool);
         reader_options.setMemoryPool(*orc_pool);
 
         std::unique_ptr<::orc::ReaderMetrics> reader_metrics;

--- a/src/paimon/format/orc/orc_file_batch_reader.h
+++ b/src/paimon/format/orc/orc_file_batch_reader.h
@@ -44,6 +44,10 @@ class OrcFileBatchReader : public PrefetchFileBatchReader {
     ~OrcFileBatchReader() override = default;
     static Result<std::unique_ptr<OrcFileBatchReader>> Create(
         std::unique_ptr<::orc::InputStream>&& input_stream, const std::shared_ptr<MemoryPool>& pool,
+        const std::shared_ptr<arrow::MemoryPool>& arrow_pool,
+        const std::map<std::string, std::string>& options, int32_t batch_size);
+    static Result<std::unique_ptr<OrcFileBatchReader>> Create(
+        std::unique_ptr<::orc::InputStream>&& input_stream, const std::shared_ptr<MemoryPool>& pool,
         const std::map<std::string, std::string>& options, int32_t batch_size);
 
     // For timestamp type, precision info is missing from file
@@ -58,8 +62,8 @@ class OrcFileBatchReader : public PrefetchFileBatchReader {
         return reader_->SetReadRanges(read_ranges);
     }
 
-    // Important: output ArrowArray is allocated on arrow_pool_ whose lifecycle holds in
-    // OrcFileBatchReader. Therefore, we need to hold BatchReader when using output ArrowArray.
+    // Output ArrowArray buffers use arrow_pool_. The caller must keep a related reader from the
+    // TableRead reader chain alive while using the returned ArrowArray.
     Result<ReadBatch> NextBatch() override;
 
     Result<uint64_t> GetPreviousBatchFirstRowNumber() const override {

--- a/src/paimon/format/orc/orc_file_batch_reader_test.cpp
+++ b/src/paimon/format/orc/orc_file_batch_reader_test.cpp
@@ -27,6 +27,7 @@
 #include "arrow/ipc/api.h"
 #include "gtest/gtest.h"
 #include "paimon/common/types/data_field.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/defs.h"
 #include "paimon/format/orc/orc_adapter.h"
 #include "paimon/format/orc/orc_format_defs.h"
@@ -35,6 +36,7 @@
 #include "paimon/format/orc/orc_memory_pool.h"
 #include "paimon/format/orc/orc_metrics.h"
 #include "paimon/format/orc/orc_output_stream_impl.h"
+#include "paimon/format/orc/orc_reader_builder.h"
 #include "paimon/fs/local/local_file_system.h"
 #include "paimon/predicate/predicate_builder.h"
 #include "paimon/testing/utils/read_result_collector.h"
@@ -246,6 +248,23 @@ TEST_F(OrcFileBatchReaderTest, TestSetReadSchema) {
     ASSERT_OK_AND_ASSIGN(result_with_read_schema,
                          paimon::test::ReadResultCollector::CollectResult(orc_batch_reader.get()));
     ASSERT_FALSE(result_with_read_schema);
+}
+
+TEST_F(OrcFileBatchReaderTest, TestReaderBuilderUsesInjectedArrowPool) {
+    std::string file_name = paimon::test::GetDataDir() +
+                            "/orc/append_09.db/append_09/f1=10/bucket-1/"
+                            "data-b9e7c41f-66e8-4dad-b25a-e6e1963becc4-0.orc";
+    auto arrow_pool = GetArrowPool(pool_);
+    std::shared_ptr<FileSystem> file_system = std::make_shared<LocalFileSystem>();
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<InputStream> input_stream, file_system->Open(file_name));
+
+    OrcReaderBuilder builder(/*options=*/{}, batch_size_);
+    builder.WithMemoryPool(pool_, arrow_pool);
+    ASSERT_OK_AND_ASSIGN(auto reader, builder.Build(input_stream));
+
+    auto* orc_reader = dynamic_cast<OrcFileBatchReader*>(reader.get());
+    ASSERT_NE(nullptr, orc_reader);
+    ASSERT_EQ(arrow_pool.get(), orc_reader->arrow_pool_.get());
 }
 
 TEST_F(OrcFileBatchReaderTest, TestCreateRowReaderOptions) {

--- a/src/paimon/format/orc/orc_reader_builder.h
+++ b/src/paimon/format/orc/orc_reader_builder.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <utility>
 
+#include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/common/utils/options_utils.h"
 #include "paimon/format/orc/orc_file_batch_reader.h"
 #include "paimon/format/orc/orc_format_defs.h"
@@ -35,6 +36,14 @@ class OrcReaderBuilder : public ReaderBuilder {
 
     ReaderBuilder* WithMemoryPool(const std::shared_ptr<MemoryPool>& pool) override {
         pool_ = pool;
+        arrow_pool_.reset();
+        return this;
+    }
+
+    ReaderBuilder* WithMemoryPool(const std::shared_ptr<MemoryPool>& pool,
+                                  const std::shared_ptr<arrow::MemoryPool>& arrow_pool) override {
+        pool_ = pool;
+        arrow_pool_ = arrow_pool;
         return this;
     }
 
@@ -49,7 +58,10 @@ class OrcReaderBuilder : public ReaderBuilder {
 
         PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<OrcInputStreamImpl> input_stream,
                                OrcInputStreamImpl::Create(path, natural_read_size));
-        return OrcFileBatchReader::Create(std::move(input_stream), pool_, options_, batch_size_);
+        std::shared_ptr<arrow::MemoryPool> arrow_pool =
+            arrow_pool_ ? arrow_pool_ : std::shared_ptr<arrow::MemoryPool>(GetArrowPool(pool_));
+        return OrcFileBatchReader::Create(std::move(input_stream), pool_, arrow_pool, options_,
+                                          batch_size_);
     }
 
     Result<std::unique_ptr<FileBatchReader>> Build(const std::string& path) const override {
@@ -59,6 +71,7 @@ class OrcReaderBuilder : public ReaderBuilder {
  private:
     int32_t batch_size_ = -1;
     std::shared_ptr<MemoryPool> pool_;
+    std::shared_ptr<arrow::MemoryPool> arrow_pool_;
     std::map<std::string, std::string> options_;
 };
 }  // namespace paimon::orc

--- a/src/paimon/format/parquet/parquet_file_batch_reader.h
+++ b/src/paimon/format/parquet/parquet_file_batch_reader.h
@@ -76,9 +76,8 @@ class ParquetFileBatchReader : public PrefetchFileBatchReader {
         return reader_->SeekToRow(row_number);
     }
 
-    // Important: output ArrowArray is allocated on arrow_pool_ whose lifecycle holds in
-    // ParquetFileBatchReader. Therefore, we need to hold BatchReader when using output
-    // ArrowArray.
+    // Output ArrowArray buffers use arrow_pool_. The caller must keep a related reader from the
+    // TableRead reader chain alive while using the returned ArrowArray.
     Result<ReadBatch> NextBatch() override;
 
     Result<std::vector<std::pair<uint64_t, uint64_t>>> GenReadRanges(

--- a/src/paimon/format/parquet/parquet_file_batch_reader_test.cpp
+++ b/src/paimon/format/parquet/parquet_file_batch_reader_test.cpp
@@ -38,6 +38,7 @@
 #include "paimon/defs.h"
 #include "paimon/format/parquet/parquet_format_defs.h"
 #include "paimon/format/parquet/parquet_format_writer.h"
+#include "paimon/format/parquet/parquet_reader_builder.h"
 #include "paimon/fs/file_system.h"
 #include "paimon/fs/local/local_file_system.h"
 #include "paimon/global_config.h"
@@ -175,6 +176,23 @@ TEST_F(ParquetFileBatchReaderTest, TestSimple) {
         std::make_shared<arrow::ChunkedArray>(struct_array_);
     ASSERT_TRUE(result_array->Equals(*expected_array,
                                      arrow::EqualOptions::Defaults().diff_sink(&std::cout)));
+}
+
+TEST_F(ParquetFileBatchReaderTest, TestReaderBuilderUsesInjectedArrowPool) {
+    std::string file_name = paimon::test::GetDataDir() +
+                            "/parquet/parquet_append_table.db/parquet_append_table/bucket-0/"
+                            "data-9ea62f34-1dca-49c1-bf7a-d37303d8fb76-0.parquet";
+    auto paimon_pool = GetDefaultPool();
+    std::shared_ptr<arrow::MemoryPool> arrow_pool = GetArrowPool(paimon_pool);
+
+    ParquetReaderBuilder builder(/*options=*/{}, batch_size_);
+    builder.WithMemoryPool(paimon_pool, arrow_pool);
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<InputStream> input_stream, fs_->Open(file_name));
+    ASSERT_OK_AND_ASSIGN(auto reader, builder.Build(input_stream));
+
+    auto* parquet_reader = dynamic_cast<ParquetFileBatchReader*>(reader.get());
+    ASSERT_NE(nullptr, parquet_reader);
+    ASSERT_EQ(arrow_pool.get(), parquet_reader->arrow_pool_.get());
 }
 
 TEST_F(ParquetFileBatchReaderTest, TestSetReadSchema) {

--- a/src/paimon/format/parquet/parquet_reader_builder.h
+++ b/src/paimon/format/parquet/parquet_reader_builder.h
@@ -38,13 +38,22 @@ class ParquetReaderBuilder : public ReaderBuilder {
 
     ReaderBuilder* WithMemoryPool(const std::shared_ptr<MemoryPool>& pool) override {
         pool_ = pool;
+        arrow_pool_.reset();
+        return this;
+    }
+
+    ReaderBuilder* WithMemoryPool(const std::shared_ptr<MemoryPool>& pool,
+                                  const std::shared_ptr<arrow::MemoryPool>& arrow_pool) override {
+        pool_ = pool;
+        arrow_pool_ = arrow_pool;
         return this;
     }
 
     Result<std::unique_ptr<FileBatchReader>> Build(
         const std::shared_ptr<InputStream>& path) const override {
         PAIMON_ASSIGN_OR_RAISE(uint64_t file_length, path->Length());
-        std::shared_ptr<arrow::MemoryPool> arrow_pool = GetArrowPool(pool_);
+        std::shared_ptr<arrow::MemoryPool> arrow_pool =
+            arrow_pool_ ? arrow_pool_ : std::shared_ptr<arrow::MemoryPool>(GetArrowPool(pool_));
         auto input_stream =
             std::make_unique<ArrowInputStreamAdapter>(path, arrow_pool, file_length);
         return ParquetFileBatchReader::Create(std::move(input_stream), arrow_pool, options_,
@@ -58,6 +67,7 @@ class ParquetReaderBuilder : public ReaderBuilder {
  private:
     int32_t batch_size_ = -1;
     std::shared_ptr<MemoryPool> pool_;
+    std::shared_ptr<arrow::MemoryPool> arrow_pool_;
     std::map<std::string, std::string> options_;
 };
 

--- a/test/inte/read_inte_test.cpp
+++ b/test/inte/read_inte_test.cpp
@@ -27,6 +27,7 @@
 #include "arrow/api.h"
 #include "arrow/array/array_base.h"
 #include "arrow/c/abi.h"
+#include "arrow/c/helpers.h"
 #include "arrow/ipc/json_simple.h"
 #include "gtest/gtest.h"
 #include "paimon/common/data/binary_row.h"
@@ -385,6 +386,49 @@ TEST_P(ReadInteTest, TestReadWithLimits) {
                              read_metrics->GetCounter("orc.read.inclusive.latency.us"));
         ASSERT_GT(latency, 0);
     }
+}
+
+TEST_P(ReadInteTest, TestArrowArrayCanBeReleasedAfterBatchReaderDestroyed) {
+    auto param = GetParam();
+    std::string path =
+        paimon::test::GetDataDir() + "/" + param.file_format + "/append_09.db/append_09";
+    ReadContextBuilder context_builder(path);
+    context_builder.AddOption(Options::FILE_FORMAT, param.file_format)
+        .AddOption(Options::READ_BATCH_SIZE, "1");
+    context_builder.EnablePrefetch(param.enable_prefetch)
+        .SetPrefetchCacheMode(param.cache_mode)
+        .AddOption("test.enable-adaptive-prefetch-strategy",
+                   param.enable_adaptive_prefetch_strategy);
+
+    ASSERT_OK_AND_ASSIGN(auto read_context, context_builder.Finish());
+    ASSERT_OK_AND_ASSIGN(auto table_read, TableRead::Create(std::move(read_context)));
+
+    std::vector<std::string> file_list;
+    if (param.file_format == "orc") {
+        file_list = {"data-db2b44c0-0d73-449d-82a0-4075bd2cb6e3-0.orc",
+                     "data-b913a160-a4d1-4084-af2a-18333c35668e-0.orc"};
+    } else if (param.file_format == "parquet") {
+        file_list = {"data-b446f78a-2cfb-4b3b-add8-31295d24a277-0.parquet",
+                     "data-fd72a479-53ae-42f7-aec0-e982ee555928-0.parquet"};
+    }
+
+    DataSplitsSimple input_data_splits = {{paimon::test::GetDataDir() + "/" + param.file_format +
+                                               "/append_09.db/append_09/f1=20/"
+                                               "bucket-0",
+                                           BinaryRowGenerator::GenerateRow({20}, pool_.get()),
+                                           file_list}};
+
+    auto data_splits = CreateDataSplits(input_data_splits, /*snapshot_id=*/3);
+    ASSERT_EQ(data_splits.size(), 1);
+    ASSERT_OK_AND_ASSIGN(auto batch_reader, table_read->CreateReader(data_splits));
+    ASSERT_OK_AND_ASSIGN(BatchReader::ReadBatch batch, batch_reader->NextBatch());
+    ASSERT_FALSE(BatchReader::IsEofBatch(batch));
+
+    batch_reader->Close();
+    batch_reader.reset();
+
+    ArrowArrayRelease(batch.first.get());
+    ArrowSchemaRelease(batch.second.get());
 }
 
 TEST_P(ReadInteTest, TestReadOnlyPartitionField) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #126

<!-- What is the purpose of the change -->
This PR fixes a lifetime issue where batches returned by `BatchReader::NextBatch()` may still hold Arrow buffers referencing the Arrow memory pool adaptor owned by the reader.

Before this change, if the caller kept the returned `ArrowArray` / `ArrowSchema`, then closed and destroyed the `BatchReader`, releasing the returned Arrow C Data objects later could access a dangling pool/adaptor pointer and crash.

This change binds the Arrow memory pool adaptor lifetime to the `TableRead` read session, and lets readers share that pool lifetime. The intended guarantee is scoped:

- returned arrays may outlive the individual `BatchReader`;
- returned arrays are not guaranteed to outlive the owning `TableRead`.

### Tests

<!-- List UT and IT cases to verify this change -->
Added regression test:

```cpp
ReadInteTest.TestArrowArrayCanBeReleasedAfterBatchReaderDestroyed

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->
This changes internal reader/memory-pool lifetime management.
It does not change storage format or protocol.
It touches reader construction APIs internally so that a shared Arrow memory pool can be passed through the TableRead session.

### Documentation

<!-- Does this change introduce a new feature -->
Added design/implementation notes documenting the TableRead Arrow memory pool lifetime model.

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: OpenAI Codex
