### PR TITLE
fix(testing): address review issues

### DIFF
--- a/include/paimon/memory/memory_pool.h
+++ b/include/paimon/memory/memory_pool.h
@@ -55,7 +55,8 @@ class PAIMON_EXPORT MemoryPool {
     ///
     /// @param size Number of bytes to allocate.
     /// @param alignment Memory alignment requirement (0 for default alignment).
-    /// @return Pointer to allocated memory, or nullptr on failure.
+    /// @return Pointer to allocated memory.
+    /// @throws std::bad_alloc if the allocation fails.
     virtual void* Malloc(uint64_t size, uint64_t alignment = 0) = 0;
 
     /// Reallocate memory to a new size.

--- a/src/paimon/common/reader/prefetch_file_batch_reader_impl_test.cpp
+++ b/src/paimon/common/reader/prefetch_file_batch_reader_impl_test.cpp
@@ -17,6 +17,7 @@
 #include "paimon/common/reader/prefetch_file_batch_reader_impl.h"
 
 #include <atomic>
+#include <limits>
 #include <set>
 
 #include "arrow/compute/api.h"
@@ -283,7 +284,8 @@ TEST_F(PrefetchFileBatchReaderImplTest, TestSimple) {
                 /*enable_adaptive_prefetch_strategy=*/false, executor_,
                 /*initialize_read_ranges=*/true, /*prefetch_cache_mode=*/PrefetchCacheMode::ALWAYS,
                 CacheConfig(), GetDefaultPool()));
-        ASSERT_EQ(reader->GetPreviousBatchFirstRowNumber().value(), -1);
+        ASSERT_EQ(std::numeric_limits<uint64_t>::max(),
+                  reader->GetPreviousBatchFirstRowNumber().value());
         ASSERT_OK_AND_ASSIGN(auto result_array,
                              ReadResultCollector::CollectResult(
                                  reader.get(), /*max simulated data processing time*/ 100));
@@ -605,7 +607,8 @@ TEST_F(PrefetchFileBatchReaderImplTest, TestReadWithLargeBatchSize) {
             prefetch_max_parallel_num * 2, /*enable_adaptive_prefetch_strategy=*/false, executor_,
             /*initialize_read_ranges=*/true, /*prefetch_cache_mode=*/PrefetchCacheMode::ALWAYS,
             CacheConfig(), GetDefaultPool()));
-    ASSERT_EQ(reader->GetPreviousBatchFirstRowNumber().value(), -1);
+    ASSERT_EQ(std::numeric_limits<uint64_t>::max(),
+              reader->GetPreviousBatchFirstRowNumber().value());
     ASSERT_OK_AND_ASSIGN(auto result_array,
                          ReadResultCollector::CollectResult(
                              reader.get(), /*max simulated data processing time*/ 100));
@@ -633,7 +636,8 @@ TEST_F(PrefetchFileBatchReaderImplTest, TestPartialReaderSuccessRead) {
     }
 
     arrow::ArrayVector result_array_vector;
-    ASSERT_EQ(reader->GetPreviousBatchFirstRowNumber().value(), -1);
+    ASSERT_EQ(std::numeric_limits<uint64_t>::max(),
+              reader->GetPreviousBatchFirstRowNumber().value());
     ASSERT_OK_AND_ASSIGN(auto batch_with_bitmap, reader->NextBatchWithBitmap());
     auto& [batch, bitmap] = batch_with_bitmap;
     ASSERT_EQ(batch.first->length, bitmap.Cardinality());
@@ -678,9 +682,11 @@ TEST_F(PrefetchFileBatchReaderImplTest, TestAllReaderFailedWithIOError) {
             ->SetNextBatchStatus(Status::IOError("mock error"));
     }
 
-    ASSERT_EQ(reader->GetPreviousBatchFirstRowNumber().value(), -1);
+    ASSERT_EQ(std::numeric_limits<uint64_t>::max(),
+              reader->GetPreviousBatchFirstRowNumber().value());
     auto batch_result = reader->NextBatchWithBitmap();
-    ASSERT_EQ(reader->GetPreviousBatchFirstRowNumber().value(), -1);
+    ASSERT_EQ(std::numeric_limits<uint64_t>::max(),
+              reader->GetPreviousBatchFirstRowNumber().value());
     ASSERT_FALSE(batch_result.ok());
     ASSERT_TRUE(batch_result.status().IsIOError());
     ASSERT_FALSE(prefetch_reader->is_shutdown_);
@@ -689,7 +695,8 @@ TEST_F(PrefetchFileBatchReaderImplTest, TestAllReaderFailedWithIOError) {
 
     // call NextBatch again, will still return error status
     auto batch_result2 = reader->NextBatchWithBitmap();
-    ASSERT_EQ(reader->GetPreviousBatchFirstRowNumber().value(), -1);
+    ASSERT_EQ(std::numeric_limits<uint64_t>::max(),
+              reader->GetPreviousBatchFirstRowNumber().value());
     ASSERT_FALSE(batch_result2.ok());
     ASSERT_TRUE(batch_result2.status().IsIOError());
 }
@@ -706,7 +713,8 @@ TEST_F(PrefetchFileBatchReaderImplTest, TestPrefetchWithEmptyData) {
             prefetch_max_parallel_num * 2, /*enable_adaptive_prefetch_strategy=*/false, executor_,
             /*initialize_read_ranges=*/true, /*prefetch_cache_mode=*/PrefetchCacheMode::ALWAYS,
             CacheConfig(), GetDefaultPool()));
-    ASSERT_EQ(reader->GetPreviousBatchFirstRowNumber().value(), -1);
+    ASSERT_EQ(std::numeric_limits<uint64_t>::max(),
+              reader->GetPreviousBatchFirstRowNumber().value());
     ASSERT_OK_AND_ASSIGN(auto result_array,
                          ReadResultCollector::CollectResult(
                              reader.get(), /*max simulated data processing time*/ 100));
@@ -726,7 +734,8 @@ TEST_F(PrefetchFileBatchReaderImplTest, TestCallNextBatchAfterReadingEof) {
             prefetch_max_parallel_num * 2, /*enable_adaptive_prefetch_strategy=*/false, executor_,
             /*initialize_read_ranges=*/true, /*prefetch_cache_mode=*/PrefetchCacheMode::ALWAYS,
             CacheConfig(), GetDefaultPool()));
-    ASSERT_EQ(reader->GetPreviousBatchFirstRowNumber().value(), -1);
+    ASSERT_EQ(std::numeric_limits<uint64_t>::max(),
+              reader->GetPreviousBatchFirstRowNumber().value());
     ASSERT_OK_AND_ASSIGN(auto result_array,
                          ReadResultCollector::CollectResult(
                              reader.get(), /*max simulated data processing time*/ 100));
@@ -832,7 +841,8 @@ TEST_P(PrefetchFileBatchReaderImplTest, TestPrefetchWithPredicatePushdownWithCom
         PreparePrefetchReader(file_format, schema.get(), predicate,
                               /*selection_bitmap=*/std::nullopt,
                               /*batch_size=*/10, /*prefetch_max_parallel_num=*/3, cache_mode);
-    ASSERT_EQ(reader->GetPreviousBatchFirstRowNumber().value(), -1);
+    ASSERT_EQ(std::numeric_limits<uint64_t>::max(),
+              reader->GetPreviousBatchFirstRowNumber().value());
     ASSERT_OK_AND_ASSIGN(auto result_array,
                          ReadResultCollector::CollectResult(
                              reader.get(), /*max simulated data processing time*/ 100));
@@ -868,7 +878,8 @@ TEST_P(PrefetchFileBatchReaderImplTest,
                               /*selection_bitmap=*/std::nullopt,
                               /*batch_size=*/10, /*prefetch_max_parallel_num=*/3, cache_mode);
     ASSERT_OK(reader->RefreshReadRanges());
-    ASSERT_EQ(reader->GetPreviousBatchFirstRowNumber().value(), -1);
+    ASSERT_EQ(std::numeric_limits<uint64_t>::max(),
+              reader->GetPreviousBatchFirstRowNumber().value());
     ASSERT_OK_AND_ASSIGN(auto result_array,
                          ReadResultCollector::CollectResult(
                              reader.get(), /*max simulated data processing time*/ 100));

--- a/src/paimon/common/utils/arrow/arrow_utils.cpp
+++ b/src/paimon/common/utils/arrow/arrow_utils.cpp
@@ -19,6 +19,7 @@
 #include "arrow/array/array_base.h"
 #include "arrow/array/array_nested.h"
 #include "arrow/util/compression.h"
+#include "fmt/format.h"
 #include "paimon/common/utils/arrow/status_utils.h"
 #include "paimon/common/utils/string_utils.h"
 

--- a/src/paimon/common/utils/arrow/arrow_utils.h
+++ b/src/paimon/common/utils/arrow/arrow_utils.h
@@ -20,7 +20,6 @@
 
 #include "arrow/api.h"
 #include "arrow/util/type_fwd.h"
-#include "fmt/format.h"
 #include "paimon/result.h"
 
 namespace paimon {

--- a/src/paimon/common/utils/arrow/arrow_utils_test.cpp
+++ b/src/paimon/common/utils/arrow/arrow_utils_test.cpp
@@ -21,6 +21,7 @@
 #include "gtest/gtest.h"
 #include "paimon/common/types/data_field.h"
 #include "paimon/testing/utils/testharness.h"
+
 namespace paimon::test {
 
 TEST(ArrowUtilsTest, TestCreateProjection) {

--- a/src/paimon/common/utils/arrow/mem_utils.cpp
+++ b/src/paimon/common/utils/arrow/mem_utils.cpp
@@ -18,6 +18,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <new>
 #include <string>
 
 #include "arrow/memory_pool.h"
@@ -33,18 +34,30 @@ class ArrowMemPoolAdaptor : public arrow::MemoryPool {
         : pool_(*pool), life_holder_(pool) {}
 
     arrow::Status Allocate(int64_t size, int64_t alignment, uint8_t** out) override {
-        *out = reinterpret_cast<uint8_t*>(pool_.Malloc(size, alignment));
-        if (size > 0 && *out == nullptr) {
+        uint8_t* new_out = nullptr;
+        try {
+            new_out = reinterpret_cast<uint8_t*>(pool_.Malloc(size, alignment));
+        } catch (const std::bad_alloc&) {
             return arrow::Status::OutOfMemory(fmt::format("failed to allocate {} bytes", size));
         }
+        if (size > 0 && new_out == nullptr) {
+            return arrow::Status::OutOfMemory(fmt::format("failed to allocate {} bytes", size));
+        }
+        *out = new_out;
         stats_.DidAllocateBytes(size);
         return arrow::Status::OK();
     }
 
     arrow::Status Reallocate(int64_t old_size, int64_t new_size, int64_t alignment,
                              uint8_t** ptr) override {
-        auto* new_ptr =
-            reinterpret_cast<uint8_t*>(pool_.Realloc(*ptr, old_size, new_size, alignment));
+        uint8_t* new_ptr = nullptr;
+        try {
+            new_ptr =
+                reinterpret_cast<uint8_t*>(pool_.Realloc(*ptr, old_size, new_size, alignment));
+        } catch (const std::bad_alloc&) {
+            return arrow::Status::OutOfMemory(
+                fmt::format("failed to reallocate memory from {} to {} bytes", old_size, new_size));
+        }
         if (new_size > 0 && new_ptr == nullptr) {
             return arrow::Status::OutOfMemory(
                 fmt::format("failed to reallocate memory from {} to {} bytes", old_size, new_size));

--- a/src/paimon/common/utils/arrow/mem_utils.cpp
+++ b/src/paimon/common/utils/arrow/mem_utils.cpp
@@ -22,6 +22,7 @@
 
 #include "arrow/memory_pool.h"
 #include "arrow/status.h"
+#include "fmt/format.h"
 #include "paimon/memory/memory_pool.h"
 
 namespace paimon {
@@ -33,13 +34,22 @@ class ArrowMemPoolAdaptor : public arrow::MemoryPool {
 
     arrow::Status Allocate(int64_t size, int64_t alignment, uint8_t** out) override {
         *out = reinterpret_cast<uint8_t*>(pool_.Malloc(size, alignment));
+        if (size > 0 && *out == nullptr) {
+            return arrow::Status::OutOfMemory(fmt::format("failed to allocate {} bytes", size));
+        }
         stats_.DidAllocateBytes(size);
         return arrow::Status::OK();
     }
 
     arrow::Status Reallocate(int64_t old_size, int64_t new_size, int64_t alignment,
                              uint8_t** ptr) override {
-        *ptr = reinterpret_cast<uint8_t*>(pool_.Realloc(*ptr, old_size, new_size, alignment));
+        auto* new_ptr =
+            reinterpret_cast<uint8_t*>(pool_.Realloc(*ptr, old_size, new_size, alignment));
+        if (new_size > 0 && new_ptr == nullptr) {
+            return arrow::Status::OutOfMemory(
+                fmt::format("failed to reallocate memory from {} to {} bytes", old_size, new_size));
+        }
+        *ptr = new_ptr;
         stats_.DidReallocateBytes(old_size, new_size);
         return arrow::Status::OK();
     }

--- a/src/paimon/common/utils/arrow/mem_utils.h
+++ b/src/paimon/common/utils/arrow/mem_utils.h
@@ -23,9 +23,6 @@
 #include "paimon/visibility.h"
 
 namespace paimon {
-class MemoryPool;
-
-PAIMON_EXPORT std::unique_ptr<arrow::MemoryPool> GetArrowPool(MemoryPool& pool);
 
 PAIMON_EXPORT std::unique_ptr<arrow::MemoryPool> GetArrowPool(
     const std::shared_ptr<MemoryPool>& pool);

--- a/src/paimon/format/orc/orc_file_batch_reader_test.cpp
+++ b/src/paimon/format/orc/orc_file_batch_reader_test.cpp
@@ -16,6 +16,7 @@
 
 #include "paimon/format/orc/orc_file_batch_reader.h"
 
+#include <limits>
 #include <list>
 #include <map>
 #include <memory>
@@ -492,7 +493,8 @@ TEST_P(OrcFileBatchReaderTest, TestNextBatchSimple) {
     for (auto batch_size : {1, 2, 3, 5, 8, 10}) {
         auto orc_batch_reader =
             PrepareOrcFileBatchReader(file_name, &read_schema, batch_size, natural_read_size);
-        ASSERT_EQ(orc_batch_reader->GetPreviousBatchFirstRowNumber().value(), -1);
+        ASSERT_EQ(std::numeric_limits<uint64_t>::max(),
+                  orc_batch_reader->GetPreviousBatchFirstRowNumber().value());
         ASSERT_OK_AND_ASSIGN(auto result_array, paimon::test::ReadResultCollector::CollectResult(
                                                     orc_batch_reader.get()));
         ASSERT_EQ(orc_batch_reader->GetPreviousBatchFirstRowNumber().value(), 8);
@@ -766,7 +768,8 @@ TEST_F(OrcFileBatchReaderTest, TestReadNoField) {
     auto orc_batch_reader = PrepareOrcFileBatchReader(file_name, &read_schema, /*batch_size=*/3,
                                                       /*natural_read_size=*/10);
     // read 3 rows
-    ASSERT_EQ(orc_batch_reader->GetPreviousBatchFirstRowNumber().value(), -1);
+    ASSERT_EQ(std::numeric_limits<uint64_t>::max(),
+              orc_batch_reader->GetPreviousBatchFirstRowNumber().value());
     ASSERT_OK_AND_ASSIGN(auto batch1, orc_batch_reader->NextBatch());
     ASSERT_EQ(orc_batch_reader->GetPreviousBatchFirstRowNumber().value(), 0);
     // read 3 rows

--- a/src/paimon/testing/mock/mock_file_batch_reader.h
+++ b/src/paimon/testing/mock/mock_file_batch_reader.h
@@ -17,7 +17,11 @@
 #pragma once
 
 #include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <limits>
 #include <memory>
+#include <random>
 #include <utility>
 #include <vector>
 
@@ -26,8 +30,8 @@
 #include "paimon/common/metrics/metrics_impl.h"
 #include "paimon/common/reader/reader_utils.h"
 #include "paimon/common/utils/arrow/status_utils.h"
-#include "paimon/common/utils/date_time_utils.h"
 #include "paimon/reader/prefetch_file_batch_reader.h"
+
 namespace paimon::test {
 
 class MockFileBatchReader : public PrefetchFileBatchReader {
@@ -39,13 +43,14 @@ class MockFileBatchReader : public PrefetchFileBatchReader {
           file_schema_(file_schema),
           read_schema_(arrow::schema(file_schema->fields())),
           batch_size_(read_batch_size) {
+        assert(read_batch_size > 0);
         // add all valid bitmap
-        int32_t data_length = data_ ? data_->length() : 0;
+        int64_t data_length = data_ ? data_->length() : 0;
+        assert(data_length >= 0);
+        assert(data_length <= static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
         bitmap_ = RoaringBitmap32();
-        bitmap_.AddRange(0, data_length);
-        read_end_pos_ = data_length;
-        int64_t seed = DateTimeUtils::GetCurrentUTCTimeUs();
-        std::srand(seed);
+        bitmap_.AddRange(0, static_cast<int32_t>(data_length));
+        read_end_pos_ = static_cast<int32_t>(data_length);
     }
 
     MockFileBatchReader(const std::shared_ptr<arrow::Array>& data,
@@ -93,7 +98,8 @@ class MockFileBatchReader : public PrefetchFileBatchReader {
     }
 
     Status SeekToRow(uint64_t row_number) override {
-        current_pos_ = row_number;
+        assert(row_number <= static_cast<uint64_t>(std::numeric_limits<int32_t>::max()));
+        current_pos_ = static_cast<int32_t>(row_number);
         return Status::OK();
     }
 
@@ -117,7 +123,8 @@ class MockFileBatchReader : public PrefetchFileBatchReader {
             }
             int32_t actual_batch_size = batch_size_;
             if (enable_randomize_batch_size_) {
-                actual_batch_size = std::rand() % batch_size_ + 1;
+                std::uniform_int_distribution<int32_t> distribution(1, batch_size_);
+                actual_batch_size = distribution(random_engine_);
             }
             int32_t batch_end_pos = std::min(read_end_pos_, current_pos_ + actual_batch_size);
             auto slice = data_->Slice(current_pos_, batch_end_pos - current_pos_);
@@ -150,14 +157,14 @@ class MockFileBatchReader : public PrefetchFileBatchReader {
     }
 
     Result<uint64_t> GetPreviousBatchFirstRowNumber() const override {
-        return previous_batch_first_row_num_;
+        return ToReaderRowNumber(previous_batch_first_row_num_);
     }
 
     Result<uint64_t> GetNumberOfRows() const override {
-        return data_ ? data_->length() : 0;
+        return ToReaderRowNumber(read_end_pos_);
     }
     uint64_t GetNextRowToRead() const override {
-        return current_pos_;
+        return ToReaderRowNumber(current_pos_);
     }
     void Close() override {}
 
@@ -170,6 +177,13 @@ class MockFileBatchReader : public PrefetchFileBatchReader {
     }
 
  private:
+    static uint64_t ToReaderRowNumber(int32_t row_number) {
+        if (row_number < 0) {
+            return std::numeric_limits<uint64_t>::max();
+        }
+        return static_cast<uint64_t>(row_number);
+    }
+
     std::shared_ptr<arrow::Array> data_;
     std::shared_ptr<arrow::DataType> file_schema_;
     std::shared_ptr<arrow::Schema> read_schema_;
@@ -181,6 +195,7 @@ class MockFileBatchReader : public PrefetchFileBatchReader {
     Status next_batch_status_;
     bool enable_randomize_batch_size_ = true;
     std::vector<std::pair<uint64_t, uint64_t>> read_ranges_;
+    std::mt19937 random_engine_{std::random_device{}()};
 };
 
 }  // namespace paimon::test

--- a/src/paimon/testing/mock/mock_file_batch_reader.h
+++ b/src/paimon/testing/mock/mock_file_batch_reader.h
@@ -195,7 +195,7 @@ class MockFileBatchReader : public PrefetchFileBatchReader {
     Status next_batch_status_;
     bool enable_randomize_batch_size_ = true;
     std::vector<std::pair<uint64_t, uint64_t>> read_ranges_;
-    std::mt19937 random_engine_{std::random_device{}()};
+    std::mt19937 random_engine_{std::random_device{}()};  // NOLINT(whitespace/braces)
 };
 
 }  // namespace paimon::test

--- a/src/paimon/testing/mock/mock_format_writer.cpp
+++ b/src/paimon/testing/mock/mock_format_writer.cpp
@@ -18,7 +18,6 @@
 
 #include <map>
 #include <string>
-#include <utility>
 
 #include "arrow/c/helpers.h"
 #include "paimon/common/utils/date_time_utils.h"
@@ -34,7 +33,7 @@ class MemoryPool;
 namespace paimon::test {
 MockFormatWriter::MockFormatWriter(const std::shared_ptr<OutputStream>& out,
                                    const std::shared_ptr<MemoryPool>& pool)
-    : FormatWriter(), out_(std::move(out)), pool_(pool) {}
+    : FormatWriter(), out_(out), pool_(pool) {}
 
 Status MockFormatWriter::AddBatch(ArrowArray* batch) {
     ArrowArrayRelease(batch);

--- a/src/paimon/testing/mock/mock_format_writer_builder.h
+++ b/src/paimon/testing/mock/mock_format_writer_builder.h
@@ -42,8 +42,6 @@ class MockFormatWriterBuilder : public WriterBuilder {
                                                 const std::string& compression) override;
 
  private:
-    Status Prepare();
-
     std::shared_ptr<MemoryPool> memory_pool_;
 };
 

--- a/src/paimon/testing/mock/mock_key_value_data_file_record_reader.h
+++ b/src/paimon/testing/mock/mock_key_value_data_file_record_reader.h
@@ -21,6 +21,7 @@
 
 #include "paimon/common/data/columnar/columnar_batch_context.h"
 #include "paimon/core/io/key_value_data_file_record_reader.h"
+
 namespace paimon::test {
 // mock reader hold data array
 class MockKeyValueDataFileRecordReader : public KeyValueDataFileRecordReader {

--- a/test/inte/blob_table_inte_test.cpp
+++ b/test/inte/blob_table_inte_test.cpp
@@ -75,6 +75,7 @@
 #include "paimon/testing/utils/test_helper.h"
 #include "paimon/testing/utils/testharness.h"
 #include "paimon/write_context.h"
+
 namespace paimon {
 class DataSplit;
 class RecordBatch;
@@ -1198,10 +1199,9 @@ TEST_P(BlobTableInteTest, TestIOException) {
                 .ValueOrDie());
         auto commit_msgs1_result = WriteArray(table_path, {}, write_cols1, {src_array1});
         CHECK_HOOK_STATUS(commit_msgs1_result.status(), i);
-        SetFirstRowId(/*reset_first_row_id=*/0,
-                      const_cast<std::vector<std::shared_ptr<paimon::CommitMessage>>&>(
-                          commit_msgs1_result.value()));
-        CHECK_HOOK_STATUS(Commit(table_path, commit_msgs1_result.value()), i);
+        auto commit_msgs1 = std::move(commit_msgs1_result).value();
+        SetFirstRowId(/*reset_first_row_id=*/0, commit_msgs1);
+        CHECK_HOOK_STATUS(Commit(table_path, commit_msgs1), i);
         write_run_complete = true;
         break;
     }
@@ -1521,7 +1521,7 @@ TEST_P(BlobTableInteTest, TestWithRowIdsForMultipleBlobFiles) {
                               /*row_ranges=*/{Range(1l, 1l), Range(5l, 5l)}));
     }
     {
-        // test ont read blob field
+        // test not read blob field
         auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
             arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({fields_[1]}), R"([
         ["aaa1"],


### PR DESCRIPTION
### Purpose

Linked issue: close #xxx

Address minor review findings in testing and Arrow utility code:

- handle allocation failures in `ArrowMemPoolAdaptor` instead of returning OK with a null pointer
- document that `MemoryPool::Malloc` throws `std::bad_alloc` on allocation failure and translate that exception to Arrow `OutOfMemory`
- remove an undefined `GetArrowPool(MemoryPool&)` declaration and a redundant forward declaration
- clean up unnecessary includes and include/namespace spacing
- simplify mock writer and mock reader behavior around dead declarations, copy semantics, random batch sizes, and previous-row sentinels
- avoid `const_cast` in blob table integration tests and fix small test comments/formatting

### Tests

- `git diff --cached --check`
- `git diff --check`
- `cmake --build build --target paimon-common-test paimon-orc-format-test paimon-blob-table-inte-test -j64`

### API and Format

No storage format or protocol changes.

This updates the documented failure behavior of `MemoryPool::Malloc` to match the current implementation: allocation failure is reported by throwing `std::bad_alloc`.

### Documentation

No user-facing documentation changes.

### Generative AI tooling

Generated-by: OpenAI Codex
