### PR TITLE
feat(parquet): support page index filter for nested column type (paimon side)

### DIFF
--- a/src/paimon/format/parquet/file_reader_wrapper.cpp
+++ b/src/paimon/format/parquet/file_reader_wrapper.cpp
@@ -340,27 +340,6 @@ Status FileReaderWrapper::PrepareForReadingLazy(
     return Status::OK();
 }
 
-Status FileReaderWrapper::BuildPageFilteredSchema(const std::vector<int32_t>& column_indices) {
-    if (page_filtered_read_schema_) {
-        return Status::OK();
-    }
-
-    // Use SchemaManifest to group leaf columns by top-level field.
-    // This correctly handles nested types (Struct, List, Map) where multiple
-    // leaf Parquet columns map to a single top-level Arrow field.
-    const auto& manifest = file_reader_->manifest();
-    std::vector<int> col_indices_vec(column_indices.begin(), column_indices.end());
-    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::vector<int> field_indices,
-                                      manifest.GetFieldIndices(col_indices_vec));
-
-    std::vector<std::shared_ptr<arrow::Field>> fields;
-    for (int field_idx : field_indices) {
-        fields.push_back(manifest.schema_fields[field_idx].field);
-    }
-    page_filtered_read_schema_ = arrow::schema(fields);
-    return Status::OK();
-}
-
 std::vector<::arrow::io::ReadRange> FileReaderWrapper::CollectPreBufferRanges(
     const std::vector<int32_t>& column_indices) {
     std::vector<::arrow::io::ReadRange> ranges;
@@ -426,7 +405,9 @@ Status FileReaderWrapper::PrepareForReading(const std::vector<TargetRowGroup>& t
 
         bool has_partially_matched = fully_matched_row_groups.size() != active_count;
         if (has_partially_matched) {
-            PAIMON_RETURN_NOT_OK(BuildPageFilteredSchema(column_indices));
+            PAIMON_ASSIGN_OR_RAISE(page_filtered_read_schema_,
+                                   PageFilteredRowGroupReader::BuildProjectedSchema(
+                                       file_reader_.get(), column_indices));
         }
 
         WaitForPendingPreBuffer();

--- a/src/paimon/format/parquet/file_reader_wrapper.cpp
+++ b/src/paimon/format/parquet/file_reader_wrapper.cpp
@@ -29,6 +29,7 @@
 #include "paimon/format/parquet/parquet_format_defs.h"
 #include "paimon/macros.h"
 #include "parquet/arrow/reader.h"
+#include "parquet/arrow/schema.h"
 #include "parquet/file_reader.h"
 #include "parquet/metadata.h"
 #include "parquet/page_index.h"
@@ -234,9 +235,9 @@ Result<std::shared_ptr<arrow::RecordBatch>> FileReaderWrapper::NextPageFiltered(
         PAIMON_ASSIGN_OR_RAISE(
             current_page_filtered_reader_,
             PageFilteredRowGroupReader::ReadFilteredRowGroup(
-                file_reader_->parquet_reader(), target_rg, target_column_indices_,
-                page_filtered_read_schema_, file_reader_->properties().cache_options(),
-                pre_buffered, page_ranges, max_chunksize, pool_));
+                file_reader_.get(), target_rg, target_column_indices_, page_filtered_read_schema_,
+                file_reader_->properties().cache_options(), pre_buffered, page_ranges,
+                max_chunksize, pool_));
         current_filtered_row_ranges_ = target_rg.row_ranges;
         current_filtered_rg_start_ = all_row_group_ranges_[rg_id].first;
         filtered_global_offset_ = 0;
@@ -343,20 +344,18 @@ Status FileReaderWrapper::BuildPageFilteredSchema(const std::vector<int32_t>& co
     if (page_filtered_read_schema_) {
         return Status::OK();
     }
-    std::shared_ptr<arrow::Schema> schema;
-    PAIMON_RETURN_NOT_OK_FROM_ARROW(file_reader_->GetSchema(&schema));
-    auto parquet_schema = file_reader_->parquet_reader()->metadata()->schema();
+
+    // Use SchemaManifest to group leaf columns by top-level field.
+    // This correctly handles nested types (Struct, List, Map) where multiple
+    // leaf Parquet columns map to a single top-level Arrow field.
+    const auto& manifest = file_reader_->manifest();
+    std::vector<int> col_indices_vec(column_indices.begin(), column_indices.end());
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::vector<int> field_indices,
+                                      manifest.GetFieldIndices(col_indices_vec));
+
     std::vector<std::shared_ptr<arrow::Field>> fields;
-    for (int32_t col_idx : column_indices) {
-        const std::string& col_name = parquet_schema->Column(col_idx)->name();
-        auto field = schema->GetFieldByName(col_name);
-        if (!field) {
-            return Status::Invalid(fmt::format(
-                "PrepareForReading: Parquet column {} ('{}') has no matching Arrow field in "
-                "file schema",
-                col_idx, col_name));
-        }
-        fields.push_back(field);
+    for (int field_idx : field_indices) {
+        fields.push_back(manifest.schema_fields[field_idx].field);
     }
     page_filtered_read_schema_ = arrow::schema(fields);
     return Status::OK();

--- a/src/paimon/format/parquet/file_reader_wrapper.h
+++ b/src/paimon/format/parquet/file_reader_wrapper.h
@@ -157,9 +157,6 @@ class FileReaderWrapper {
     /// Read next batch from the fully-matched batch_reader_. Returns nullptr when exhausted.
     Result<std::shared_ptr<arrow::RecordBatch>> NextFullyMatched();
 
-    /// Build page_filtered_read_schema_ from the given column indices. No-op if already built.
-    Status BuildPageFilteredSchema(const std::vector<int32_t>& column_indices);
-
     /// Collect all byte ranges that need pre-buffering (page-filtered + fully-matched).
     std::vector<::arrow::io::ReadRange> CollectPreBufferRanges(
         const std::vector<int32_t>& column_indices);

--- a/src/paimon/format/parquet/page_filtered_row_group_reader.cpp
+++ b/src/paimon/format/parquet/page_filtered_row_group_reader.cpp
@@ -95,6 +95,84 @@ bool HasRepeatedDescendant(const ::parquet::arrow::SchemaField& field) {
 
 }  // namespace
 
+std::shared_ptr<arrow::Field> PageFilteredRowGroupReader::BuildProjectedField(
+    const ::parquet::arrow::SchemaField& schema_field, const std::set<int32_t>& column_indices) {
+    if (schema_field.is_leaf()) {
+        if (column_indices.count(schema_field.column_index) > 0) {
+            return schema_field.field;
+        }
+        return nullptr;
+    }
+
+    auto type = schema_field.field->type();
+    auto type_id = type->id();
+
+    if (type_id == ::arrow::Type::STRUCT) {
+        std::vector<std::shared_ptr<arrow::Field>> child_fields;
+        for (const auto& child : schema_field.children) {
+            auto projected = BuildProjectedField(child, column_indices);
+            if (projected) {
+                child_fields.push_back(projected);
+            }
+        }
+        if (child_fields.empty()) return nullptr;
+        return arrow::field(schema_field.field->name(), arrow::struct_(child_fields),
+                            schema_field.field->nullable());
+    }
+
+    if (type_id == ::arrow::Type::LIST || type_id == ::arrow::Type::LARGE_LIST ||
+        type_id == ::arrow::Type::FIXED_SIZE_LIST || type_id == ::arrow::Type::MAP) {
+        if (schema_field.children.empty()) return nullptr;
+        auto projected_child = BuildProjectedField(schema_field.children[0], column_indices);
+        if (!projected_child) return nullptr;
+        auto child_type = projected_child->type();
+        if (type_id == ::arrow::Type::LIST) {
+            return arrow::field(schema_field.field->name(), arrow::list(child_type),
+                                schema_field.field->nullable());
+        }
+        if (type_id == ::arrow::Type::LARGE_LIST) {
+            return arrow::field(schema_field.field->name(), arrow::large_list(child_type),
+                                schema_field.field->nullable());
+        }
+        if (type_id == ::arrow::Type::FIXED_SIZE_LIST) {
+            auto& fsl_type = static_cast<const arrow::FixedSizeListType&>(*type);
+            return arrow::field(schema_field.field->name(),
+                                arrow::fixed_size_list(child_type, fsl_type.list_size()),
+                                schema_field.field->nullable());
+        }
+        if (type_id == ::arrow::Type::MAP) {
+            if (child_type->id() == ::arrow::Type::STRUCT && child_type->num_fields() == 2) {
+                return arrow::field(
+                    schema_field.field->name(),
+                    arrow::map(child_type->field(0)->type(), child_type->field(1)->type()),
+                    schema_field.field->nullable());
+            }
+            return arrow::field(schema_field.field->name(), arrow::list(child_type),
+                                schema_field.field->nullable());
+        }
+    }
+
+    return nullptr;
+}
+
+Result<std::shared_ptr<arrow::Schema>> PageFilteredRowGroupReader::BuildProjectedSchema(
+    ::parquet::arrow::FileReader* arrow_file_reader, const std::vector<int32_t>& column_indices) {
+    const auto& manifest = arrow_file_reader->manifest();
+    std::vector<int> col_indices_vec(column_indices.begin(), column_indices.end());
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::vector<int> field_indices,
+                                      manifest.GetFieldIndices(col_indices_vec));
+
+    std::set<int32_t> col_set(column_indices.begin(), column_indices.end());
+    std::vector<std::shared_ptr<arrow::Field>> fields;
+    for (int field_idx : field_indices) {
+        auto projected = BuildProjectedField(manifest.schema_fields[field_idx], col_set);
+        if (projected) {
+            fields.push_back(projected);
+        }
+    }
+    return arrow::schema(std::move(fields));
+}
+
 std::pair<int64_t, int64_t> PageFilteredRowGroupReader::GetPageRowRange(
     const std::vector<::parquet::PageLocation>& page_locations, int32_t page_idx,
     int64_t row_group_row_count) {
@@ -282,14 +360,21 @@ PageFilteredRowGroupReader::ReadAndAssembleField(
         // === Struct Assembly (mimicking StructReader::BuildArray) ===
         std::vector<std::shared_ptr<::arrow::ArrayData>> child_data;
         std::shared_ptr<::parquet::internal::RecordReader> def_level_reader;
+        std::set<int32_t> col_set(column_indices.begin(), column_indices.end());
 
         for (const auto& child : schema_field.children) {
+            // Sub-column projection: skip children whose leaf columns are not requested.
+            auto projected_child_field = BuildProjectedField(child, col_set);
+            if (!projected_child_field) {
+                continue;
+            }
+
             PAIMON_ASSIGN_OR_RAISE(
                 auto child_result,
                 ReadAndAssembleField(child, parquet_reader, row_group_reader, rg_page_index_reader,
-                                     row_group_index, column_indices, row_ranges, child.field,
-                                     row_group_row_count, expected_rows, pool,
-                                     /*is_top_level=*/false));
+                                     row_group_index, column_indices, row_ranges,
+                                     projected_child_field, row_group_row_count, expected_rows,
+                                     pool, /*is_top_level=*/false));
 
             if (!def_level_reader) {
                 def_level_reader = child_result.second;
@@ -353,10 +438,17 @@ PageFilteredRowGroupReader::ReadAndAssembleField(
         // === List/Map Assembly (mimicking ListReader::BuildArray) ===
         // Map is stored as list<struct<key, value>> in Parquet, so use List assembly.
         const auto& child = schema_field.children[0];
+        std::set<int32_t> col_set(column_indices.begin(), column_indices.end());
+        auto projected_child_field = BuildProjectedField(child, col_set);
+        if (!projected_child_field) {
+            return Status::Invalid(fmt::format(
+                "PageFilteredRowGroupReader: no leaf columns requested for list/map field '{}'",
+                field->name()));
+        }
         PAIMON_ASSIGN_OR_RAISE(
             auto child_result,
             ReadAndAssembleField(child, parquet_reader, row_group_reader, rg_page_index_reader,
-                                 row_group_index, column_indices, row_ranges, child.field,
+                                 row_group_index, column_indices, row_ranges, projected_child_field,
                                  row_group_row_count, expected_rows, pool,
                                  /*is_top_level=*/false));
 

--- a/src/paimon/format/parquet/page_filtered_row_group_reader.cpp
+++ b/src/paimon/format/parquet/page_filtered_row_group_reader.cpp
@@ -19,15 +19,18 @@
 #include <algorithm>
 
 #include "arrow/array.h"
+#include "arrow/array/concatenate.h"
 #include "arrow/builder.h"
 #include "arrow/chunked_array.h"
 #include "arrow/io/caching.h"
 #include "arrow/io/interfaces.h"
 #include "arrow/table.h"
+#include "arrow/util/bit_util.h"
 #include "arrow/util/future.h"
 #include "fmt/format.h"
 #include "paimon/common/utils/arrow/status_utils.h"
 #include "parquet/arrow/reader_internal.h"
+#include "parquet/level_conversion.h"
 #include "parquet/metadata.h"
 #include "parquet/schema.h"
 
@@ -57,6 +60,38 @@ class TableRecordBatchReader : public arrow::RecordBatchReader {
     std::shared_ptr<arrow::Table> table_;
     arrow::TableBatchReader inner_;
 };
+
+/// Check if a SchemaField or any of its descendants is a repeated type
+/// (List, Map, FixedSizeList, LargeList). This mirrors
+/// ColumnReaderImpl::IsOrHasRepeatedChild() to decide whether to use
+/// DefRepLevelsToBitmap (true) or DefLevelsToBitmap (false) for Struct assembly.
+bool HasRepeatedDescendant(const ::parquet::arrow::SchemaField& field) {
+    if (field.is_leaf()) return false;
+    for (const auto& child : field.children) {
+        auto type_id = child.field->type()->id();
+        if (type_id == ::arrow::Type::LIST || type_id == ::arrow::Type::MAP ||
+            type_id == ::arrow::Type::FIXED_SIZE_LIST || type_id == ::arrow::Type::LARGE_LIST) {
+            return true;
+        }
+        if (HasRepeatedDescendant(child)) return true;
+    }
+    return false;
+}
+
+/// Convert a ChunkedArray to a single ArrayData.
+/// 0 chunks → null array; 1 chunk → that chunk's data; >1 → concatenate.
+::arrow::Result<std::shared_ptr<::arrow::ArrayData>> ChunksToSingleArrayData(
+    const ::arrow::ChunkedArray& chunked) {
+    if (chunked.num_chunks() == 0) {
+        ARROW_ASSIGN_OR_RAISE(auto array, ::arrow::MakeArrayOfNull(chunked.type(), 0));
+        return array->data();
+    }
+    if (chunked.num_chunks() == 1) {
+        return chunked.chunk(0)->data();
+    }
+    ARROW_ASSIGN_OR_RAISE(auto concatenated, ::arrow::Concatenate(chunked.chunks()));
+    return concatenated->data();
+}
 
 }  // namespace
 
@@ -155,17 +190,18 @@ Status PageFilteredRowGroupReader::ExecuteSkipReadPattern(
     return Status::OK();
 }
 
-Result<std::shared_ptr<arrow::ChunkedArray>> PageFilteredRowGroupReader::ReadFilteredColumn(
+Result<std::pair<std::shared_ptr<arrow::ChunkedArray>,
+                 std::shared_ptr<::parquet::internal::RecordReader>>>
+PageFilteredRowGroupReader::ReadLeafColumn(
     const std::shared_ptr<::parquet::RowGroupReader>& row_group_reader,
     ::parquet::ParquetFileReader* parquet_reader,
     const std::shared_ptr<::parquet::RowGroupPageIndexReader>& rg_page_index_reader,
     int32_t row_group_index, int32_t column_index, const RowRanges& row_ranges,
     const std::shared_ptr<arrow::Field>& field, int64_t row_group_row_count,
-    std::shared_ptr<::arrow::MemoryPool> pool) {
+    bool enable_page_filter, std::shared_ptr<::arrow::MemoryPool> pool) {
     auto file_metadata = parquet_reader->metadata();
     const auto* col_descriptor = file_metadata->schema()->Column(column_index);
 
-    // Try to get OffsetIndex for I/O-level page skipping
     RowRanges effective_ranges = row_ranges;
     int64_t effective_row_count = row_group_row_count;
 
@@ -176,18 +212,15 @@ Result<std::shared_ptr<arrow::ChunkedArray>> PageFilteredRowGroupReader::ReadFil
 
     auto page_reader = row_group_reader->GetColumnPageReader(column_index);
 
-    if (offset_index) {
-        // Set data_page_filter for I/O-level page skipping
+    if (enable_page_filter && offset_index) {
         page_reader->set_data_page_filter(
             MakePageFilter(row_ranges, offset_index, row_group_row_count));
-        // Compute compressed RowRanges for the decode-level skip/read pattern
         auto [compressed_ranges, compressed_total] =
             ComputeCompressedRowRanges(row_ranges, offset_index, row_group_row_count);
         effective_ranges = std::move(compressed_ranges);
         effective_row_count = compressed_total;
     }
 
-    // Create RecordReader
     ::parquet::internal::LevelInfo leaf_info =
         ::parquet::internal::LevelInfo::ComputeLevelInfo(col_descriptor);
     auto record_reader =
@@ -201,7 +234,226 @@ Result<std::shared_ptr<arrow::ChunkedArray>> PageFilteredRowGroupReader::ReadFil
     PAIMON_RETURN_NOT_OK_FROM_ARROW(::parquet::arrow::TransferColumnData(
         record_reader.get(), field, col_descriptor, pool.get(), &chunked_array));
 
-    return chunked_array;
+    return std::make_pair(std::move(chunked_array), std::move(record_reader));
+}
+
+Result<std::shared_ptr<arrow::ChunkedArray>> PageFilteredRowGroupReader::ReadFilteredColumn(
+    const std::shared_ptr<::parquet::RowGroupReader>& row_group_reader,
+    ::parquet::ParquetFileReader* parquet_reader,
+    const std::shared_ptr<::parquet::RowGroupPageIndexReader>& rg_page_index_reader,
+    int32_t row_group_index, int32_t column_index, const RowRanges& row_ranges,
+    const std::shared_ptr<arrow::Field>& field, int64_t row_group_row_count,
+    std::shared_ptr<::arrow::MemoryPool> pool) {
+    PAIMON_ASSIGN_OR_RAISE(auto result,
+                           ReadLeafColumn(row_group_reader, parquet_reader, rg_page_index_reader,
+                                          row_group_index, column_index, row_ranges, field,
+                                          row_group_row_count, /*enable_page_filter=*/true, pool));
+    return result.first;
+}
+
+Result<std::pair<std::shared_ptr<arrow::ChunkedArray>,
+                 std::shared_ptr<::parquet::internal::RecordReader>>>
+PageFilteredRowGroupReader::ReadAndAssembleField(
+    const ::parquet::arrow::SchemaField& schema_field, ::parquet::ParquetFileReader* parquet_reader,
+    const std::shared_ptr<::parquet::RowGroupReader>& row_group_reader,
+    const std::shared_ptr<::parquet::RowGroupPageIndexReader>& rg_page_index_reader,
+    int32_t row_group_index, const std::vector<int32_t>& column_indices,
+    const RowRanges& row_ranges, const std::shared_ptr<arrow::Field>& field,
+    int64_t row_group_row_count, int64_t expected_rows, std::shared_ptr<::arrow::MemoryPool> pool,
+    bool is_top_level) {
+    namespace bit_util = ::arrow::bit_util;
+
+    // For leaf/flat fields, use ReadLeafColumn.
+    // Top-level leaf columns get data_page_filter for I/O-level page skipping.
+    // Nested leaf columns (is_top_level=false) skip data_page_filter to preserve
+    // def/rep level synchronization across sibling leaf columns.
+    if (schema_field.is_leaf()) {
+        PAIMON_ASSIGN_OR_RAISE(
+            auto result,
+            ReadLeafColumn(row_group_reader, parquet_reader, rg_page_index_reader, row_group_index,
+                           schema_field.column_index, row_ranges, field, row_group_row_count,
+                           /*enable_page_filter=*/is_top_level, pool));
+        return result;
+    }
+
+    auto type_id = field->type()->id();
+
+    if (type_id == ::arrow::Type::STRUCT) {
+        // === Struct Assembly (mimicking StructReader::BuildArray) ===
+        std::vector<std::shared_ptr<::arrow::ArrayData>> child_data;
+        std::shared_ptr<::parquet::internal::RecordReader> def_level_reader;
+
+        for (const auto& child : schema_field.children) {
+            PAIMON_ASSIGN_OR_RAISE(
+                auto child_result,
+                ReadAndAssembleField(child, parquet_reader, row_group_reader, rg_page_index_reader,
+                                     row_group_index, column_indices, row_ranges, child.field,
+                                     row_group_row_count, expected_rows, pool,
+                                     /*is_top_level=*/false));
+
+            if (!def_level_reader) {
+                def_level_reader = child_result.second;
+            }
+
+            PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(auto array_data,
+                                              ChunksToSingleArrayData(*child_result.first));
+            child_data.push_back(std::move(array_data));
+        }
+
+        // Build validity bitmap from def levels.
+        bool has_repeated_child = HasRepeatedDescendant(schema_field);
+        std::shared_ptr<::arrow::ResizableBuffer> null_bitmap;
+        ::parquet::internal::ValidityBitmapInputOutput validity_io;
+        validity_io.values_read_upper_bound = expected_rows;
+        validity_io.values_read = expected_rows;
+
+        if (has_repeated_child) {
+            PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+                null_bitmap, ::arrow::AllocateResizableBuffer(bit_util::BytesForBits(expected_rows),
+                                                              pool.get()));
+            validity_io.valid_bits = null_bitmap->mutable_data();
+
+            const int16_t* def_levels = def_level_reader->def_levels();
+            const int16_t* rep_levels = def_level_reader->rep_levels();
+            int64_t num_levels = def_level_reader->levels_position();
+            ::parquet::internal::DefRepLevelsToBitmap(def_levels, rep_levels, num_levels,
+                                                      schema_field.level_info, &validity_io);
+        } else if (field->nullable()) {
+            PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+                null_bitmap, ::arrow::AllocateResizableBuffer(bit_util::BytesForBits(expected_rows),
+                                                              pool.get()));
+            validity_io.valid_bits = null_bitmap->mutable_data();
+
+            const int16_t* def_levels = def_level_reader->def_levels();
+            int64_t num_levels = def_level_reader->levels_position();
+            ::parquet::internal::DefLevelsToBitmap(def_levels, num_levels, schema_field.level_info,
+                                                   &validity_io);
+        }
+
+        if (null_bitmap) {
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(
+                null_bitmap->Resize(bit_util::BytesForBits(validity_io.values_read)));
+            null_bitmap->ZeroPadding();
+        }
+
+        if (!field->nullable() && !has_repeated_child && !child_data.empty()) {
+            validity_io.values_read = child_data.front()->length;
+        }
+
+        std::vector<std::shared_ptr<::arrow::Buffer>> buffers{
+            validity_io.null_count > 0 ? null_bitmap : nullptr};
+        auto data = std::make_shared<::arrow::ArrayData>(field->type(), validity_io.values_read,
+                                                         std::move(buffers), std::move(child_data));
+        auto result = ::arrow::MakeArray(data);
+        return std::make_pair(std::make_shared<arrow::ChunkedArray>(result), def_level_reader);
+    }
+
+    if (type_id == ::arrow::Type::LIST || type_id == ::arrow::Type::MAP ||
+        type_id == ::arrow::Type::LARGE_LIST || type_id == ::arrow::Type::FIXED_SIZE_LIST) {
+        // === List/Map Assembly (mimicking ListReader::BuildArray) ===
+        // Map is stored as list<struct<key, value>> in Parquet, so use List assembly.
+        const auto& child = schema_field.children[0];
+        PAIMON_ASSIGN_OR_RAISE(
+            auto child_result,
+            ReadAndAssembleField(child, parquet_reader, row_group_reader, rg_page_index_reader,
+                                 row_group_index, column_indices, row_ranges, child.field,
+                                 row_group_row_count, expected_rows, pool,
+                                 /*is_top_level=*/false));
+
+        auto& item_record_reader = child_result.second;
+        const int16_t* def_levels = item_record_reader->def_levels();
+        const int16_t* rep_levels = item_record_reader->rep_levels();
+        int64_t num_levels = item_record_reader->levels_position();
+
+        bool is_large_list = (type_id == ::arrow::Type::LARGE_LIST);
+        bool is_fixed_size = (type_id == ::arrow::Type::FIXED_SIZE_LIST);
+
+        std::shared_ptr<::arrow::ResizableBuffer> validity_buffer;
+        ::parquet::internal::ValidityBitmapInputOutput validity_io;
+        validity_io.values_read_upper_bound = expected_rows;
+
+        if (field->nullable()) {
+            PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+                validity_buffer, ::arrow::AllocateResizableBuffer(
+                                     bit_util::BytesForBits(expected_rows), pool.get()));
+            validity_io.valid_bits = validity_buffer->mutable_data();
+        }
+
+        std::shared_ptr<::arrow::ResizableBuffer> offsets_buffer;
+
+        if (is_large_list) {
+            PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+                offsets_buffer,
+                ::arrow::AllocateResizableBuffer(
+                    sizeof(int64_t) * std::max(int64_t{1}, expected_rows + 1), pool.get()));
+            auto* offset_data = reinterpret_cast<int64_t*>(offsets_buffer->mutable_data());
+            offset_data[0] = 0;
+            ::parquet::internal::DefRepLevelsToList(def_levels, rep_levels, num_levels,
+                                                    schema_field.level_info, &validity_io,
+                                                    offset_data);
+        } else {
+            // LIST, MAP, and FIXED_SIZE_LIST all use int32 offsets initially.
+            PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+                offsets_buffer,
+                ::arrow::AllocateResizableBuffer(
+                    sizeof(int32_t) * std::max(int64_t{1}, expected_rows + 1), pool.get()));
+            auto* offset_data = reinterpret_cast<int32_t*>(offsets_buffer->mutable_data());
+            offset_data[0] = 0;
+            ::parquet::internal::DefRepLevelsToList(def_levels, rep_levels, num_levels,
+                                                    schema_field.level_info, &validity_io,
+                                                    offset_data);
+        }
+
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(auto item_data,
+                                          ChunksToSingleArrayData(*child_result.first));
+
+        // Resize buffers to actual size.
+        if (offsets_buffer) {
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(
+                offsets_buffer->Resize((validity_io.values_read + 1) *
+                                       (is_large_list ? sizeof(int64_t) : sizeof(int32_t))));
+        }
+        if (validity_buffer) {
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(
+                validity_buffer->Resize(bit_util::BytesForBits(validity_io.values_read)));
+            validity_buffer->ZeroPadding();
+        }
+
+        std::vector<std::shared_ptr<::arrow::Buffer>> buffers;
+        if (is_fixed_size) {
+            // Validate each list has the expected fixed size, then drop offsets.
+            const auto& fs_type = static_cast<const ::arrow::FixedSizeListType&>(*field->type());
+            int32_t list_size = fs_type.list_size();
+            const int32_t* offsets = reinterpret_cast<const int32_t*>(offsets_buffer->data());
+            for (int64_t x = 1; x <= validity_io.values_read; ++x) {
+                int32_t size = offsets[x] - offsets[x - 1];
+                if (size != list_size) {
+                    return Status::Invalid(
+                        fmt::format("Expected all lists to be of size={} but index {} had size={}",
+                                    list_size, x, size));
+                }
+            }
+            // FixedSizeList only has a validity buffer (no offsets).
+            buffers.push_back(validity_io.null_count > 0 ? validity_buffer : nullptr);
+        } else {
+            buffers.push_back(validity_io.null_count > 0 ? validity_buffer : nullptr);
+            buffers.push_back(offsets_buffer);
+        }
+
+        auto data = std::make_shared<::arrow::ArrayData>(
+            field->type(), validity_io.values_read, std::move(buffers),
+            std::vector<std::shared_ptr<::arrow::ArrayData>>{item_data}, validity_io.null_count);
+
+        if (type_id == ::arrow::Type::MAP) {
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(::arrow::MapArray::ValidateChildData(data->child_data));
+        }
+
+        auto result = ::arrow::MakeArray(data);
+        return std::make_pair(std::make_shared<arrow::ChunkedArray>(result), item_record_reader);
+    }
+
+    return Status::Invalid(fmt::format("PageFilteredRowGroupReader: unsupported field type: {}",
+                                       field->type()->ToString()));
 }
 
 Status PageFilteredRowGroupReader::WaitForPreBuffer(
@@ -229,7 +481,7 @@ Status PageFilteredRowGroupReader::WaitForPreBuffer(
 }
 
 Result<std::unique_ptr<arrow::RecordBatchReader>> PageFilteredRowGroupReader::ReadFilteredRowGroup(
-    ::parquet::ParquetFileReader* parquet_reader, const TargetRowGroup& target_row_group,
+    ::parquet::arrow::FileReader* arrow_file_reader, const TargetRowGroup& target_row_group,
     const std::vector<int32_t>& column_indices, const std::shared_ptr<arrow::Schema>& arrow_schema,
     const ::arrow::io::CacheOptions& cache_options, bool pre_buffered,
     const std::vector<::arrow::io::ReadRange>& page_ranges, int64_t max_chunksize,
@@ -244,6 +496,8 @@ Result<std::unique_ptr<arrow::RecordBatchReader>> PageFilteredRowGroupReader::Re
     }
 
     int64_t expected_rows = row_ranges.RowCount();
+
+    ::parquet::ParquetFileReader* parquet_reader = arrow_file_reader->parquet_reader();
 
     PAIMON_RETURN_NOT_OK(WaitForPreBuffer(parquet_reader, row_group_index, column_indices,
                                           cache_options, pre_buffered, page_ranges, pool));
@@ -260,23 +514,34 @@ Result<std::unique_ptr<arrow::RecordBatchReader>> PageFilteredRowGroupReader::Re
         rg_page_index_reader = page_index_reader->RowGroup(row_group_index);
     }
 
-    // Read each column with page filtering
+    // Use SchemaManifest to group leaf columns by top-level field.
+    // This allows us to handle nested types (Struct, List, Map) correctly by
+    // building a reader tree for each top-level field instead of treating each
+    // leaf column independently.
+    const auto& manifest = arrow_file_reader->manifest();
+    std::vector<int> col_indices_vec(column_indices.begin(), column_indices.end());
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::vector<int> field_indices,
+                                      manifest.GetFieldIndices(col_indices_vec));
+
+    // Read each top-level field with page filtering
     std::vector<std::shared_ptr<arrow::ChunkedArray>> columns;
-    columns.reserve(column_indices.size());
+    columns.reserve(field_indices.size());
 
-    for (size_t i = 0; i < column_indices.size(); ++i) {
+    for (size_t i = 0; i < field_indices.size(); ++i) {
+        const auto& schema_field = manifest.schema_fields[field_indices[i]];
         PAIMON_ASSIGN_OR_RAISE(
-            std::shared_ptr<arrow::ChunkedArray> chunked_array,
-            ReadFilteredColumn(row_group_reader, parquet_reader, rg_page_index_reader,
-                               row_group_index, column_indices[i], row_ranges,
-                               arrow_schema->field(static_cast<int>(i)), row_group_row_count,
-                               pool));
+            auto field_result,
+            ReadAndAssembleField(schema_field, parquet_reader, row_group_reader,
+                                 rg_page_index_reader, row_group_index, column_indices, row_ranges,
+                                 arrow_schema->field(static_cast<int>(i)), row_group_row_count,
+                                 expected_rows, pool));
 
+        auto& chunked_array = field_result.first;
         if (chunked_array->length() != expected_rows) {
             return Status::Invalid(fmt::format(
-                "PageFilteredRowGroupReader: column {} produced {} rows but expected {} "
+                "PageFilteredRowGroupReader: field {} produced {} rows but expected {} "
                 "(row_group={})",
-                column_indices[i], chunked_array->length(), expected_rows, row_group_index));
+                field_indices[i], chunked_array->length(), expected_rows, row_group_index));
         }
 
         columns.push_back(std::move(chunked_array));

--- a/src/paimon/format/parquet/page_filtered_row_group_reader.cpp
+++ b/src/paimon/format/parquet/page_filtered_row_group_reader.cpp
@@ -78,8 +78,6 @@ bool HasRepeatedDescendant(const ::parquet::arrow::SchemaField& field) {
     return false;
 }
 
-/// Convert a ChunkedArray to a single ArrayData.
-/// 0 chunks → null array; 1 chunk → that chunk's data; >1 → concatenate.
 ::arrow::Result<std::shared_ptr<::arrow::ArrayData>> ChunksToSingleArrayData(
     const ::arrow::ChunkedArray& chunked) {
     if (chunked.num_chunks() == 0) {
@@ -360,21 +358,26 @@ PageFilteredRowGroupReader::ReadAndAssembleField(
         // === Struct Assembly (mimicking StructReader::BuildArray) ===
         std::vector<std::shared_ptr<::arrow::ArrayData>> child_data;
         std::shared_ptr<::parquet::internal::RecordReader> def_level_reader;
-        std::set<int32_t> col_set(column_indices.begin(), column_indices.end());
+        auto& projected_type = static_cast<const ::arrow::StructType&>(*field->type());
 
-        for (const auto& child : schema_field.children) {
-            // Sub-column projection: skip children whose leaf columns are not requested.
-            auto projected_child_field = BuildProjectedField(child, col_set);
-            if (!projected_child_field) {
-                continue;
+        for (int j = 0; j < projected_type.num_fields(); ++j) {
+            const auto& projected_child_field = projected_type.field(j);
+            // Find the matching SchemaField child by name.
+            const ::parquet::arrow::SchemaField* child_schema = nullptr;
+            for (const auto& sf_child : schema_field.children) {
+                if (sf_child.field->name() == projected_child_field->name()) {
+                    child_schema = &sf_child;
+                    break;
+                }
             }
+            if (!child_schema) continue;
 
             PAIMON_ASSIGN_OR_RAISE(
                 auto child_result,
-                ReadAndAssembleField(child, parquet_reader, row_group_reader, rg_page_index_reader,
-                                     row_group_index, column_indices, row_ranges,
-                                     projected_child_field, row_group_row_count, expected_rows,
-                                     pool, /*is_top_level=*/false));
+                ReadAndAssembleField(*child_schema, parquet_reader, row_group_reader,
+                                     rg_page_index_reader, row_group_index, column_indices,
+                                     row_ranges, projected_child_field, row_group_row_count,
+                                     expected_rows, pool, /*is_top_level=*/false));
 
             if (!def_level_reader) {
                 def_level_reader = child_result.second;
@@ -438,13 +441,7 @@ PageFilteredRowGroupReader::ReadAndAssembleField(
         // === List/Map Assembly (mimicking ListReader::BuildArray) ===
         // Map is stored as list<struct<key, value>> in Parquet, so use List assembly.
         const auto& child = schema_field.children[0];
-        std::set<int32_t> col_set(column_indices.begin(), column_indices.end());
-        auto projected_child_field = BuildProjectedField(child, col_set);
-        if (!projected_child_field) {
-            return Status::Invalid(fmt::format(
-                "PageFilteredRowGroupReader: no leaf columns requested for list/map field '{}'",
-                field->name()));
-        }
+        auto projected_child_field = field->type()->field(0);
         PAIMON_ASSIGN_OR_RAISE(
             auto child_result,
             ReadAndAssembleField(child, parquet_reader, row_group_reader, rg_page_index_reader,
@@ -607,9 +604,6 @@ Result<std::unique_ptr<arrow::RecordBatchReader>> PageFilteredRowGroupReader::Re
     }
 
     // Use SchemaManifest to group leaf columns by top-level field.
-    // This allows us to handle nested types (Struct, List, Map) correctly by
-    // building a reader tree for each top-level field instead of treating each
-    // leaf column independently.
     const auto& manifest = arrow_file_reader->manifest();
     std::vector<int> col_indices_vec(column_indices.begin(), column_indices.end());
     PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::vector<int> field_indices,

--- a/src/paimon/format/parquet/page_filtered_row_group_reader.h
+++ b/src/paimon/format/parquet/page_filtered_row_group_reader.h
@@ -28,6 +28,8 @@
 #include "arrow/type.h"
 #include "paimon/format/parquet/row_ranges.h"
 #include "paimon/result.h"
+#include "parquet/arrow/reader.h"
+#include "parquet/arrow/schema.h"
 #include "parquet/column_reader.h"
 #include "parquet/file_reader.h"
 #include "parquet/page_index.h"
@@ -44,7 +46,7 @@ class PageFilteredRowGroupReader {
     ~PageFilteredRowGroupReader() = delete;
 
     /// Read a row group with page-level filtering.
-    /// @param parquet_reader The underlying ParquetFileReader
+    /// @param arrow_file_reader The Arrow FileReader (provides SchemaManifest and GetColumn)
     /// @param target_row_group Target row group with index and row ranges
     /// @param column_indices Leaf column indices to read
     /// @param arrow_schema The target Arrow schema for output columns
@@ -56,7 +58,7 @@ class PageFilteredRowGroupReader {
     /// @param max_chunksize Per-batch row cap for the returned reader.
     /// @return A RecordBatchReader streaming the filtered rows.
     static Result<std::unique_ptr<arrow::RecordBatchReader>> ReadFilteredRowGroup(
-        ::parquet::ParquetFileReader* parquet_reader, const TargetRowGroup& target_row_group,
+        ::parquet::arrow::FileReader* arrow_file_reader, const TargetRowGroup& target_row_group,
         const std::vector<int32_t>& column_indices,
         const std::shared_ptr<arrow::Schema>& arrow_schema,
         const ::arrow::io::CacheOptions& cache_options, bool pre_buffered,
@@ -91,6 +93,40 @@ class PageFilteredRowGroupReader {
         const std::shared_ptr<::parquet::internal::RecordReader>& record_reader,
         const RowRanges& ranges, int64_t total_row_count, int32_t row_group_index,
         int32_t column_index);
+
+    /// Read a leaf column and return both the array and the RecordReader.
+    /// The RecordReader is kept alive so callers can access def/rep levels
+    /// for nested array assembly. When enable_page_filter is true,
+    /// data_page_filter + compressed ranges are used for I/O-level page skipping
+    /// (for flat top-level columns). When false, only decode-level skipping
+    /// is used (for leaf columns within nested types, to preserve def/rep
+    /// level synchronization).
+    static Result<std::pair<std::shared_ptr<arrow::ChunkedArray>,
+                            std::shared_ptr<::parquet::internal::RecordReader>>>
+    ReadLeafColumn(const std::shared_ptr<::parquet::RowGroupReader>& row_group_reader,
+                   ::parquet::ParquetFileReader* parquet_reader,
+                   const std::shared_ptr<::parquet::RowGroupPageIndexReader>& rg_page_index_reader,
+                   int32_t row_group_index, int32_t column_index, const RowRanges& row_ranges,
+                   const std::shared_ptr<arrow::Field>& field, int64_t row_group_row_count,
+                   bool enable_page_filter, std::shared_ptr<::arrow::MemoryPool> pool);
+
+    /// Read a single top-level field (which may be flat or nested) and assemble
+    /// the result array. For flat/leaf fields, delegates to ReadFilteredColumn with
+    /// data_page_filter + compressed ranges. For nested fields (Struct, List, Map),
+    /// reads all leaf columns via RecordReaders (without data_page_filter), then
+    /// manually assembles the nested array using def/rep levels — mimicking
+    /// StructReader::BuildArray and ListReader::BuildArray.
+    static Result<std::pair<std::shared_ptr<arrow::ChunkedArray>,
+                            std::shared_ptr<::parquet::internal::RecordReader>>>
+    ReadAndAssembleField(
+        const ::parquet::arrow::SchemaField& schema_field,
+        ::parquet::ParquetFileReader* parquet_reader,
+        const std::shared_ptr<::parquet::RowGroupReader>& row_group_reader,
+        const std::shared_ptr<::parquet::RowGroupPageIndexReader>& rg_page_index_reader,
+        int32_t row_group_index, const std::vector<int32_t>& column_indices,
+        const RowRanges& row_ranges, const std::shared_ptr<arrow::Field>& field,
+        int64_t row_group_row_count, int64_t expected_rows,
+        std::shared_ptr<::arrow::MemoryPool> pool, bool is_top_level = true);
 
     /// Create a data_page_filter callback for a column based on RowRanges + OffsetIndex.
     static std::function<bool(const ::parquet::DataPageStats&)> MakePageFilter(

--- a/src/paimon/format/parquet/page_filtered_row_group_reader.h
+++ b/src/paimon/format/parquet/page_filtered_row_group_reader.h
@@ -111,11 +111,6 @@ class PageFilteredRowGroupReader {
 
     /// Read a leaf column and return both the array and the RecordReader.
     /// The RecordReader is kept alive so callers can access def/rep levels
-    /// for nested array assembly. When enable_page_filter is true,
-    /// data_page_filter + compressed ranges are used for I/O-level page skipping
-    /// (for flat top-level columns). When false, only decode-level skipping
-    /// is used (for leaf columns within nested types, to preserve def/rep
-    /// level synchronization).
     static Result<std::pair<std::shared_ptr<arrow::ChunkedArray>,
                             std::shared_ptr<::parquet::internal::RecordReader>>>
     ReadLeafColumn(const std::shared_ptr<::parquet::RowGroupReader>& row_group_reader,

--- a/src/paimon/format/parquet/page_filtered_row_group_reader.h
+++ b/src/paimon/format/parquet/page_filtered_row_group_reader.h
@@ -20,6 +20,7 @@
 #include <functional>
 #include <limits>
 #include <memory>
+#include <set>
 #include <vector>
 
 #include "arrow/io/caching.h"
@@ -71,6 +72,20 @@ class PageFilteredRowGroupReader {
     /// Falls back to entire column chunk range if OffsetIndex is unavailable.
     static std::vector<::arrow::io::ReadRange> ComputePageRanges(
         ::parquet::ParquetFileReader* parquet_reader, const TargetRowGroup& target_row_group,
+        const std::vector<int32_t>& column_indices);
+
+    /// Recursively build a projected Arrow field from a SchemaField, including only
+    /// leaf columns that are in column_indices. Returns nullptr if no leaves are
+    /// included. This enables sub-column projection (e.g., reading only struct<x>
+    /// from a struct<x, y> field).
+    static std::shared_ptr<arrow::Field> BuildProjectedField(
+        const ::parquet::arrow::SchemaField& schema_field, const std::set<int32_t>& column_indices);
+
+    /// Build the projected Arrow schema for page-filtered reading. Groups leaf
+    /// column indices into top-level fields via SchemaManifest, then projects
+    /// each field to include only requested sub-columns.
+    static Result<std::shared_ptr<arrow::Schema>> BuildProjectedSchema(
+        ::parquet::arrow::FileReader* arrow_file_reader,
         const std::vector<int32_t>& column_indices);
 
  private:

--- a/src/paimon/format/parquet/page_filtered_row_group_reader_test.cpp
+++ b/src/paimon/format/parquet/page_filtered_row_group_reader_test.cpp
@@ -44,6 +44,7 @@
 #include "paimon/status.h"
 #include "paimon/testing/utils/read_result_collector.h"
 #include "paimon/testing/utils/testharness.h"
+#include "paimon/utils/roaring_bitmap32.h"
 #include "parquet/arrow/reader.h"
 #include "parquet/file_reader.h"
 #include "parquet/properties.h"
@@ -873,34 +874,32 @@ TEST_F(PageFilteredRowGroupReaderTest, ComputePageRangesWithDictionaryEncoding) 
     auto partial_concat = arrow::Concatenate(result_partial->chunks()).ValueOrDie();
     ASSERT_TRUE(partial_concat->Equals(expected_struct));
 }
-/// Helper: build a StructArray with a top-level int32 "id" column and a nested struct column
-/// "info" containing two int32 fields: "x" and "y".
-/// id[i] = i, info.x[i] = i * 100, info.y[i] = i * 100 + 1, for i in [0, N).
-///
-/// Arrow schema: { id: int32, info: struct<x: int32, y: int32> }
-/// Parquet leaf columns: [id (index 0), info.x (index 1), info.y (index 2)]
-static std::shared_ptr<arrow::StructArray> MakeNestedStructData(int32_t num_rows) {
-    arrow::Int32Builder id_builder, x_builder, y_builder;
+/// Helper: build an Int32Array with sequential values 0..N-1.
+static std::shared_ptr<arrow::Array> MakeIdColumn(int32_t num_rows) {
+    arrow::Int32Builder id_builder;
     EXPECT_TRUE(id_builder.Reserve(num_rows).ok());
+    for (int32_t i = 0; i < num_rows; ++i) {
+        id_builder.UnsafeAppend(i);
+    }
+    return id_builder.Finish().ValueOrDie();
+}
+
+/// Helper: build a struct<x: int32, y: int32> array (without id column).
+/// x[i] = i * 100, y[i] = i * 100 + 1, for i in [0, N).
+static std::shared_ptr<arrow::StructArray> MakeNestedStructData(int32_t num_rows) {
+    arrow::Int32Builder x_builder, y_builder;
     EXPECT_TRUE(x_builder.Reserve(num_rows).ok());
     EXPECT_TRUE(y_builder.Reserve(num_rows).ok());
     for (int32_t i = 0; i < num_rows; ++i) {
-        id_builder.UnsafeAppend(i);
         x_builder.UnsafeAppend(i * 100);
         y_builder.UnsafeAppend(i * 100 + 1);
     }
-    auto id_array = id_builder.Finish().ValueOrDie();
     auto x_array = x_builder.Finish().ValueOrDie();
     auto y_array = y_builder.Finish().ValueOrDie();
 
     auto field_x = arrow::field("x", arrow::int32());
     auto field_y = arrow::field("y", arrow::int32());
-    auto inner_struct =
-        arrow::StructArray::Make({x_array, y_array}, {field_x, field_y}).ValueOrDie();
-
-    auto field_id = arrow::field("id", arrow::int32());
-    auto field_info = arrow::field("info", arrow::struct_({field_x, field_y}));
-    return arrow::StructArray::Make({id_array, inner_struct}, {field_id, field_info}).ValueOrDie();
+    return arrow::StructArray::Make({x_array, y_array}, {field_x, field_y}).ValueOrDie();
 }
 
 /// Test: rowgroup-level filtering on a file with nested struct columns.
@@ -916,13 +915,19 @@ static std::shared_ptr<arrow::StructArray> MakeNestedStructData(int32_t num_rows
 /// The read schema requests both "id" and "info" columns.
 TEST_F(PageFilteredRowGroupReaderTest, NestedStructColumnRowGroupFilter) {
     std::string file_name = dir_->Str() + "/nested_struct_filter.parquet";
-    auto data = MakeNestedStructData(100);
-    WriteTestFile(file_name, data, /*write_batch_size=*/10, /*max_row_group_length=*/50);
 
     auto field_x = arrow::field("x", arrow::int32());
     auto field_y = arrow::field("y", arrow::int32());
-    auto read_schema = arrow::schema({arrow::field("id", arrow::int32()),
-                                      arrow::field("info", arrow::struct_({field_x, field_y}))});
+    auto field_id = arrow::field("id", arrow::int32());
+    auto field_info = arrow::field("info", arrow::struct_({field_x, field_y}));
+
+    auto id_array = MakeIdColumn(100);
+    auto info_array = MakeNestedStructData(100);
+    auto data = arrow::StructArray::Make({id_array, info_array}, {field_id, field_info})
+                    .ValueOrDie();
+    WriteTestFile(file_name, data, /*write_batch_size=*/10, /*max_row_group_length=*/50);
+
+    auto read_schema = arrow::schema({field_id, field_info});
 
     auto predicate = PredicateBuilder::GreaterOrEqual(
         /*field_index=*/0, /*field_name=*/"id", FieldType::INT, Literal(70));
@@ -949,13 +954,18 @@ TEST_F(PageFilteredRowGroupReaderTest, NestedStructColumnRowGroupFilter) {
 /// Predicate on "id": id >= 70.
 TEST_F(PageFilteredRowGroupReaderTest, NestedStructColumnOnlyReadIdField) {
     std::string file_name = dir_->Str() + "/nested_struct_only_nested.parquet";
-    auto data = MakeNestedStructData(100);
-    WriteTestFile(file_name, data, /*write_batch_size=*/10, /*max_row_group_length=*/50);
 
-    auto field_id = arrow::field("id", arrow::int32());
     auto field_x = arrow::field("x", arrow::int32());
     auto field_y = arrow::field("y", arrow::int32());
+    auto field_id = arrow::field("id", arrow::int32());
     auto field_info = arrow::field("info", arrow::struct_({field_x, field_y}));
+
+    auto id_array = MakeIdColumn(100);
+    auto info_array = MakeNestedStructData(100);
+    auto data = arrow::StructArray::Make({id_array, info_array}, {field_id, field_info})
+                    .ValueOrDie();
+    WriteTestFile(file_name, data, /*write_batch_size=*/10, /*max_row_group_length=*/50);
+
     // Read "id" column only
     auto read_schema = arrow::schema({field_id});
 
@@ -975,19 +985,9 @@ TEST_F(PageFilteredRowGroupReaderTest, NestedStructColumnOnlyReadIdField) {
     ASSERT_TRUE(data->field(0)->Slice(70, 30)->Equals(result_struct->field(0)));
 }
 
-/// Helper: build a StructArray with an int32 "id" column and a list<int32> "tags" column.
-/// id[i] = i, tags[i] = [i*10, i*10+1], for i in [0, N).
-///
-/// Arrow schema: { id: int32, tags: list<item: int32> }
-/// Parquet leaf columns: [id (index 0), tags.item (index 1)]
-static std::shared_ptr<arrow::StructArray> MakeListColumnData(int32_t num_rows) {
-    arrow::Int32Builder id_builder;
-    EXPECT_TRUE(id_builder.Reserve(num_rows).ok());
-    for (int32_t i = 0; i < num_rows; ++i) {
-        id_builder.UnsafeAppend(i);
-    }
-    auto id_array = id_builder.Finish().ValueOrDie();
-
+/// Helper: build a list<item: int32> array (without id column).
+/// tags[i] = [i*10, i*10+1], for i in [0, N).
+static std::shared_ptr<arrow::Array> MakeListColumnData(int32_t num_rows) {
     auto value_builder = std::make_shared<arrow::Int32Builder>();
     arrow::ListBuilder list_builder(arrow::default_memory_pool(), value_builder);
     for (int32_t i = 0; i < num_rows; ++i) {
@@ -995,26 +995,12 @@ static std::shared_ptr<arrow::StructArray> MakeListColumnData(int32_t num_rows) 
         EXPECT_TRUE(value_builder->Append(i * 10).ok());
         EXPECT_TRUE(value_builder->Append(i * 10 + 1).ok());
     }
-    auto list_array = list_builder.Finish().ValueOrDie();
-
-    auto field_id = arrow::field("id", arrow::int32());
-    auto field_tags = arrow::field("tags", arrow::list(arrow::field("item", arrow::int32())));
-    return arrow::StructArray::Make({id_array, list_array}, {field_id, field_tags}).ValueOrDie();
+    return list_builder.Finish().ValueOrDie();
 }
 
-/// Helper: build a StructArray with an int32 "id" column and a map<utf8, int32> "props" column.
-/// id[i] = i, props[i] = {"k_i": i * 100}, for i in [0, N).
-///
-/// Arrow schema: { id: int32, props: map<utf8, int32> }
-/// Parquet leaf columns: [id (index 0), props.key (index 1), props.value (index 2)]
-static std::shared_ptr<arrow::StructArray> MakeMapColumnData(int32_t num_rows) {
-    arrow::Int32Builder id_builder;
-    EXPECT_TRUE(id_builder.Reserve(num_rows).ok());
-    for (int32_t i = 0; i < num_rows; ++i) {
-        id_builder.UnsafeAppend(i);
-    }
-    auto id_array = id_builder.Finish().ValueOrDie();
-
+/// Helper: build a map<utf8, int32> array (without id column).
+/// props[i] = {"k_i": i * 100}, for i in [0, N).
+static std::shared_ptr<arrow::Array> MakeMapColumnData(int32_t num_rows) {
     auto key_builder = std::make_shared<arrow::StringBuilder>();
     auto value_builder = std::make_shared<arrow::Int32Builder>();
     arrow::MapBuilder map_builder(arrow::default_memory_pool(), key_builder, value_builder);
@@ -1024,11 +1010,7 @@ static std::shared_ptr<arrow::StructArray> MakeMapColumnData(int32_t num_rows) {
         EXPECT_TRUE(key_builder->Append(key).ok());
         EXPECT_TRUE(value_builder->Append(i * 100).ok());
     }
-    auto map_array = map_builder.Finish().ValueOrDie();
-
-    auto field_id = arrow::field("id", arrow::int32());
-    auto field_props = arrow::field("props", arrow::map(arrow::utf8(), arrow::int32()));
-    return arrow::StructArray::Make({id_array, map_array}, {field_id, field_props}).ValueOrDie();
+    return map_builder.Finish().ValueOrDie();
 }
 
 /// Test: rowgroup-level filtering on a file with a list column.
@@ -1038,12 +1020,17 @@ static std::shared_ptr<arrow::StructArray> MakeMapColumnData(int32_t num_rows) {
 /// Predicate: id >= 70 → row groups 0 skipped, row groups 1 read → 50 rows expected.
 TEST_F(PageFilteredRowGroupReaderTest, NestedListColumnRowGroupFilter) {
     std::string file_name = dir_->Str() + "/nested_list_filter.parquet";
-    auto data = MakeListColumnData(100);
+
+    auto field_id = arrow::field("id", arrow::int32());
+    auto field_tags = arrow::field("tags", arrow::list(arrow::field("item", arrow::int32())));
+
+    auto id_array = MakeIdColumn(100);
+    auto tags_array = MakeListColumnData(100);
+    auto data = arrow::StructArray::Make({id_array, tags_array}, {field_id, field_tags})
+                    .ValueOrDie();
     WriteTestFile(file_name, data, /*write_batch_size=*/10, /*max_row_group_length=*/50);
 
-    auto read_schema =
-        arrow::schema({arrow::field("id", arrow::int32()),
-                       arrow::field("tags", arrow::list(arrow::field("item", arrow::int32())))});
+    auto read_schema = arrow::schema({field_id, field_tags});
 
     auto predicate = PredicateBuilder::GreaterOrEqual(
         /*field_index=*/0, /*field_name=*/"id", FieldType::INT, Literal(70));
@@ -1066,12 +1053,17 @@ TEST_F(PageFilteredRowGroupReaderTest, NestedListColumnRowGroupFilter) {
 /// Predicate: id >= 70 → row groups 0 skipped, row groups 1 read → 50 rows expected.
 TEST_F(PageFilteredRowGroupReaderTest, NestedMapColumnRowGroupFilter) {
     std::string file_name = dir_->Str() + "/nested_map_filter.parquet";
-    auto data = MakeMapColumnData(100);
+
+    auto field_id = arrow::field("id", arrow::int32());
+    auto field_props = arrow::field("props", arrow::map(arrow::utf8(), arrow::int32()));
+
+    auto id_array = MakeIdColumn(100);
+    auto props_array = MakeMapColumnData(100);
+    auto data = arrow::StructArray::Make({id_array, props_array}, {field_id, field_props})
+                    .ValueOrDie();
     WriteTestFile(file_name, data, /*write_batch_size=*/10, /*max_row_group_length=*/50);
 
-    auto read_schema =
-        arrow::schema({arrow::field("id", arrow::int32()),
-                       arrow::field("props", arrow::map(arrow::utf8(), arrow::int32()))});
+    auto read_schema = arrow::schema({field_id, field_props});
 
     auto predicate = PredicateBuilder::GreaterOrEqual(
         /*field_index=*/0, /*field_name=*/"id", FieldType::INT, Literal(70));
@@ -1095,35 +1087,16 @@ TEST_F(PageFilteredRowGroupReaderTest, NestedMapColumnRowGroupFilter) {
 TEST_F(PageFilteredRowGroupReaderTest, MultipleAdjacentNestedColumns) {
     std::string file_name = dir_->Str() + "/multi_nested.parquet";
 
-    // Build data with id, info (struct), tags (list)
-    arrow::Int32Builder id_builder, x_builder, y_builder;
-    ASSERT_TRUE(id_builder.Reserve(100).ok());
-    ASSERT_TRUE(x_builder.Reserve(100).ok());
-    ASSERT_TRUE(y_builder.Reserve(100).ok());
-    auto value_builder = std::make_shared<arrow::Int32Builder>();
-    arrow::ListBuilder list_builder(arrow::default_memory_pool(), value_builder);
-
-    for (int32_t i = 0; i < 100; ++i) {
-        id_builder.UnsafeAppend(i);
-        x_builder.UnsafeAppend(i * 100);
-        y_builder.UnsafeAppend(i * 100 + 1);
-        ASSERT_TRUE(list_builder.Append().ok());
-        ASSERT_TRUE(value_builder->Append(i * 10).ok());
-    }
-    auto id_array = id_builder.Finish().ValueOrDie();
-    auto x_array = x_builder.Finish().ValueOrDie();
-    auto y_array = y_builder.Finish().ValueOrDie();
-    auto list_array = list_builder.Finish().ValueOrDie();
-
     auto field_x = arrow::field("x", arrow::int32());
     auto field_y = arrow::field("y", arrow::int32());
-    auto inner_struct =
-        arrow::StructArray::Make({x_array, y_array}, {field_x, field_y}).ValueOrDie();
-
     auto field_id = arrow::field("id", arrow::int32());
     auto field_info = arrow::field("info", arrow::struct_({field_x, field_y}));
     auto field_tags = arrow::field("tags", arrow::list(arrow::field("item", arrow::int32())));
-    auto data = arrow::StructArray::Make({id_array, inner_struct, list_array},
+
+    auto id_array = MakeIdColumn(100);
+    auto info_array = MakeNestedStructData(100);
+    auto tags_array = MakeListColumnData(100);
+    auto data = arrow::StructArray::Make({id_array, info_array, tags_array},
                                          {field_id, field_info, field_tags})
                     .ValueOrDie();
 
@@ -1142,6 +1115,66 @@ TEST_F(PageFilteredRowGroupReaderTest, MultipleAdjacentNestedColumns) {
     // Build expected result: rows 50-99 from the original data
     auto expected = data->Slice(70, 30);
     ASSERT_TRUE(expected->Equals(result->chunk(0)));
+}
+
+/// Test: predicate pushdown with all nested column types (struct, list, map).
+///
+/// Schema: { id: int32, info: struct<x: int32, y: int32>,
+///           tags: list<item: int32>, props: map<utf8, int32> }
+/// 100 rows, 10 rows per page, 50 rows per row group → 2 row groups.
+/// Predicate: id in [15, 29] or id in [80, 99] (Between is inclusive).
+/// Read schema: full schema (all columns).
+/// Page-level filtering (10 rows/page):
+///   Between(15, 29) → pages 1-2 (rows 10-29)
+///   Between(80, 99) → pages 8-9 (rows 80-99)
+///   Total: 40 rows.
+TEST_F(PageFilteredRowGroupReaderTest, MultipleNestedColumns) {
+    std::string file_name = dir_->Str() + "/multi_nested_columns.parquet";
+
+    auto field_x = arrow::field("x", arrow::int32());
+    auto field_y = arrow::field("y", arrow::int32());
+    auto field_id = arrow::field("id", arrow::int32());
+    auto field_info = arrow::field("info", arrow::struct_({field_x, field_y}));
+    auto field_tags = arrow::field("tags", arrow::list(arrow::field("item", arrow::int32())));
+    auto field_props = arrow::field("props", arrow::map(arrow::utf8(), arrow::int32()));
+
+    // Build data with all nested column types using shared helpers
+    auto id_array = MakeIdColumn(100);
+    auto info_array = MakeNestedStructData(100);
+    auto tags_array = MakeListColumnData(100);
+    auto props_array = MakeMapColumnData(100);
+    auto data = arrow::StructArray::Make({id_array, info_array, tags_array, props_array},
+                                         {field_id, field_info, field_tags, field_props})
+                    .ValueOrDie();
+
+    // Write: 10 rows per page, 50 rows per row group → 2 row groups
+    WriteTestFile(file_name, data, /*write_batch_size=*/10, /*max_row_group_length=*/50);
+
+    // Read full schema
+    auto read_schema = arrow::schema({field_id, field_info, field_tags, field_props});
+
+    // predicate: id in [15, 29] or id in [80, 99]
+    ASSERT_OK_AND_ASSIGN(
+        auto predicate,
+        PredicateBuilder::Or({PredicateBuilder::Between(/*field_index=*/0, /*field_name=*/"id",
+                                                        FieldType::INT, Literal(15), Literal(29)),
+                              PredicateBuilder::Between(/*field_index=*/0, /*field_name=*/"id",
+                                                        FieldType::INT, Literal(80), Literal(99))}));
+
+    std::shared_ptr<arrow::ChunkedArray> result;
+    ReadWithPredicateImpl(file_name, read_schema, predicate, &result,
+                          /*batch_size=*/1024);
+
+    // Page-level filtering (10 rows/page):
+    //   Between(15, 29) → pages 1-2 (rows 10-29)
+    //   Between(80, 99) → pages 8-9 (rows 80-99)
+    //   Total: 40 rows
+    ASSERT_TRUE(result);
+    ASSERT_EQ(40, result->length());
+
+    auto expected =
+        arrow::ChunkedArray::Make({data->Slice(10, 20), data->Slice(80, 20)}).ValueOrDie();
+    ASSERT_TRUE(result->Equals(expected));
 }
 
 }  // namespace paimon::parquet::test

--- a/src/paimon/format/parquet/page_filtered_row_group_reader_test.cpp
+++ b/src/paimon/format/parquet/page_filtered_row_group_reader_test.cpp
@@ -923,8 +923,8 @@ TEST_F(PageFilteredRowGroupReaderTest, NestedStructColumnRowGroupFilter) {
 
     auto id_array = MakeIdColumn(100);
     auto info_array = MakeNestedStructData(100);
-    auto data = arrow::StructArray::Make({id_array, info_array}, {field_id, field_info})
-                    .ValueOrDie();
+    auto data =
+        arrow::StructArray::Make({id_array, info_array}, {field_id, field_info}).ValueOrDie();
     WriteTestFile(file_name, data, /*write_batch_size=*/10, /*max_row_group_length=*/50);
 
     auto read_schema = arrow::schema({field_id, field_info});
@@ -962,8 +962,8 @@ TEST_F(PageFilteredRowGroupReaderTest, NestedStructColumnOnlyReadIdField) {
 
     auto id_array = MakeIdColumn(100);
     auto info_array = MakeNestedStructData(100);
-    auto data = arrow::StructArray::Make({id_array, info_array}, {field_id, field_info})
-                    .ValueOrDie();
+    auto data =
+        arrow::StructArray::Make({id_array, info_array}, {field_id, field_info}).ValueOrDie();
     WriteTestFile(file_name, data, /*write_batch_size=*/10, /*max_row_group_length=*/50);
 
     // Read "id" column only
@@ -1026,8 +1026,8 @@ TEST_F(PageFilteredRowGroupReaderTest, NestedListColumnRowGroupFilter) {
 
     auto id_array = MakeIdColumn(100);
     auto tags_array = MakeListColumnData(100);
-    auto data = arrow::StructArray::Make({id_array, tags_array}, {field_id, field_tags})
-                    .ValueOrDie();
+    auto data =
+        arrow::StructArray::Make({id_array, tags_array}, {field_id, field_tags}).ValueOrDie();
     WriteTestFile(file_name, data, /*write_batch_size=*/10, /*max_row_group_length=*/50);
 
     auto read_schema = arrow::schema({field_id, field_tags});
@@ -1059,8 +1059,8 @@ TEST_F(PageFilteredRowGroupReaderTest, NestedMapColumnRowGroupFilter) {
 
     auto id_array = MakeIdColumn(100);
     auto props_array = MakeMapColumnData(100);
-    auto data = arrow::StructArray::Make({id_array, props_array}, {field_id, field_props})
-                    .ValueOrDie();
+    auto data =
+        arrow::StructArray::Make({id_array, props_array}, {field_id, field_props}).ValueOrDie();
     WriteTestFile(file_name, data, /*write_batch_size=*/10, /*max_row_group_length=*/50);
 
     auto read_schema = arrow::schema({field_id, field_props});
@@ -1155,11 +1155,11 @@ TEST_F(PageFilteredRowGroupReaderTest, MultipleNestedColumns) {
 
     // predicate: id in [15, 29] or id in [80, 99]
     ASSERT_OK_AND_ASSIGN(
-        auto predicate,
-        PredicateBuilder::Or({PredicateBuilder::Between(/*field_index=*/0, /*field_name=*/"id",
-                                                        FieldType::INT, Literal(15), Literal(29)),
-                              PredicateBuilder::Between(/*field_index=*/0, /*field_name=*/"id",
-                                                        FieldType::INT, Literal(80), Literal(99))}));
+        auto predicate, PredicateBuilder::Or(
+                            {PredicateBuilder::Between(/*field_index=*/0, /*field_name=*/"id",
+                                                       FieldType::INT, Literal(15), Literal(29)),
+                             PredicateBuilder::Between(/*field_index=*/0, /*field_name=*/"id",
+                                                       FieldType::INT, Literal(80), Literal(99))}));
 
     std::shared_ptr<arrow::ChunkedArray> result;
     ReadWithPredicateImpl(file_name, read_schema, predicate, &result,

--- a/src/paimon/format/parquet/page_filtered_row_group_reader_test.cpp
+++ b/src/paimon/format/parquet/page_filtered_row_group_reader_test.cpp
@@ -1177,4 +1177,53 @@ TEST_F(PageFilteredRowGroupReaderTest, MultipleNestedColumns) {
     ASSERT_TRUE(result->Equals(expected));
 }
 
+/// Test: sub-column projection of a struct type with page-level filtering.
+///
+/// Schema: { id: int32, info: struct<x: int32, y: int32> }
+/// Read schema: { info: struct<x: int32> } — project only x, not y.
+/// Predicate: id >= 70 → 30 rows expected.
+/// Verifies that reading a sub-column of a nested struct works correctly
+/// with page-level filtering and the ColumnReader tree (GetColumn + filter_leaves).
+TEST_F(PageFilteredRowGroupReaderTest, NestedStructSubColumnProjection) {
+    std::string file_name = dir_->Str() + "/nested_struct_subcol.parquet";
+
+    auto field_x = arrow::field("x", arrow::int32());
+    auto field_y = arrow::field("y", arrow::int32());
+    auto field_id = arrow::field("id", arrow::int32());
+    auto field_info = arrow::field("info", arrow::struct_({field_x, field_y}));
+
+    auto id_array = MakeIdColumn(100);
+    auto info_array = MakeNestedStructData(100);
+    auto data =
+        arrow::StructArray::Make({id_array, info_array}, {field_id, field_info}).ValueOrDie();
+    WriteTestFile(file_name, data, /*write_batch_size=*/10, /*max_row_group_length=*/50);
+
+    // Read only info.x (sub-column projection: only x, not y)
+    auto read_schema = arrow::schema({arrow::field("info", arrow::struct_({field_x}))});
+
+    auto predicate = PredicateBuilder::GreaterOrEqual(
+        /*field_index=*/0, /*field_name=*/"id", FieldType::INT, Literal(70));
+
+    std::shared_ptr<arrow::ChunkedArray> result;
+    ReadWithPredicateImpl(file_name, read_schema, predicate, &result);
+
+    ASSERT_TRUE(result);
+    ASSERT_EQ(30, result->length());
+
+    // Result is struct<info: struct<x: int32>>
+    auto result_struct = std::dynamic_pointer_cast<arrow::StructArray>(result->chunk(0));
+    ASSERT_TRUE(result_struct);
+    ASSERT_EQ(1, result_struct->num_fields());
+
+    auto info_result = std::dynamic_pointer_cast<arrow::StructArray>(result_struct->field(0));
+    ASSERT_TRUE(info_result);
+    ASSERT_EQ(1, info_result->num_fields());
+
+    auto x_arr = std::dynamic_pointer_cast<arrow::Int32Array>(info_result->field(0));
+    ASSERT_TRUE(x_arr);
+    for (int32_t i = 0; i < 30; ++i) {
+        ASSERT_EQ((70 + i) * 100, x_arr->Value(i)) << "Mismatch at index " << i;
+    }
+}
+
 }  // namespace paimon::parquet::test

--- a/src/paimon/format/parquet/page_filtered_row_group_reader_test.cpp
+++ b/src/paimon/format/parquet/page_filtered_row_group_reader_test.cpp
@@ -932,10 +932,10 @@ TEST_F(PageFilteredRowGroupReaderTest, NestedStructColumnRowGroupFilter) {
 
     // Should get rows 50-99 = 50 rows
     ASSERT_TRUE(result);
-    ASSERT_EQ(50, result->length());
+    ASSERT_EQ(30, result->length());
 
     // Build expected result: rows 50-99 from the original data
-    auto expected = data->Slice(50, 50);
+    auto expected = data->Slice(70, 30);
     ASSERT_TRUE(expected->Equals(result->chunk(0)));
 }
 
@@ -1052,10 +1052,10 @@ TEST_F(PageFilteredRowGroupReaderTest, NestedListColumnRowGroupFilter) {
     ReadWithPredicateImpl(file_name, read_schema, predicate, &result);
 
     ASSERT_TRUE(result);
-    ASSERT_EQ(50, result->length());
+    ASSERT_EQ(30, result->length());
 
     // Build expected result: rows 50-99 from the original data
-    auto expected = data->Slice(50, 50);
+    auto expected = data->Slice(70, 30);
     ASSERT_TRUE(expected->Equals(result->chunk(0)));
 }
 
@@ -1080,10 +1080,10 @@ TEST_F(PageFilteredRowGroupReaderTest, NestedMapColumnRowGroupFilter) {
     ReadWithPredicateImpl(file_name, read_schema, predicate, &result);
 
     ASSERT_TRUE(result);
-    ASSERT_EQ(50, result->length());
+    ASSERT_EQ(30, result->length());
 
     // Build expected result: rows 50-99 from the original data
-    auto expected = data->Slice(50, 50);
+    auto expected = data->Slice(70, 30);
     ASSERT_TRUE(expected->Equals(result->chunk(0)));
 }
 
@@ -1137,10 +1137,10 @@ TEST_F(PageFilteredRowGroupReaderTest, MultipleAdjacentNestedColumns) {
     ReadWithPredicateImpl(file_name, read_schema, predicate, &result);
 
     ASSERT_TRUE(result);
-    ASSERT_EQ(50, result->length());
+    ASSERT_EQ(30, result->length());
 
     // Build expected result: rows 50-99 from the original data
-    auto expected = data->Slice(50, 50);
+    auto expected = data->Slice(70, 30);
     ASSERT_TRUE(expected->Equals(result->chunk(0)));
 }
 

--- a/src/paimon/format/parquet/parquet_file_batch_reader.cpp
+++ b/src/paimon/format/parquet/parquet_file_batch_reader.cpp
@@ -134,13 +134,6 @@ Status ParquetFileBatchReader::SetReadSchema(
                                           arrow::ImportSchema(schema));
 
         PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Schema> file_schema, reader_->GetSchema());
-        bool has_nested_field = false;
-        for (const auto& field : read_schema->fields()) {
-            if (ArrowSchemaValidator::IsNestedType(field->type())) {
-                has_nested_field = true;
-                break;
-            }
-        }
 
         // Recursively match read_schema against file_schema by field names.
         // STRUCT supports sub-field projection; LIST/MAP require exact type match.
@@ -178,7 +171,7 @@ Status ParquetFileBatchReader::SetReadSchema(
                                                     DEFAULT_PARQUET_READ_ENABLE_PAGE_INDEX_FILTER));
             // walkaround: page index filter does not support nested fields for now, skip page index
             // filter if there is any nested field in the schema
-            if (enable_page_index_filter && !has_nested_field) {
+            if (enable_page_index_filter) {
                 // Build column name to index map for page-level filtering.
                 // For leaf columns, indices[0] is the correct leaf column index in Parquet.
                 // For nested types (struct/list/map), FlattenSchema produces multiple leaf indices,


### PR DESCRIPTION
## feat: support page index filter for nested column type

### Purpose

Linked issue: close #xxx

Previously, page index filtering was only applied to flat (scalar) columns. When the read schema contained any nested field (struct, list, or map), the entire page index filter was disabled as a workaround (`has_nested_field` check in `ParquetFileBatchReader::SetReadSchema`), causing nested columns to fall back to rowgroup-level filtering only and miss fine-grained page-level I/O skipping.

This PR extends page index filtering to nested column types by implementing nested array assembly on the Paimon side. The core idea is to read each top-level field (flat or nested) via its leaf `RecordReader`s, then manually assemble the nested Arrow array using def/rep levels — mimicking Arrow's `StructReader::BuildArray` and `ListReader::BuildArray` logic.

Key implementation changes:

1. **`PageFilteredRowGroupReader`**: The `ReadFilteredRowGroup` entry point now accepts `parquet::arrow::FileReader*` (instead of `ParquetFileReader*`) to access `SchemaManifest`. Leaf column indices are grouped into top-level fields via `SchemaManifest::GetFieldIndices`, and each field is read through the new `ReadAndAssembleField` method.

2. **`ReadAndAssembleField`** (new): Recursively reads a top-level field and assembles the result array:
   - **Leaf fields**: Delegates to `ReadLeafColumn`. Top-level leaf columns get `data_page_filter` + compressed ranges for I/O-level page skipping. Leaf columns within nested types skip `data_page_filter` (to preserve def/rep level synchronization across sibling leaves) and rely on decode-level skipping only.
   - **Struct fields**: Reads all requested child fields recursively, then builds the validity bitmap from def levels using `DefLevelsToBitmap` (or `DefRepLevelsToBitmap` if a repeated descendant exists).
   - **List/Map fields**: Reads the child field, then builds offsets and validity from def/rep levels using `DefRepLevelsToList`. Map is handled as `list<struct<key, value>>` per Parquet's storage model.

3. **`BuildProjectedField` / `BuildProjectedSchema`** (new): Recursively builds a projected Arrow schema from `SchemaField` trees, including only requested leaf columns. This enables sub-column projection (e.g., reading only `struct<x>` from `struct<x, y>`).

4. **`ReadLeafColumn`** (refactored from `ReadFilteredColumn`): Returns both the `ChunkedArray` and the `RecordReader` so callers can access def/rep levels for nested array assembly. The `enable_page_filter` flag controls whether I/O-level page skipping is applied.

5. **`FileReaderWrapper`**: Removes `BuildPageFilteredSchema` and `page_filtered_read_schema_` construction logic — schema projection is now delegated to `PageFilteredRowGroupReader::BuildProjectedSchema`.

6. **`ParquetFileBatchReader`**: Removes the `has_nested_field` check that previously disabled page index filter for nested fields.

### Tests

UT — `PageFilteredRowGroupReaderTest` (`src/paimon/format/parquet/page_filtered_row_group_reader_test.cpp`):
- `NestedStructColumnRowGroupFilter` — rowgroup-level filtering on struct columns (fixed expected row count: 50 → 30, since page-level filtering now correctly applies)
- `NestedStructColumnOnlyReadIdField` — reading only the flat `id` field from a file with nested struct
- `NestedListColumnRowGroupFilter` — rowgroup-level filtering on list column (fixed expected row count)
- `NestedMapColumnRowGroupFilter` — rowgroup-level filtering on map column (fixed expected row count)
- `MultipleAdjacentNestedColumns` — multiple adjacent nested columns (fixed expected row count)
- `MultipleNestedColumns` (new) — predicate pushdown with all nested types (struct, list, map) and page-level filtering across multiple row groups
- `NestedStructSubColumnProjection` (new) — sub-column projection of a struct type (`struct<x>` from `struct<x, y>`) with page-level filtering

Test helper functions were refactored for reusability: `MakeIdColumn`, `MakeNestedStructData`, `MakeListColumnData`, and `MakeMapColumnData` now each build a single column (instead of wrapping with an `id` column), allowing flexible composition across test cases.

### API and Format

- **Internal API change**: `PageFilteredRowGroupReader::ReadFilteredRowGroup` signature changed — now takes `parquet::arrow::FileReader*` instead of `parquet::ParquetFileReader*`. This is an internal API (not in `include/`).
- **Internal API change**: `FileReaderWrapper::BuildPageFilteredSchema` is removed; schema projection is now handled by `PageFilteredRowGroupReader::BuildProjectedSchema`.
- No changes to Paimon's public API in `include/`.
- No storage format or protocol changes.
- No Arrow dependency patch changes.

### Documentation

No new user-facing feature documentation needed — this is an internal performance optimization that is transparent to users.

### Generative AI tooling

Generated-by: GLM 5.2
