### PR TITLE
fix(build): disable glog unwind without libunwind

### DIFF
--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -1809,6 +1809,8 @@ endmacro()
 
 macro(build_glog)
     message(STATUS "Building glog from source")
+    find_library(LIBUNWIND_LIBRARY NAMES unwind)
+
     set(GLOG_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/glog_ep-install")
     set(GLOG_INCLUDE_DIR "${GLOG_PREFIX}/include")
     if(${UPPERCASE_BUILD_TYPE} STREQUAL "DEBUG")
@@ -1831,6 +1833,9 @@ macro(build_glog)
         -DWITH_GTEST=OFF
         -DCMAKE_CXX_FLAGS=${GLOG_CMAKE_CXX_FLAGS}
         -DCMAKE_C_FLAGS=${GLOG_CMAKE_C_FLAGS})
+    if(NOT LIBUNWIND_LIBRARY)
+        list(APPEND GLOG_CMAKE_ARGS -DWITH_UNWIND=none)
+    endif()
 
     externalproject_add(glog_ep
                         URL ${GLOG_SOURCE_URL}
@@ -1848,7 +1853,6 @@ macro(build_glog)
 
     add_dependencies(glog glog_ep)
 
-    find_library(LIBUNWIND_LIBRARY NAMES unwind)
     if(LIBUNWIND_LIBRARY)
         target_link_libraries(glog INTERFACE ${LIBUNWIND_LIBRARY})
     endif()


### PR DESCRIPTION
### Purpose

Linked issue: N/A

This is a follow-up to #60. That change fixed static-link errors in regular configurations by adding a discovered libunwind library to the imported `glog` target's link interface. However, it made that decision after bundled glog had already been configured, so an explicit `LIBUNWIND_LIBRARY=FALSE` setting was not propagated to glog.

A downstream build can explicitly set `-DLIBUNWIND_LIBRARY=FALSE` to prevent paimon-cpp from using or propagating libunwind. Before this change, paimon-cpp skipped adding libunwind to the imported `glog` target, but glog still used its default unwind auto-detection. When libunwind was installed and discoverable by glog's CMake configuration, glog enabled libunwind support and compiled stacktrace code with `unw_*` references.

The inconsistency becomes visible when a downstream application links the resulting static glog library: paimon-cpp does not propagate `-lunwind`, while glog contains calls that require it, which can produce unresolved `unw_*` symbols. Downstream users must then carry a glog-specific patch or otherwise override glog's unwind configuration.

Use the same `LIBUNWIND_LIBRARY` result for both decisions. When libunwind is unavailable or explicitly disabled, pass `-DWITH_UNWIND=none` to bundled glog and omit the libunwind link dependency. Otherwise, retain the existing automatic discovery and linking behavior.

### Tests

- `cmake --build build --target glog_ep -j 4`
- `pre-commit run --files cmake_modules/ThirdpartyToolchain.cmake`
- `git diff --check`

### API and Format

No public API, storage format, or protocol changes.

### Documentation

No documentation changes.

### Generative AI tooling

Generated-by: Codex GPT-5.6 Terra