### PR TITLE
fix(avro): include headers used by file batch reader

### DIFF
--- a/src/paimon/format/avro/avro_file_batch_reader.h
+++ b/src/paimon/format/avro/avro_file_batch_reader.h
@@ -16,12 +16,14 @@
 
 #pragma once
 
+#include <limits>
 #include <memory>
 #include <set>
 #include <utility>
 #include <vector>
 
 #include "avro/DataFile.hh"
+#include "fmt/format.h"
 #include "paimon/format/avro/avro_direct_decoder.h"
 #include "paimon/memory/memory_pool.h"
 #include "paimon/metrics.h"


### PR DESCRIPTION
### Purpose

Linked issue: N/A

Fix `AvroFileBatchReader` header self-containment by including the headers used by its inline `GetPreviousBatchFileRowId` implementation.

### Tests

- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPAIMON_BUILD_TESTS=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5`
- Direct compile of `src/paimon/format/avro/avro_file_batch_reader.cpp` using the generated compile command plus local fmt/Arrow source include paths
- `git diff --check`

Not run:

- `cmake --build build --target paimon_avro_file_format_objlib -j8` was blocked by bundled Arrow dependency download failure: Apache Thrift 0.16.0 mirror URLs returned 404.
- `pre-commit run --files src/paimon/format/avro/avro_file_batch_reader.h` was not run because `pre-commit` is not installed in this environment.

### API and Format

No public API, storage format, or protocol changes.

### Documentation

No user-facing feature or documentation changes.

### Generative AI tooling

Generated-by: OpenAI Codex