### PR TITLE
fix(orc): avoid removed Arrow bitmap append API

### DIFF
--- a/src/paimon/format/orc/orc_adapter.cpp
+++ b/src/paimon/format/orc/orc_adapter.cpp
@@ -144,7 +144,9 @@ class UnPooledBooleanBuilder : public EmptyBuilder {
     }
 
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return arrow::ArrayBuilder::AppendToBitmap(valid_bytes, length);
+        ARROW_RETURN_NOT_OK(this->Reserve(length));
+        this->UnsafeAppendToBitmap(valid_bytes, length);
+        return arrow::Status::OK();
     }
 
     arrow::Status SetData(const uint8_t* data, int64_t length) {
@@ -189,7 +191,9 @@ class UnPooledPrimitiveBuilder : public arrow::NumericBuilder<Type> {
     }
 
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return arrow::ArrayBuilder::AppendToBitmap(valid_bytes, length);
+        ARROW_RETURN_NOT_OK(this->Reserve(length));
+        this->UnsafeAppendToBitmap(valid_bytes, length);
+        return arrow::Status::OK();
     }
 
     arrow::Status FinishInternal(std::shared_ptr<arrow::ArrayData>* out) override {
@@ -230,7 +234,9 @@ class UnPooledLargeBinaryBuilder : public arrow::LargeBinaryBuilder {
         length_ += length;
     }
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return arrow::ArrayBuilder::AppendToBitmap(valid_bytes, length);
+        ARROW_RETURN_NOT_OK(this->Reserve(length));
+        this->UnsafeAppendToBitmap(valid_bytes, length);
+        return arrow::Status::OK();
     }
     arrow::Status FinishInternal(std::shared_ptr<arrow::ArrayData>* out) override {
         std::shared_ptr<arrow::Buffer> null_bitmap;
@@ -275,7 +281,9 @@ class UnPooledBinaryBuilder : public arrow::BinaryBuilder {
     }
 
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return arrow::ArrayBuilder::AppendToBitmap(valid_bytes, length);
+        ARROW_RETURN_NOT_OK(this->Reserve(length));
+        this->UnsafeAppendToBitmap(valid_bytes, length);
+        return arrow::Status::OK();
     }
 
     arrow::Status FinishInternal(std::shared_ptr<arrow::ArrayData>* out) override {
@@ -315,7 +323,9 @@ class UnPooledListBuilder : public EmptyBuilder {
     }
 
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return arrow::ArrayBuilder::AppendToBitmap(valid_bytes, length);
+        ARROW_RETURN_NOT_OK(this->Reserve(length));
+        this->UnsafeAppendToBitmap(valid_bytes, length);
+        return arrow::Status::OK();
     }
 
     void SetOffsets(const std::shared_ptr<arrow::Buffer>& offsets) {
@@ -363,7 +373,9 @@ class UnPooledStructBuilder : public EmptyBuilder {
     }
 
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return arrow::ArrayBuilder::AppendToBitmap(valid_bytes, length);
+        ARROW_RETURN_NOT_OK(this->Reserve(length));
+        this->UnsafeAppendToBitmap(valid_bytes, length);
+        return arrow::Status::OK();
     }
 
     arrow::Status FinishInternal(std::shared_ptr<arrow::ArrayData>* out) override {
@@ -489,7 +501,9 @@ class UnPooledStringDictionaryBuilder : public EmptyBuilder {
         indices_ = indices;
     }
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return arrow::ArrayBuilder::AppendToBitmap(valid_bytes, length);
+        ARROW_RETURN_NOT_OK(this->Reserve(length));
+        this->UnsafeAppendToBitmap(valid_bytes, length);
+        return arrow::Status::OK();
     }
     arrow::Status FinishInternal(std::shared_ptr<arrow::ArrayData>* out) override {
         std::shared_ptr<arrow::Buffer> null_bitmap;

--- a/src/paimon/format/orc/orc_adapter.cpp
+++ b/src/paimon/format/orc/orc_adapter.cpp
@@ -101,38 +101,31 @@ class OrcBackedArrowBuffer : public arrow::ResizableBuffer {
     ::orc::DataBuffer<T> orc_buffer_;
 };
 
-template <typename BaseBuilder>
-class ValidityBitmapAppendingBuilder : public BaseBuilder {
- public:
-    using BaseBuilder::BaseBuilder;
-
- protected:
-    arrow::Status AppendValidBytesToBitmap(const uint8_t* valid_bytes, int64_t length) {
-        ARROW_RETURN_NOT_OK(ReserveValidityBitmap(length));
-        this->UnsafeAppendToBitmap(valid_bytes, length);
-        return arrow::Status::OK();
+arrow::Status AppendValidBytesToBitmap(arrow::ArrayBuilder* builder,
+                                       arrow::TypedBufferBuilder<bool>* null_bitmap_builder,
+                                       int64_t* length, int64_t* null_count,
+                                       const uint8_t* valid_bytes, int64_t valid_length) {
+    int64_t min_capacity = builder->length() + valid_length;
+    if (min_capacity > builder->capacity()) {
+        int64_t new_capacity =
+            arrow::BufferBuilder::GrowByFactor(builder->capacity(), min_capacity);
+        ARROW_RETURN_NOT_OK(builder->arrow::ArrayBuilder::Resize(new_capacity));
     }
 
- private:
-    arrow::Status ReserveValidityBitmap(int64_t additional_capacity) {
-        int64_t min_capacity = this->length() + additional_capacity;
-        if (min_capacity <= this->capacity()) {
-            return arrow::Status::OK();
-        }
-
-        int64_t new_capacity = arrow::BufferBuilder::GrowByFactor(this->capacity(), min_capacity);
-        ARROW_RETURN_NOT_OK(this->CheckCapacity(new_capacity));
-        ARROW_RETURN_NOT_OK(this->null_bitmap_builder_.Resize(new_capacity));
-        this->capacity_ = new_capacity;
-        return arrow::Status::OK();
+    if (valid_bytes == nullptr) {
+        null_bitmap_builder->UnsafeAppend(valid_length, true);
+    } else {
+        null_bitmap_builder->UnsafeAppend(valid_bytes, valid_length);
+        *null_count = null_bitmap_builder->false_count();
     }
-};
+    *length += valid_length;
+    return arrow::Status::OK();
+}
 
-class EmptyBuilder : public ValidityBitmapAppendingBuilder<arrow::ArrayBuilder> {
+class EmptyBuilder : public arrow::ArrayBuilder {
  public:
-    using Base = ValidityBitmapAppendingBuilder<arrow::ArrayBuilder>;
     using arrow::ArrayBuilder::SetNotNull;
-    explicit EmptyBuilder(arrow::MemoryPool* pool) : Base(pool) {}
+    explicit EmptyBuilder(arrow::MemoryPool* pool) : arrow::ArrayBuilder(pool) {}
     arrow::Status AppendNulls(int64_t length) override {
         return arrow::Status::NotImplemented("AppendNulls is not implemented");
     }
@@ -172,7 +165,8 @@ class UnPooledBooleanBuilder : public EmptyBuilder {
     }
 
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return this->AppendValidBytesToBitmap(valid_bytes, length);
+        return AppendValidBytesToBitmap(this, &null_bitmap_builder_, &length_, &null_count_,
+                                        valid_bytes, length);
     }
 
     arrow::Status SetData(const uint8_t* data, int64_t length) {
@@ -202,12 +196,10 @@ class UnPooledBooleanBuilder : public EmptyBuilder {
 };
 
 template <typename Type>
-class UnPooledPrimitiveBuilder
-    : public ValidityBitmapAppendingBuilder<arrow::NumericBuilder<Type>> {
+class UnPooledPrimitiveBuilder : public arrow::NumericBuilder<Type> {
  public:
-    using Base = ValidityBitmapAppendingBuilder<arrow::NumericBuilder<Type>>;
     UnPooledPrimitiveBuilder(const std::shared_ptr<arrow::DataType>& type, arrow::MemoryPool* pool)
-        : Base(type, pool) {}
+        : arrow::NumericBuilder<Type>(type, pool) {}
 
     void SetData(const std::shared_ptr<arrow::Buffer>& data) {
         data_ = data;
@@ -219,7 +211,8 @@ class UnPooledPrimitiveBuilder
     }
 
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return this->AppendValidBytesToBitmap(valid_bytes, length);
+        return AppendValidBytesToBitmap(this, &this->null_bitmap_builder_, &this->length_,
+                                        &this->null_count_, valid_bytes, length);
     }
 
     arrow::Status FinishInternal(std::shared_ptr<arrow::ArrayData>* out) override {
@@ -242,14 +235,12 @@ class UnPooledPrimitiveBuilder
     std::shared_ptr<arrow::Buffer> data_;
 };
 
-class UnPooledLargeBinaryBuilder
-    : public ValidityBitmapAppendingBuilder<arrow::LargeBinaryBuilder> {
+class UnPooledLargeBinaryBuilder : public arrow::LargeBinaryBuilder {
  public:
-    using Base = ValidityBitmapAppendingBuilder<arrow::LargeBinaryBuilder>;
     using arrow::ArrayBuilder::SetNotNull;
     UnPooledLargeBinaryBuilder(const std::shared_ptr<arrow::DataType>& type,
                                arrow::MemoryPool* pool)
-        : Base(pool), type_(type) {}
+        : arrow::LargeBinaryBuilder(pool), type_(type) {}
 
     void SetOffsets(const std::shared_ptr<arrow::Buffer>& offsets) {
         offsets_ = offsets;
@@ -262,7 +253,8 @@ class UnPooledLargeBinaryBuilder
         length_ += length;
     }
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return this->AppendValidBytesToBitmap(valid_bytes, length);
+        return AppendValidBytesToBitmap(this, &null_bitmap_builder_, &length_, &null_count_,
+                                        valid_bytes, length);
     }
     arrow::Status FinishInternal(std::shared_ptr<arrow::ArrayData>* out) override {
         std::shared_ptr<arrow::Buffer> null_bitmap;
@@ -287,12 +279,11 @@ class UnPooledLargeBinaryBuilder
     std::shared_ptr<arrow::Buffer> data_;
 };
 
-class UnPooledBinaryBuilder : public ValidityBitmapAppendingBuilder<arrow::BinaryBuilder> {
+class UnPooledBinaryBuilder : public arrow::BinaryBuilder {
  public:
-    using Base = ValidityBitmapAppendingBuilder<arrow::BinaryBuilder>;
     using arrow::ArrayBuilder::SetNotNull;
     UnPooledBinaryBuilder(const std::shared_ptr<arrow::DataType>& type, arrow::MemoryPool* pool)
-        : Base(pool), type_(type) {}
+        : arrow::BinaryBuilder(pool), type_(type) {}
 
     void SetOffsets(const std::shared_ptr<arrow::Buffer>& offsets) {
         offsets_ = offsets;
@@ -308,7 +299,8 @@ class UnPooledBinaryBuilder : public ValidityBitmapAppendingBuilder<arrow::Binar
     }
 
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return this->AppendValidBytesToBitmap(valid_bytes, length);
+        return AppendValidBytesToBitmap(this, &null_bitmap_builder_, &length_, &null_count_,
+                                        valid_bytes, length);
     }
 
     arrow::Status FinishInternal(std::shared_ptr<arrow::ArrayData>* out) override {
@@ -348,7 +340,8 @@ class UnPooledListBuilder : public EmptyBuilder {
     }
 
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return this->AppendValidBytesToBitmap(valid_bytes, length);
+        return AppendValidBytesToBitmap(this, &null_bitmap_builder_, &length_, &null_count_,
+                                        valid_bytes, length);
     }
 
     void SetOffsets(const std::shared_ptr<arrow::Buffer>& offsets) {
@@ -396,7 +389,8 @@ class UnPooledStructBuilder : public EmptyBuilder {
     }
 
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return this->AppendValidBytesToBitmap(valid_bytes, length);
+        return AppendValidBytesToBitmap(this, &null_bitmap_builder_, &length_, &null_count_,
+                                        valid_bytes, length);
     }
 
     arrow::Status FinishInternal(std::shared_ptr<arrow::ArrayData>* out) override {
@@ -522,7 +516,8 @@ class UnPooledStringDictionaryBuilder : public EmptyBuilder {
         indices_ = indices;
     }
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return this->AppendValidBytesToBitmap(valid_bytes, length);
+        return AppendValidBytesToBitmap(this, &null_bitmap_builder_, &length_, &null_count_,
+                                        valid_bytes, length);
     }
     arrow::Status FinishInternal(std::shared_ptr<arrow::ArrayData>* out) override {
         std::shared_ptr<arrow::Buffer> null_bitmap;

--- a/src/paimon/format/orc/orc_adapter.cpp
+++ b/src/paimon/format/orc/orc_adapter.cpp
@@ -101,10 +101,38 @@ class OrcBackedArrowBuffer : public arrow::ResizableBuffer {
     ::orc::DataBuffer<T> orc_buffer_;
 };
 
-class EmptyBuilder : public arrow::ArrayBuilder {
+template <typename BaseBuilder>
+class ValidityBitmapAppendingBuilder : public BaseBuilder {
  public:
+    using BaseBuilder::BaseBuilder;
+
+ protected:
+    arrow::Status AppendValidBytesToBitmap(const uint8_t* valid_bytes, int64_t length) {
+        ARROW_RETURN_NOT_OK(ReserveValidityBitmap(length));
+        this->UnsafeAppendToBitmap(valid_bytes, length);
+        return arrow::Status::OK();
+    }
+
+ private:
+    arrow::Status ReserveValidityBitmap(int64_t additional_capacity) {
+        int64_t min_capacity = this->length() + additional_capacity;
+        if (min_capacity <= this->capacity()) {
+            return arrow::Status::OK();
+        }
+
+        int64_t new_capacity = arrow::BufferBuilder::GrowByFactor(this->capacity(), min_capacity);
+        ARROW_RETURN_NOT_OK(this->CheckCapacity(new_capacity));
+        ARROW_RETURN_NOT_OK(this->null_bitmap_builder_.Resize(new_capacity));
+        this->capacity_ = new_capacity;
+        return arrow::Status::OK();
+    }
+};
+
+class EmptyBuilder : public ValidityBitmapAppendingBuilder<arrow::ArrayBuilder> {
+ public:
+    using Base = ValidityBitmapAppendingBuilder<arrow::ArrayBuilder>;
     using arrow::ArrayBuilder::SetNotNull;
-    explicit EmptyBuilder(arrow::MemoryPool* pool) : arrow::ArrayBuilder(pool) {}
+    explicit EmptyBuilder(arrow::MemoryPool* pool) : Base(pool) {}
     arrow::Status AppendNulls(int64_t length) override {
         return arrow::Status::NotImplemented("AppendNulls is not implemented");
     }
@@ -144,9 +172,7 @@ class UnPooledBooleanBuilder : public EmptyBuilder {
     }
 
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        ARROW_RETURN_NOT_OK(this->Reserve(length));
-        this->UnsafeAppendToBitmap(valid_bytes, length);
-        return arrow::Status::OK();
+        return this->AppendValidBytesToBitmap(valid_bytes, length);
     }
 
     arrow::Status SetData(const uint8_t* data, int64_t length) {
@@ -176,10 +202,12 @@ class UnPooledBooleanBuilder : public EmptyBuilder {
 };
 
 template <typename Type>
-class UnPooledPrimitiveBuilder : public arrow::NumericBuilder<Type> {
+class UnPooledPrimitiveBuilder
+    : public ValidityBitmapAppendingBuilder<arrow::NumericBuilder<Type>> {
  public:
+    using Base = ValidityBitmapAppendingBuilder<arrow::NumericBuilder<Type>>;
     UnPooledPrimitiveBuilder(const std::shared_ptr<arrow::DataType>& type, arrow::MemoryPool* pool)
-        : arrow::NumericBuilder<Type>(type, pool) {}
+        : Base(type, pool) {}
 
     void SetData(const std::shared_ptr<arrow::Buffer>& data) {
         data_ = data;
@@ -191,9 +219,7 @@ class UnPooledPrimitiveBuilder : public arrow::NumericBuilder<Type> {
     }
 
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        ARROW_RETURN_NOT_OK(this->Reserve(length));
-        this->UnsafeAppendToBitmap(valid_bytes, length);
-        return arrow::Status::OK();
+        return this->AppendValidBytesToBitmap(valid_bytes, length);
     }
 
     arrow::Status FinishInternal(std::shared_ptr<arrow::ArrayData>* out) override {
@@ -216,12 +242,14 @@ class UnPooledPrimitiveBuilder : public arrow::NumericBuilder<Type> {
     std::shared_ptr<arrow::Buffer> data_;
 };
 
-class UnPooledLargeBinaryBuilder : public arrow::LargeBinaryBuilder {
+class UnPooledLargeBinaryBuilder
+    : public ValidityBitmapAppendingBuilder<arrow::LargeBinaryBuilder> {
  public:
+    using Base = ValidityBitmapAppendingBuilder<arrow::LargeBinaryBuilder>;
     using arrow::ArrayBuilder::SetNotNull;
     UnPooledLargeBinaryBuilder(const std::shared_ptr<arrow::DataType>& type,
                                arrow::MemoryPool* pool)
-        : arrow::LargeBinaryBuilder(pool), type_(type) {}
+        : Base(pool), type_(type) {}
 
     void SetOffsets(const std::shared_ptr<arrow::Buffer>& offsets) {
         offsets_ = offsets;
@@ -234,9 +262,7 @@ class UnPooledLargeBinaryBuilder : public arrow::LargeBinaryBuilder {
         length_ += length;
     }
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        ARROW_RETURN_NOT_OK(this->Reserve(length));
-        this->UnsafeAppendToBitmap(valid_bytes, length);
-        return arrow::Status::OK();
+        return this->AppendValidBytesToBitmap(valid_bytes, length);
     }
     arrow::Status FinishInternal(std::shared_ptr<arrow::ArrayData>* out) override {
         std::shared_ptr<arrow::Buffer> null_bitmap;
@@ -261,11 +287,12 @@ class UnPooledLargeBinaryBuilder : public arrow::LargeBinaryBuilder {
     std::shared_ptr<arrow::Buffer> data_;
 };
 
-class UnPooledBinaryBuilder : public arrow::BinaryBuilder {
+class UnPooledBinaryBuilder : public ValidityBitmapAppendingBuilder<arrow::BinaryBuilder> {
  public:
+    using Base = ValidityBitmapAppendingBuilder<arrow::BinaryBuilder>;
     using arrow::ArrayBuilder::SetNotNull;
     UnPooledBinaryBuilder(const std::shared_ptr<arrow::DataType>& type, arrow::MemoryPool* pool)
-        : arrow::BinaryBuilder(pool), type_(type) {}
+        : Base(pool), type_(type) {}
 
     void SetOffsets(const std::shared_ptr<arrow::Buffer>& offsets) {
         offsets_ = offsets;
@@ -281,9 +308,7 @@ class UnPooledBinaryBuilder : public arrow::BinaryBuilder {
     }
 
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        ARROW_RETURN_NOT_OK(this->Reserve(length));
-        this->UnsafeAppendToBitmap(valid_bytes, length);
-        return arrow::Status::OK();
+        return this->AppendValidBytesToBitmap(valid_bytes, length);
     }
 
     arrow::Status FinishInternal(std::shared_ptr<arrow::ArrayData>* out) override {
@@ -323,9 +348,7 @@ class UnPooledListBuilder : public EmptyBuilder {
     }
 
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        ARROW_RETURN_NOT_OK(this->Reserve(length));
-        this->UnsafeAppendToBitmap(valid_bytes, length);
-        return arrow::Status::OK();
+        return this->AppendValidBytesToBitmap(valid_bytes, length);
     }
 
     void SetOffsets(const std::shared_ptr<arrow::Buffer>& offsets) {
@@ -373,9 +396,7 @@ class UnPooledStructBuilder : public EmptyBuilder {
     }
 
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        ARROW_RETURN_NOT_OK(this->Reserve(length));
-        this->UnsafeAppendToBitmap(valid_bytes, length);
-        return arrow::Status::OK();
+        return this->AppendValidBytesToBitmap(valid_bytes, length);
     }
 
     arrow::Status FinishInternal(std::shared_ptr<arrow::ArrayData>* out) override {
@@ -501,9 +522,7 @@ class UnPooledStringDictionaryBuilder : public EmptyBuilder {
         indices_ = indices;
     }
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        ARROW_RETURN_NOT_OK(this->Reserve(length));
-        this->UnsafeAppendToBitmap(valid_bytes, length);
-        return arrow::Status::OK();
+        return this->AppendValidBytesToBitmap(valid_bytes, length);
     }
     arrow::Status FinishInternal(std::shared_ptr<arrow::ArrayData>* out) override {
         std::shared_ptr<arrow::Buffer> null_bitmap;

--- a/src/paimon/format/orc/orc_adapter.cpp
+++ b/src/paimon/format/orc/orc_adapter.cpp
@@ -101,24 +101,11 @@ class OrcBackedArrowBuffer : public arrow::ResizableBuffer {
     ::orc::DataBuffer<T> orc_buffer_;
 };
 
-arrow::Status AppendValidBytesToBitmap(arrow::ArrayBuilder* builder,
-                                       arrow::TypedBufferBuilder<bool>* null_bitmap_builder,
-                                       int64_t* length, int64_t* null_count,
-                                       const uint8_t* valid_bytes, int64_t valid_length) {
-    int64_t min_capacity = builder->length() + valid_length;
-    if (min_capacity > builder->capacity()) {
-        int64_t new_capacity =
-            arrow::BufferBuilder::GrowByFactor(builder->capacity(), min_capacity);
-        ARROW_RETURN_NOT_OK(builder->arrow::ArrayBuilder::Resize(new_capacity));
-    }
-
-    if (valid_bytes == nullptr) {
-        null_bitmap_builder->UnsafeAppend(valid_length, true);
-    } else {
-        null_bitmap_builder->UnsafeAppend(valid_bytes, valid_length);
-        *null_count = null_bitmap_builder->false_count();
-    }
-    *length += valid_length;
+template <typename AppendToBitmap>
+arrow::Status AppendValidBytesToBitmap(arrow::ArrayBuilder* builder, int64_t length,
+                                       AppendToBitmap append_to_bitmap) {
+    ARROW_RETURN_NOT_OK(builder->Reserve(length));
+    append_to_bitmap();
     return arrow::Status::OK();
 }
 
@@ -165,8 +152,9 @@ class UnPooledBooleanBuilder : public EmptyBuilder {
     }
 
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return AppendValidBytesToBitmap(this, &null_bitmap_builder_, &length_, &null_count_,
-                                        valid_bytes, length);
+        return AppendValidBytesToBitmap(this, length, [this, valid_bytes, length] {
+            this->UnsafeAppendToBitmap(valid_bytes, length);
+        });
     }
 
     arrow::Status SetData(const uint8_t* data, int64_t length) {
@@ -211,8 +199,9 @@ class UnPooledPrimitiveBuilder : public arrow::NumericBuilder<Type> {
     }
 
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return AppendValidBytesToBitmap(this, &this->null_bitmap_builder_, &this->length_,
-                                        &this->null_count_, valid_bytes, length);
+        return AppendValidBytesToBitmap(this, length, [this, valid_bytes, length] {
+            this->UnsafeAppendToBitmap(valid_bytes, length);
+        });
     }
 
     arrow::Status FinishInternal(std::shared_ptr<arrow::ArrayData>* out) override {
@@ -253,8 +242,9 @@ class UnPooledLargeBinaryBuilder : public arrow::LargeBinaryBuilder {
         length_ += length;
     }
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return AppendValidBytesToBitmap(this, &null_bitmap_builder_, &length_, &null_count_,
-                                        valid_bytes, length);
+        return AppendValidBytesToBitmap(this, length, [this, valid_bytes, length] {
+            this->UnsafeAppendToBitmap(valid_bytes, length);
+        });
     }
     arrow::Status FinishInternal(std::shared_ptr<arrow::ArrayData>* out) override {
         std::shared_ptr<arrow::Buffer> null_bitmap;
@@ -299,8 +289,9 @@ class UnPooledBinaryBuilder : public arrow::BinaryBuilder {
     }
 
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return AppendValidBytesToBitmap(this, &null_bitmap_builder_, &length_, &null_count_,
-                                        valid_bytes, length);
+        return AppendValidBytesToBitmap(this, length, [this, valid_bytes, length] {
+            this->UnsafeAppendToBitmap(valid_bytes, length);
+        });
     }
 
     arrow::Status FinishInternal(std::shared_ptr<arrow::ArrayData>* out) override {
@@ -340,8 +331,9 @@ class UnPooledListBuilder : public EmptyBuilder {
     }
 
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return AppendValidBytesToBitmap(this, &null_bitmap_builder_, &length_, &null_count_,
-                                        valid_bytes, length);
+        return AppendValidBytesToBitmap(this, length, [this, valid_bytes, length] {
+            this->UnsafeAppendToBitmap(valid_bytes, length);
+        });
     }
 
     void SetOffsets(const std::shared_ptr<arrow::Buffer>& offsets) {
@@ -389,8 +381,9 @@ class UnPooledStructBuilder : public EmptyBuilder {
     }
 
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return AppendValidBytesToBitmap(this, &null_bitmap_builder_, &length_, &null_count_,
-                                        valid_bytes, length);
+        return AppendValidBytesToBitmap(this, length, [this, valid_bytes, length] {
+            this->UnsafeAppendToBitmap(valid_bytes, length);
+        });
     }
 
     arrow::Status FinishInternal(std::shared_ptr<arrow::ArrayData>* out) override {
@@ -516,8 +509,9 @@ class UnPooledStringDictionaryBuilder : public EmptyBuilder {
         indices_ = indices;
     }
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return AppendValidBytesToBitmap(this, &null_bitmap_builder_, &length_, &null_count_,
-                                        valid_bytes, length);
+        return AppendValidBytesToBitmap(this, length, [this, valid_bytes, length] {
+            this->UnsafeAppendToBitmap(valid_bytes, length);
+        });
     }
     arrow::Status FinishInternal(std::shared_ptr<arrow::ArrayData>* out) override {
         std::shared_ptr<arrow::Buffer> null_bitmap;

--- a/src/paimon/format/orc/orc_adapter.cpp
+++ b/src/paimon/format/orc/orc_adapter.cpp
@@ -101,14 +101,6 @@ class OrcBackedArrowBuffer : public arrow::ResizableBuffer {
     ::orc::DataBuffer<T> orc_buffer_;
 };
 
-template <typename AppendToBitmap>
-arrow::Status AppendValidBytesToBitmap(arrow::ArrayBuilder* builder, int64_t length,
-                                       AppendToBitmap append_to_bitmap) {
-    ARROW_RETURN_NOT_OK(builder->Reserve(length));
-    append_to_bitmap();
-    return arrow::Status::OK();
-}
-
 class EmptyBuilder : public arrow::ArrayBuilder {
  public:
     using arrow::ArrayBuilder::SetNotNull;
@@ -152,9 +144,9 @@ class UnPooledBooleanBuilder : public EmptyBuilder {
     }
 
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return AppendValidBytesToBitmap(this, length, [this, valid_bytes, length] {
-            this->UnsafeAppendToBitmap(valid_bytes, length);
-        });
+        ARROW_RETURN_NOT_OK(this->Reserve(length));
+        this->UnsafeAppendToBitmap(valid_bytes, length);
+        return arrow::Status::OK();
     }
 
     arrow::Status SetData(const uint8_t* data, int64_t length) {
@@ -199,9 +191,9 @@ class UnPooledPrimitiveBuilder : public arrow::NumericBuilder<Type> {
     }
 
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return AppendValidBytesToBitmap(this, length, [this, valid_bytes, length] {
-            this->UnsafeAppendToBitmap(valid_bytes, length);
-        });
+        ARROW_RETURN_NOT_OK(this->Reserve(length));
+        this->UnsafeAppendToBitmap(valid_bytes, length);
+        return arrow::Status::OK();
     }
 
     arrow::Status FinishInternal(std::shared_ptr<arrow::ArrayData>* out) override {
@@ -242,9 +234,9 @@ class UnPooledLargeBinaryBuilder : public arrow::LargeBinaryBuilder {
         length_ += length;
     }
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return AppendValidBytesToBitmap(this, length, [this, valid_bytes, length] {
-            this->UnsafeAppendToBitmap(valid_bytes, length);
-        });
+        ARROW_RETURN_NOT_OK(this->Reserve(length));
+        this->UnsafeAppendToBitmap(valid_bytes, length);
+        return arrow::Status::OK();
     }
     arrow::Status FinishInternal(std::shared_ptr<arrow::ArrayData>* out) override {
         std::shared_ptr<arrow::Buffer> null_bitmap;
@@ -289,9 +281,9 @@ class UnPooledBinaryBuilder : public arrow::BinaryBuilder {
     }
 
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return AppendValidBytesToBitmap(this, length, [this, valid_bytes, length] {
-            this->UnsafeAppendToBitmap(valid_bytes, length);
-        });
+        ARROW_RETURN_NOT_OK(this->Reserve(length));
+        this->UnsafeAppendToBitmap(valid_bytes, length);
+        return arrow::Status::OK();
     }
 
     arrow::Status FinishInternal(std::shared_ptr<arrow::ArrayData>* out) override {
@@ -331,9 +323,9 @@ class UnPooledListBuilder : public EmptyBuilder {
     }
 
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return AppendValidBytesToBitmap(this, length, [this, valid_bytes, length] {
-            this->UnsafeAppendToBitmap(valid_bytes, length);
-        });
+        ARROW_RETURN_NOT_OK(this->Reserve(length));
+        this->UnsafeAppendToBitmap(valid_bytes, length);
+        return arrow::Status::OK();
     }
 
     void SetOffsets(const std::shared_ptr<arrow::Buffer>& offsets) {
@@ -381,9 +373,9 @@ class UnPooledStructBuilder : public EmptyBuilder {
     }
 
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return AppendValidBytesToBitmap(this, length, [this, valid_bytes, length] {
-            this->UnsafeAppendToBitmap(valid_bytes, length);
-        });
+        ARROW_RETURN_NOT_OK(this->Reserve(length));
+        this->UnsafeAppendToBitmap(valid_bytes, length);
+        return arrow::Status::OK();
     }
 
     arrow::Status FinishInternal(std::shared_ptr<arrow::ArrayData>* out) override {
@@ -509,9 +501,9 @@ class UnPooledStringDictionaryBuilder : public EmptyBuilder {
         indices_ = indices;
     }
     arrow::Status SetNulls(const uint8_t* valid_bytes, int64_t length) {
-        return AppendValidBytesToBitmap(this, length, [this, valid_bytes, length] {
-            this->UnsafeAppendToBitmap(valid_bytes, length);
-        });
+        ARROW_RETURN_NOT_OK(this->Reserve(length));
+        this->UnsafeAppendToBitmap(valid_bytes, length);
+        return arrow::Status::OK();
     }
     arrow::Status FinishInternal(std::shared_ptr<arrow::ArrayData>* out) override {
         std::shared_ptr<arrow::Buffer> null_bitmap;


### PR DESCRIPTION
### Purpose

Linked issue: N/A

Arrow removed `ArrayBuilder::AppendToBitmap` in newer releases. Replace the ORC adapter's calls with the equivalent `Reserve` + `UnsafeAppendToBitmap` sequence, which is available in the repository's pinned Arrow 17.0.0 and newer Arrow versions.

### API and Format

No public API, storage format, or protocol changes.

### Documentation

No new feature; no documentation update required.

### Generative AI tooling

Generated-by: OpenAI Codex
