### PR TITLE
fix(blob): identify a missing blob file with FileSystem::Exists

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -57,7 +57,6 @@ if(PAIMON_BUILD_BENCHMARKS)
                          ${PAIMON_BENCHMARK_STATIC_LINK_LIBS}
                          test_utils_static
                          Threads::Threads
-                         ${CMAKE_DL_LIBS}
                          ${PAIMON_BENCHMARK_PLATFORM_LINK_LIBS}
                          ${PAIMON_BENCHMARK_LINK_TOOLCHAIN}
                          EXTRA_INCLUDES

--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -1643,6 +1643,9 @@ macro(build_arrow)
 
     # libarrow.a calls dlsym; keep ${CMAKE_DL_LIBS} in the interface so -ldl is placed
     # after libarrow.a on linkers that resolve symbols strictly left-to-right.
+    # Every library that uses dl itself (arrow here; also lucene and jindosdk::nextarch)
+    # declares it on its own interface the same way; consumers inherit it transitively
+    # and must not list ${CMAKE_DL_LIBS} again themselves.
     target_link_libraries(arrow
                           INTERFACE zstd
                                     snappy

--- a/include/paimon/defs.h
+++ b/include/paimon/defs.h
@@ -440,13 +440,14 @@ struct PAIMON_EXPORT Options {
     /// path and requires manual configuration by the user. No default value.
     static const char BLOB_VIEW_UPSTREAM_WAREHOUSE[];
     /// "blob-write-null-on-missing-file" - Whether to write NULL for a descriptor BLOB value when
-    /// the referenced file does not exist at write time. When false, the write fails when the
-    /// descriptor is read. Default value is "false".
+    /// the referenced file does not exist at write time. When false, a missing file is treated
+    /// like any other fetch failure, following "blob-write-null-on-fetch-failure". Default value
+    /// is "false".
     static const char BLOB_WRITE_NULL_ON_MISSING_FILE[];
     /// "blob-write-null-on-fetch-failure" - Whether to write NULL for a descriptor BLOB value when
     /// the referenced data cannot be fetched at write time (e.g. invalid descriptor or invalid
-    /// offset). A missing file is handled by "blob-write-null-on-missing-file". When false, the
-    /// write fails when the descriptor is read. Default value is "false".
+    /// offset). A missing file is handled by "blob-write-null-on-missing-file" when that option is
+    /// enabled. When false, the write fails when the descriptor is read. Default value is "false".
     static const char BLOB_WRITE_NULL_ON_FETCH_FAILURE[];
     /// "global-index.enabled" - Whether to enable global index for scan. Default value is "true".
     static const char GLOBAL_INDEX_ENABLED[];

--- a/src/paimon/CMakeLists.txt
+++ b/src/paimon/CMakeLists.txt
@@ -392,7 +392,6 @@ add_paimon_lib(paimon
                arrow
                tbb
                glog
-               ${CMAKE_DL_LIBS}
                fmt
                roaring_bitmap
                xxhash

--- a/src/paimon/common/file_index/CMakeLists.txt
+++ b/src/paimon/common/file_index/CMakeLists.txt
@@ -42,7 +42,6 @@ add_paimon_lib(paimon_file_index
                arrow
                fmt
                xxhash
-               ${CMAKE_DL_LIBS}
                Threads::Threads
                SHARED_LINK_LIBS
                paimon_shared

--- a/src/paimon/common/global_index/CMakeLists.txt
+++ b/src/paimon/common/global_index/CMakeLists.txt
@@ -38,7 +38,6 @@ add_paimon_lib(paimon_global_index
                STATIC_LINK_LIBS
                arrow
                fmt
-               ${CMAKE_DL_LIBS}
                Threads::Threads
                SHARED_LINK_LIBS
                paimon_shared

--- a/src/paimon/format/avro/CMakeLists.txt
+++ b/src/paimon/format/avro/CMakeLists.txt
@@ -38,7 +38,6 @@ if(PAIMON_ENABLE_AVRO)
                    fmt
                    avro
                    tbb
-                   ${CMAKE_DL_LIBS}
                    Threads::Threads
                    SHARED_LINK_LIBS
                    paimon_shared

--- a/src/paimon/format/blob/CMakeLists.txt
+++ b/src/paimon/format/blob/CMakeLists.txt
@@ -25,7 +25,6 @@ add_paimon_lib(paimon_blob_file_format
                STATIC_LINK_LIBS
                arrow
                fmt
-               ${CMAKE_DL_LIBS}
                Threads::Threads
                SHARED_LINK_LIBS
                paimon_shared

--- a/src/paimon/format/blob/blob_format_writer.cpp
+++ b/src/paimon/format/blob/blob_format_writer.cpp
@@ -30,6 +30,7 @@
 #include "paimon/common/utils/arrow/status_utils.h"
 #include "paimon/common/utils/delta_varint_compressor.h"
 #include "paimon/data/blob.h"
+#include "paimon/fs/file_system.h"
 #include "paimon/io/byte_array_input_stream.h"
 #include "paimon/logging.h"
 
@@ -48,6 +49,8 @@ BlobFormatWriter::BlobFormatWriter(const std::shared_ptr<OutputStream>& out, con
       pool_(pool),
       write_null_on_missing_file_(write_null_on_missing_file),
       write_null_on_fetch_failure_(write_null_on_fetch_failure) {
+    // Create() has already checked that data_type has exactly one BLOB field.
+    blob_field_name_ = data_type_->field(0)->name();
     metrics_ = std::make_shared<MetricsImpl>();
     tmp_buffer_ = Bytes::AllocateBytes(kTmpBufferSize, pool_.get());
     magic_number_bytes_ = IntegerToLittleEndian<int32_t>(BlobDefs::kMagicNumber, pool_);
@@ -66,6 +69,9 @@ Result<std::unique_ptr<BlobFormatWriter>> BlobFormatWriter::Create(
     }
     if (pool == nullptr) {
         return Status::Invalid("blob format writer create failed. pool is nullptr");
+    }
+    if (fs == nullptr) {
+        return Status::Invalid("blob format writer create failed. fs is nullptr");
     }
     if (data_type->num_fields() != 1) {
         return Status::Invalid(
@@ -117,6 +123,10 @@ Status BlobFormatWriter::AddBatch(ArrowArray* batch) {
 }
 
 Status BlobFormatWriter::Flush() {
+    metrics_->SetCounter(BlobMetrics::WRITE_NULL_ON_MISSING_FILE_COUNT,
+                         null_on_missing_file_count_);
+    metrics_->SetCounter(BlobMetrics::WRITE_NULL_ON_FETCH_FAILURE_COUNT,
+                         null_on_fetch_failure_count_);
     return out_->Flush();
 }
 
@@ -140,29 +150,20 @@ Status BlobFormatWriter::Finish() {
 Status BlobFormatWriter::WriteBlob(std::string_view blob_data) {
     // Open the blob input stream before writing any bytes, so that a failed fetch can be
     // converted to a NULL element without leaving partial data in the output stream.
-    // Dynamically check whether blob_data is a serialized BlobDescriptor (by magic header)
-    // rather than relying on blob_as_descriptor_ config. This is consistent with Java behavior:
-    // at write time, the input bytes are auto-detected as descriptor or raw data.
+    // Whether blob_data is a serialized BlobDescriptor is detected by its magic header rather
+    // than taken from a blob_as_descriptor option, so each row may hold either form.
     std::unique_ptr<InputStream> in;
     PAIMON_ASSIGN_OR_RAISE(bool is_descriptor,
                            BlobDescriptor::IsBlobDescriptor(blob_data.data(), blob_data.size()));
     if (is_descriptor) {
-        Result<std::unique_ptr<InputStream>> opened = OpenDescriptorInputStream(blob_data);
-        if (!opened.ok()) {
-            const Status& status = opened.status();
-            // A missing file is only handled by 'blob-write-null-on-missing-file'; other fetch
-            // failures are only handled by 'blob-write-null-on-fetch-failure' (aligned with Java).
-            bool write_null =
-                status.IsNotExist() ? write_null_on_missing_file_ : write_null_on_fetch_failure_;
-            if (write_null) {
-                PAIMON_LOG_WARN(logger_, "Failed to open blob, writing NULL for BLOB field: %s",
-                                status.ToString().c_str());
-                bin_lengths_.push_back(BlobDefs::kNullBinLength);
-                return Status::OK();
-            }
-            return status;
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<InputStream> descriptor_in,
+                               OpenDescriptorInputStream(blob_data));
+        // A null stream means a write-null option already converted the failure.
+        if (descriptor_in == nullptr) {
+            bin_lengths_.push_back(BlobDefs::kNullBinLength);
+            return Status::OK();
         }
-        in = std::move(opened).value();
+        in = std::move(descriptor_in);
     } else {
         in = std::make_unique<ByteArrayInputStream>(blob_data.data(), blob_data.size());
     }
@@ -206,10 +207,73 @@ Status BlobFormatWriter::WriteBlob(std::string_view blob_data) {
 }
 
 Result<std::unique_ptr<InputStream>> BlobFormatWriter::OpenDescriptorInputStream(
-    std::string_view blob_data) const {
-    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<Blob> blob,
-                           Blob::FromDescriptor(blob_data.data(), blob_data.size()));
-    return blob->NewInputStream(fs_);
+    std::string_view blob_data) {
+    // A descriptor that cannot be deserialized is a fetch failure: the referenced data cannot be
+    // reached. Its URI is inside the unreadable bytes, hence the placeholder; the underlying
+    // status comes from the byte reader and never mentions blobs, hence the added context.
+    Result<std::unique_ptr<Blob>> blob_result =
+        Blob::FromDescriptor(blob_data.data(), blob_data.size());
+    if (!blob_result.ok()) {
+        const Status& status = blob_result.status();
+        return HandleFetchFailure(
+            "<unknown>", status.WithMessage("invalid blob descriptor: ", status.message()));
+    }
+    std::unique_ptr<Blob> blob = std::move(blob_result).value();
+
+    // A missing file is identified by FileSystem::Exists rather than by the status of a failed
+    // open, since file system implementations disagree on which status a missing file maps to.
+    // The check runs only when `write_null_on_missing_file_` needs the classification; otherwise
+    // a missing file gets the same treatment as any other failed open.
+    if (write_null_on_missing_file_) {
+        Result<bool> exists = fs_->Exists(blob->Uri());
+        if (exists.ok()) {
+            if (!exists.value()) {
+                return HandleMissingFile(blob->Uri());
+            }
+        } else if (!write_null_on_fetch_failure_) {
+            // The check cannot answer whether the file is there; with no fetch-failure handling
+            // to defer to, fail rather than assume either answer.
+            const Status& status = exists.status();
+            return status.WithMessage("failed to check existence of blob file '", blob->Uri(),
+                                      "': ", status.message());
+        }
+        // A failed check is otherwise deferred to the open below, which can still succeed.
+    }
+
+    Result<std::unique_ptr<InputStream>> opened = blob->NewInputStream(fs_);
+    if (!opened.ok()) {
+        // The file can be deleted between the check above and this open. Classifying that from
+        // `opened.status()` would reintroduce the plugin-specific status codes this writer avoids,
+        // so ask FileSystem::Exists once more. This narrows the window rather than closing it; a
+        // check that cannot answer falls through to the open failure.
+        if (write_null_on_missing_file_) {
+            Result<bool> exists = fs_->Exists(blob->Uri());
+            if (exists.ok() && !exists.value()) {
+                return HandleMissingFile(blob->Uri());
+            }
+        }
+        return HandleFetchFailure(blob->Uri(), opened.status());
+    }
+    return std::move(opened).value();
+}
+
+std::unique_ptr<InputStream> BlobFormatWriter::HandleMissingFile(const std::string& blob_uri) {
+    PAIMON_LOG_WARN(logger_, "Blob file %s does not exist, writing NULL for BLOB field %s into %s",
+                    blob_uri.c_str(), blob_field_name_.c_str(), uri_.c_str());
+    ++null_on_missing_file_count_;
+    return std::unique_ptr<InputStream>();
+}
+
+Result<std::unique_ptr<InputStream>> BlobFormatWriter::HandleFetchFailure(
+    const std::string& blob_uri, const Status& status) {
+    if (!write_null_on_fetch_failure_) {
+        return status;
+    }
+    PAIMON_LOG_WARN(logger_, "Failed to fetch blob %s, writing NULL for BLOB field %s into %s: %s",
+                    blob_uri.c_str(), blob_field_name_.c_str(), uri_.c_str(),
+                    status.ToString().c_str());
+    ++null_on_fetch_failure_count_;
+    return std::unique_ptr<InputStream>();
 }
 
 Status BlobFormatWriter::WriteBytes(const char* data, int64_t length) {

--- a/src/paimon/format/blob/blob_format_writer.h
+++ b/src/paimon/format/blob/blob_format_writer.h
@@ -47,14 +47,27 @@ class OutputStream;
 
 namespace paimon::blob {
 
+class BlobMetrics {
+ public:
+    /// Number of rows written as NULL because their referenced file did not exist.
+    static inline const char WRITE_NULL_ON_MISSING_FILE_COUNT[] =
+        "blob.write.null-on-missing-file.count";
+    /// Number of rows written as NULL because their referenced data could not be reached.
+    static inline const char WRITE_NULL_ON_FETCH_FAILURE_COUNT[] =
+        "blob.write.null-on-fetch-failure.count";
+};
+
 // Blob format:
 // https://cwiki.apache.org/confluence/display/PAIMON/PIP-35%3A+Introduce+Blob+to+store+multimodal+data
 class BlobFormatWriter : public FormatWriter {
  public:
-    /// When opening a descriptor input fails, `write_null_on_missing_file` converts a
-    /// missing file (Status::NotExist) to a NULL element and `write_null_on_fetch_failure`
-    /// converts any other open failure; failures during the streaming copy always fail the
-    /// write. See Options::BLOB_WRITE_NULL_ON_MISSING_FILE / BLOB_WRITE_NULL_ON_FETCH_FAILURE.
+    /// `write_null_on_missing_file` converts a descriptor whose referenced file does not exist
+    /// (as reported by FileSystem::Exists) to a NULL element, and `write_null_on_fetch_failure`
+    /// converts any other failure to access the referenced data; failures during the streaming
+    /// copy always fail the write. The existence check runs only when
+    /// `write_null_on_missing_file` is enabled; otherwise a missing file follows
+    /// `write_null_on_fetch_failure` like any other failed open.
+    /// See Options::BLOB_WRITE_NULL_ON_MISSING_FILE / BLOB_WRITE_NULL_ON_FETCH_FAILURE.
     static Result<std::unique_ptr<BlobFormatWriter>> Create(
         const std::shared_ptr<OutputStream>& out, const std::shared_ptr<arrow::DataType>& data_type,
         bool write_null_on_missing_file, bool write_null_on_fetch_failure,
@@ -84,8 +97,19 @@ class BlobFormatWriter : public FormatWriter {
     Status WriteBlob(std::string_view blob_data);
 
     /// Deserialize the descriptor and open an input stream on the referenced data.
-    Result<std::unique_ptr<InputStream>> OpenDescriptorInputStream(
-        std::string_view blob_data) const;
+    /// Returns a null stream when the failure is converted to a NULL element by
+    /// `write_null_on_missing_file_` or `write_null_on_fetch_failure_`.
+    Result<std::unique_ptr<InputStream>> OpenDescriptorInputStream(std::string_view blob_data);
+
+    /// Convert a file that FileSystem::Exists reported as absent to a NULL element: count it and
+    /// return a null stream. Only reached under `write_null_on_missing_file_`, which callers check.
+    std::unique_ptr<InputStream> HandleMissingFile(const std::string& blob_uri);
+
+    /// Apply `write_null_on_fetch_failure_` to a failure to reach the referenced data: returns
+    /// `status` when the option is disabled, and a null stream when it converts the failure to a
+    /// NULL element. `blob_uri` is only used for logging.
+    Result<std::unique_ptr<InputStream>> HandleFetchFailure(const std::string& blob_uri,
+                                                            const Status& status);
 
     Status WriteBytes(const char* data, int64_t length);
     Status WriteWithCrc32(const char* data, int64_t length);
@@ -100,15 +124,19 @@ class BlobFormatWriter : public FormatWriter {
     uint32_t crc32_ = 0;
     std::vector<int64_t> bin_lengths_;
     std::shared_ptr<OutputStream> out_;
+    /// Path of the blob file being written, not of any referenced blob.
     std::string uri_;
     PAIMON_UNIQUE_PTR<Bytes> tmp_buffer_;
     PAIMON_UNIQUE_PTR<Bytes> magic_number_bytes_;
     std::shared_ptr<arrow::DataType> data_type_;
+    std::string blob_field_name_;
     std::shared_ptr<FileSystem> fs_;
     std::shared_ptr<MemoryPool> pool_;
     std::shared_ptr<Metrics> metrics_;
     bool write_null_on_missing_file_ = false;
     bool write_null_on_fetch_failure_ = false;
+    uint64_t null_on_missing_file_count_ = 0;
+    uint64_t null_on_fetch_failure_count_ = 0;
     std::unique_ptr<Logger> logger_;
 };
 

--- a/src/paimon/format/blob/blob_format_writer_test.cpp
+++ b/src/paimon/format/blob/blob_format_writer_test.cpp
@@ -22,6 +22,7 @@
 
 #include "arrow/c/bridge.h"
 #include "gtest/gtest.h"
+#include "paimon/common/data/blob_descriptor.h"
 #include "paimon/common/utils/arrow/status_utils.h"
 #include "paimon/common/utils/stream_utils.h"
 #include "paimon/data/blob.h"
@@ -33,18 +34,78 @@
 
 namespace paimon::blob::test {
 
-/// A file system whose Open() always fails with the configured status, for verifying how the
-/// writer classifies open failures by status code.
+/// A file system whose Open() always fails with the configured status while Exists() keeps the
+/// real local check, standing in for a plugin that reports a missing file as something other than
+/// Status::NotExist. Open() calls are counted so a test can assert a missing file is never opened.
 class OpenFailFileSystem : public LocalFileSystem {
  public:
     explicit OpenFailFileSystem(Status open_status) : open_status_(std::move(open_status)) {}
 
     Result<std::unique_ptr<InputStream>> Open(const std::string& path) const override {
+        ++open_call_count_;
         return open_status_;
+    }
+
+    int64_t OpenCallCount() const {
+        return open_call_count_;
     }
 
  private:
     Status open_status_;
+    mutable int64_t open_call_count_ = 0;
+};
+
+/// A file system whose Exists() always fails with the configured status, counting the calls. By
+/// default Open() is delegated to a separate LocalFileSystem so that it still succeeds
+/// (LocalFileSystem::Open() calls Exists() on itself, so without the delegation a failed check
+/// would also fail the open); a non-OK `open_status` makes Open() fail with it instead.
+class ExistsFailFileSystem : public LocalFileSystem {
+ public:
+    explicit ExistsFailFileSystem(Status exists_status, Status open_status = Status::OK())
+        : exists_status_(std::move(exists_status)), open_status_(std::move(open_status)) {}
+
+    Result<bool> Exists(const std::string& path) const override {
+        ++exists_call_count_;
+        return exists_status_;
+    }
+
+    Result<std::unique_ptr<InputStream>> Open(const std::string& path) const override {
+        if (!open_status_.ok()) {
+            return open_status_;
+        }
+        return real_fs_.Open(path);
+    }
+
+    int64_t ExistsCallCount() const {
+        return exists_call_count_;
+    }
+
+ private:
+    Status exists_status_;
+    Status open_status_;
+    LocalFileSystem real_fs_;
+    mutable int64_t exists_call_count_ = 0;
+};
+
+/// A file system that reports a file as present on the first Exists() and absent afterwards,
+/// standing in for a file deleted between the check and the open. Open() fails with a plain
+/// IOError, so a test can tell a re-checked classification apart from one taken from the open.
+class VanishingFileSystem : public LocalFileSystem {
+ public:
+    Result<bool> Exists(const std::string& path) const override {
+        return ++exists_call_count_ == 1;
+    }
+
+    Result<std::unique_ptr<InputStream>> Open(const std::string& path) const override {
+        return Status::IOError("mock io error");
+    }
+
+    int64_t ExistsCallCount() const {
+        return exists_call_count_;
+    }
+
+ private:
+    mutable int64_t exists_call_count_ = 0;
 };
 
 class BlobFormatWriterTestBase : public ::testing::Test {
@@ -81,6 +142,20 @@ class BlobFormatWriterTestBase : public ::testing::Test {
     Result<std::shared_ptr<arrow::Array>> PrepareDescriptorArray(
         const std::shared_ptr<Blob>& blob) const {
         return paimon::test::TestHelper::MakeBlobDescriptorArray(struct_type_, blob, pool_);
+    }
+
+    /// Build a single-row blob array holding `bytes` verbatim, for bytes no Blob can produce,
+    /// such as a truncated descriptor.
+    Result<std::shared_ptr<arrow::Array>> MakeBlobArrayFromBytes(const std::string& bytes) const {
+        arrow::StructBuilder struct_builder(struct_type_, arrow::default_memory_pool(),
+                                            {std::make_shared<arrow::LargeBinaryBuilder>()});
+        auto blob_builder =
+            static_cast<arrow::LargeBinaryBuilder*>(struct_builder.field_builder(0));
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(struct_builder.Append());
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(blob_builder->Append(bytes.data(), bytes.size()));
+        std::shared_ptr<arrow::Array> array;
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(struct_builder.Finish(&array));
+        return array;
     }
 
     Result<std::shared_ptr<arrow::StructArray>> ReadBackAsData() const {
@@ -223,6 +298,12 @@ TEST_P(BlobFormatWriterTest, TestCreateWithInvalidParameters) {
         BlobFormatWriter::Create(output_stream_, struct_type_, /*write_null_on_missing_file=*/false,
                                  /*write_null_on_fetch_failure=*/false, file_system_, nullptr),
         "blob format writer create failed. pool is nullptr");
+
+    // Test with nullptr file system
+    ASSERT_NOK_WITH_MSG(
+        BlobFormatWriter::Create(output_stream_, struct_type_, /*write_null_on_missing_file=*/false,
+                                 /*write_null_on_fetch_failure=*/false, nullptr, pool_),
+        "blob format writer create failed. fs is nullptr");
 
     // Test with invalid field count (more than 1 field)
     auto multi_field_type = arrow::struct_(
@@ -452,8 +533,8 @@ TEST_F(BlobFormatWriterWriteNullTest, TestWriteNullOnMissingFile) {
     ASSERT_OK_AND_ASSIGN(auto missing_array, PrepareDescriptorArray(missing_blob));
     ASSERT_OK(AddBatchOnce(writer, missing_array));
 
-    // A fetch failure is not converted to NULL by write_null_on_missing_file alone (aligned
-    // with Java); the rejected row leaves the writer usable.
+    // A fetch failure is not converted to NULL by write_null_on_missing_file alone; the
+    // rejected row leaves the writer usable.
     std::string file = paimon::test::GetDataDir() + "/xxhash.data";
     ASSERT_OK_AND_ASSIGN(std::shared_ptr<Blob> bad_offset_blob,
                          Blob::FromPath(file, /*offset=*/1 << 20, /*length=*/10));
@@ -490,20 +571,31 @@ TEST_F(BlobFormatWriterWriteNullTest, TestWriteNullOnFetchFailure) {
     ASSERT_OK_AND_ASSIGN(auto bad_offset_array, PrepareDescriptorArray(bad_offset_blob));
     ASSERT_OK(AddBatchOnce(writer, bad_offset_array));
 
-    // A missing file is not converted to NULL by write_null_on_fetch_failure alone (aligned
-    // with Java); the rejected row leaves the writer usable.
+    // Without write_null_on_missing_file no existence check runs, so a missing file is not told
+    // apart from any other failed open and is converted by this option.
     ASSERT_OK_AND_ASSIGN(std::shared_ptr<Blob> missing_blob,
                          Blob::FromPath(dir_->Str() + "/not_exist_file", /*offset=*/0,
                                         /*length=*/10));
     ASSERT_OK_AND_ASSIGN(auto missing_array, PrepareDescriptorArray(missing_blob));
-    ASSERT_NOK_WITH_MSG(AddBatchOnce(writer, missing_array), "not exists");
+    ASSERT_OK(AddBatchOnce(writer, missing_array));
 
     ASSERT_OK(writer->Flush());
     ASSERT_OK(writer->Finish());
 
+    // Both rows count as fetch failures.
+    ASSERT_OK_AND_ASSIGN(
+        uint64_t missing_nulls,
+        writer->GetWriterMetrics()->GetCounter(BlobMetrics::WRITE_NULL_ON_MISSING_FILE_COUNT));
+    ASSERT_EQ(missing_nulls, 0);
+    ASSERT_OK_AND_ASSIGN(
+        uint64_t fetch_failure_nulls,
+        writer->GetWriterMetrics()->GetCounter(BlobMetrics::WRITE_NULL_ON_FETCH_FAILURE_COUNT));
+    ASSERT_EQ(fetch_failure_nulls, 2);
+
     ASSERT_OK_AND_ASSIGN(std::shared_ptr<arrow::StructArray> result_struct, ReadBackAsData());
-    ASSERT_EQ(result_struct->length(), 1);
+    ASSERT_EQ(result_struct->length(), 2);
     ASSERT_TRUE(result_struct->field(0)->IsNull(0));
+    ASSERT_TRUE(result_struct->field(0)->IsNull(1));
 }
 
 TEST_F(BlobFormatWriterWriteNullTest, TestWriteNullOnBothOptionsEnabled) {
@@ -534,6 +626,16 @@ TEST_F(BlobFormatWriterWriteNullTest, TestWriteNullOnBothOptionsEnabled) {
     ASSERT_OK(writer->Flush());
     ASSERT_OK(writer->Finish());
 
+    // The two NULL rows had different causes, counted separately.
+    ASSERT_OK_AND_ASSIGN(
+        uint64_t missing_nulls,
+        writer->GetWriterMetrics()->GetCounter(BlobMetrics::WRITE_NULL_ON_MISSING_FILE_COUNT));
+    ASSERT_EQ(missing_nulls, 1);
+    ASSERT_OK_AND_ASSIGN(
+        uint64_t fetch_failure_nulls,
+        writer->GetWriterMetrics()->GetCounter(BlobMetrics::WRITE_NULL_ON_FETCH_FAILURE_COUNT));
+    ASSERT_EQ(fetch_failure_nulls, 1);
+
     ASSERT_OK_AND_ASSIGN(std::shared_ptr<arrow::StructArray> result_struct, ReadBackAsData());
     ASSERT_EQ(result_struct->length(), 3);
     ASSERT_TRUE(result_struct->field(0)->IsNull(0));
@@ -546,42 +648,251 @@ TEST_F(BlobFormatWriterWriteNullTest, TestWriteNullOnBothOptionsEnabled) {
               std::string_view(expected_data->data(), expected_data->size()));
 }
 
-TEST_F(BlobFormatWriterWriteNullTest, TestWriteNullClassifiesByStatusCode) {
-    // The missing-file vs fetch-failure split keys on the open status code (NotExist <-> missing
-    // file), independent of the file system implementation.
-    ASSERT_OK_AND_ASSIGN(std::shared_ptr<Blob> blob,
-                         Blob::FromPath(dir_->Str() + "/any_file", /*offset=*/0, /*length=*/10));
-    ASSERT_OK_AND_ASSIGN(auto array, PrepareDescriptorArray(blob));
-    auto not_exist_fs = std::make_shared<OpenFailFileSystem>(Status::NotExist("mock not exist"));
+TEST_F(BlobFormatWriterWriteNullTest, TestWriteNullClassifiesByExistence) {
+    // Each case needs its own option pair and therefore its own writer, so none of them finishes
+    // the shared output stream: this test only asserts how a failure is classified. That the
+    // resulting NULL element is written correctly is covered by the TestWriteNullOn* tests.
     auto io_error_fs = std::make_shared<OpenFailFileSystem>(Status::IOError("mock io error"));
 
-    {
-        ASSERT_OK_AND_ASSIGN(std::shared_ptr<BlobFormatWriter> writer,
-                             BlobFormatWriter::Create(
-                                 output_stream_, struct_type_, /*write_null_on_missing_file=*/true,
-                                 /*write_null_on_fetch_failure=*/false, not_exist_fs, pool_));
-        ASSERT_OK(AddBatchOnce(writer, array));
-    }
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<Blob> missing_blob,
+                         Blob::FromPath(dir_->Str() + "/not_exist_file", /*offset=*/0,
+                                        /*length=*/10));
+    ASSERT_OK_AND_ASSIGN(auto missing_array, PrepareDescriptorArray(missing_blob));
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<Blob> existing_blob,
+                         Blob::FromPath(paimon::test::GetDataDir() + "/xxhash.data"));
+    ASSERT_OK_AND_ASSIGN(auto existing_array, PrepareDescriptorArray(existing_blob));
+
+    // Missing file: classified without opening it, so what Open would return is irrelevant.
     {
         ASSERT_OK_AND_ASSIGN(std::shared_ptr<BlobFormatWriter> writer,
                              BlobFormatWriter::Create(
                                  output_stream_, struct_type_, /*write_null_on_missing_file=*/true,
                                  /*write_null_on_fetch_failure=*/false, io_error_fs, pool_));
-        ASSERT_NOK_WITH_MSG(AddBatchOnce(writer, array), "mock io error");
+        ASSERT_OK(AddBatchOnce(writer, missing_array));
+        ASSERT_EQ(io_error_fs->OpenCallCount(), 0);
     }
+    // Existing file that cannot be opened: a fetch failure, which this writer does not convert.
+    {
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<BlobFormatWriter> writer,
+                             BlobFormatWriter::Create(
+                                 output_stream_, struct_type_, /*write_null_on_missing_file=*/true,
+                                 /*write_null_on_fetch_failure=*/false, io_error_fs, pool_));
+        ASSERT_NOK_WITH_MSG(AddBatchOnce(writer, existing_array), "mock io error");
+    }
+    // The same fetch failure, now converted to NULL.
     {
         ASSERT_OK_AND_ASSIGN(std::shared_ptr<BlobFormatWriter> writer,
                              BlobFormatWriter::Create(
                                  output_stream_, struct_type_, /*write_null_on_missing_file=*/false,
                                  /*write_null_on_fetch_failure=*/true, io_error_fs, pool_));
-        ASSERT_OK(AddBatchOnce(writer, array));
+        ASSERT_OK(AddBatchOnce(writer, existing_array));
+    }
+    // Missing file with only fetch-failure enabled: no existence check runs, so the file is
+    // opened and the failure is converted like any other fetch failure. The mock's count
+    // accumulates across cases, so compare against it.
+    {
+        const int64_t open_calls_before = io_error_fs->OpenCallCount();
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<BlobFormatWriter> writer,
+                             BlobFormatWriter::Create(
+                                 output_stream_, struct_type_, /*write_null_on_missing_file=*/false,
+                                 /*write_null_on_fetch_failure=*/true, io_error_fs, pool_));
+        ASSERT_OK(AddBatchOnce(writer, missing_array));
+        ASSERT_EQ(io_error_fs->OpenCallCount(), open_calls_before + 1);
+        ASSERT_OK_AND_ASSIGN(
+            uint64_t fetch_failure_nulls,
+            writer->GetWriterMetrics()->GetCounter(BlobMetrics::WRITE_NULL_ON_FETCH_FAILURE_COUNT));
+        ASSERT_EQ(fetch_failure_nulls, 1);
+    }
+
+    // A file deleted between the check and the open is still a missing file: the failed open
+    // triggers one more check rather than being classified by its status. Without it the deletion
+    // would defeat write_null_on_missing_file, which does not convert a fetch failure. Each case
+    // needs its own file system, since the mock reports the file as present only on the first call.
+    {
+        auto vanishing_fs = std::make_shared<VanishingFileSystem>();
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<BlobFormatWriter> writer,
+                             BlobFormatWriter::Create(
+                                 output_stream_, struct_type_, /*write_null_on_missing_file=*/true,
+                                 /*write_null_on_fetch_failure=*/false, vanishing_fs, pool_));
+        ASSERT_OK(AddBatchOnce(writer, existing_array));
+        // One check before the open and one after it.
+        ASSERT_EQ(vanishing_fs->ExistsCallCount(), 2);
+        ASSERT_OK_AND_ASSIGN(
+            uint64_t missing_nulls,
+            writer->GetWriterMetrics()->GetCounter(BlobMetrics::WRITE_NULL_ON_MISSING_FILE_COUNT));
+        ASSERT_EQ(missing_nulls, 1);
+        ASSERT_OK_AND_ASSIGN(
+            uint64_t fetch_failure_nulls,
+            writer->GetWriterMetrics()->GetCounter(BlobMetrics::WRITE_NULL_ON_FETCH_FAILURE_COUNT));
+        ASSERT_EQ(fetch_failure_nulls, 0);
+    }
+    // The same deletion with both options enabled: classified as missing rather than swallowed
+    // by fetch-failure.
+    {
+        auto vanishing_fs = std::make_shared<VanishingFileSystem>();
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<BlobFormatWriter> writer,
+                             BlobFormatWriter::Create(
+                                 output_stream_, struct_type_, /*write_null_on_missing_file=*/true,
+                                 /*write_null_on_fetch_failure=*/true, vanishing_fs, pool_));
+        ASSERT_OK(AddBatchOnce(writer, existing_array));
+        ASSERT_EQ(vanishing_fs->ExistsCallCount(), 2);
+        ASSERT_OK_AND_ASSIGN(
+            uint64_t missing_nulls,
+            writer->GetWriterMetrics()->GetCounter(BlobMetrics::WRITE_NULL_ON_MISSING_FILE_COUNT));
+        ASSERT_EQ(missing_nulls, 1);
+        ASSERT_OK_AND_ASSIGN(
+            uint64_t fetch_failure_nulls,
+            writer->GetWriterMetrics()->GetCounter(BlobMetrics::WRITE_NULL_ON_FETCH_FAILURE_COUNT));
+        ASSERT_EQ(fetch_failure_nulls, 0);
+    }
+    // The same deletion with only fetch-failure enabled: existence is never consulted, and the
+    // failed open is converted like any other fetch failure.
+    {
+        auto vanishing_fs = std::make_shared<VanishingFileSystem>();
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<BlobFormatWriter> writer,
+                             BlobFormatWriter::Create(
+                                 output_stream_, struct_type_, /*write_null_on_missing_file=*/false,
+                                 /*write_null_on_fetch_failure=*/true, vanishing_fs, pool_));
+        ASSERT_OK(AddBatchOnce(writer, existing_array));
+        ASSERT_EQ(vanishing_fs->ExistsCallCount(), 0);
+    }
+    // Neither option: existence is never consulted, and the open failure propagates as it is.
+    {
+        auto vanishing_fs = std::make_shared<VanishingFileSystem>();
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<BlobFormatWriter> writer,
+                             BlobFormatWriter::Create(
+                                 output_stream_, struct_type_, /*write_null_on_missing_file=*/false,
+                                 /*write_null_on_fetch_failure=*/false, vanishing_fs, pool_));
+        ASSERT_NOK_WITH_MSG(AddBatchOnce(writer, existing_array), "mock io error");
+        ASSERT_EQ(vanishing_fs->ExistsCallCount(), 0);
+    }
+}
+
+TEST_F(BlobFormatWriterWriteNullTest, TestWriteNullOnInvalidDescriptor) {
+    // Descriptor detection only inspects version and magic, so a descriptor truncated after those
+    // passes detection and then fails to deserialize: a fetch failure, not a missing file.
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<Blob> blob,
+                         Blob::FromPath(paimon::test::GetDataDir() + "/xxhash.data"));
+    PAIMON_UNIQUE_PTR<Bytes> descriptor = blob->ToDescriptor(pool_);
+    ASSERT_GT(descriptor->size(), 8);
+    std::string truncated(descriptor->data(), descriptor->size() - 8);
+    ASSERT_OK_AND_ASSIGN(bool is_descriptor,
+                         BlobDescriptor::IsBlobDescriptor(truncated.data(), truncated.size()));
+    ASSERT_TRUE(is_descriptor);
+    ASSERT_OK_AND_ASSIGN(auto array, MakeBlobArrayFromBytes(truncated));
+
+    {
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<BlobFormatWriter> writer,
+                             BlobFormatWriter::Create(
+                                 output_stream_, struct_type_, /*write_null_on_missing_file=*/true,
+                                 /*write_null_on_fetch_failure=*/false, file_system_, pool_));
+        ASSERT_NOK_WITH_MSG(AddBatchOnce(writer, array), "invalid blob descriptor");
     }
     {
         ASSERT_OK_AND_ASSIGN(std::shared_ptr<BlobFormatWriter> writer,
                              BlobFormatWriter::Create(
                                  output_stream_, struct_type_, /*write_null_on_missing_file=*/false,
-                                 /*write_null_on_fetch_failure=*/true, not_exist_fs, pool_));
-        ASSERT_NOK_WITH_MSG(AddBatchOnce(writer, array), "mock not exist");
+                                 /*write_null_on_fetch_failure=*/true, file_system_, pool_));
+        ASSERT_OK(AddBatchOnce(writer, array));
+        ASSERT_OK(writer->Flush());
+        ASSERT_OK(writer->Finish());
+    }
+
+    // Only the second case reaches the stream; the first fails before writing any byte.
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<arrow::StructArray> result_struct, ReadBackAsData());
+    ASSERT_EQ(result_struct->length(), 1);
+    ASSERT_TRUE(result_struct->field(0)->IsNull(0));
+}
+
+TEST_F(BlobFormatWriterWriteNullTest, TestWriteNullOnExistsCheckFailure) {
+    // An existence check that cannot answer leaves it unknown whether the file is there. With no
+    // fetch-failure handling to defer to, the write fails; otherwise the failed check is deferred
+    // to the open, whose own outcome decides.
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<Blob> blob,
+                         Blob::FromPath(paimon::test::GetDataDir() + "/xxhash.data"));
+    ASSERT_OK_AND_ASSIGN(auto array, PrepareDescriptorArray(blob));
+
+    // Deferred check failure whose open succeeds: the blob is written as data, not as NULL.
+    // This case finishes the shared output stream, so it runs first and is read back below.
+    {
+        auto exists_fail_fs =
+            std::make_shared<ExistsFailFileSystem>(Status::IOError("mock exists error"));
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<BlobFormatWriter> writer,
+                             BlobFormatWriter::Create(
+                                 output_stream_, struct_type_, /*write_null_on_missing_file=*/true,
+                                 /*write_null_on_fetch_failure=*/true, exists_fail_fs, pool_));
+        ASSERT_OK(AddBatchOnce(writer, array));
+        ASSERT_EQ(exists_fail_fs->ExistsCallCount(), 1);
+        ASSERT_OK(writer->Flush());
+        ASSERT_OK(writer->Finish());
+        ASSERT_OK_AND_ASSIGN(
+            uint64_t missing_nulls,
+            writer->GetWriterMetrics()->GetCounter(BlobMetrics::WRITE_NULL_ON_MISSING_FILE_COUNT));
+        ASSERT_EQ(missing_nulls, 0);
+        ASSERT_OK_AND_ASSIGN(
+            uint64_t fetch_failure_nulls,
+            writer->GetWriterMetrics()->GetCounter(BlobMetrics::WRITE_NULL_ON_FETCH_FAILURE_COUNT));
+        ASSERT_EQ(fetch_failure_nulls, 0);
+    }
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<arrow::StructArray> result_struct, ReadBackAsData());
+    ASSERT_EQ(result_struct->length(), 1);
+    ASSERT_FALSE(result_struct->field(0)->IsNull(0));
+    auto binary_array =
+        arrow::internal::checked_pointer_cast<arrow::LargeBinaryArray>(result_struct->field(0));
+    ASSERT_OK_AND_ASSIGN(auto expected_data, blob->ToData(file_system_, pool_));
+    ASSERT_EQ(binary_array->GetView(0),
+              std::string_view(expected_data->data(), expected_data->size()));
+
+    // With no fetch-failure handling to defer to, the check failure fails the write.
+    {
+        auto exists_fail_fs =
+            std::make_shared<ExistsFailFileSystem>(Status::IOError("mock exists error"));
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<BlobFormatWriter> writer,
+                             BlobFormatWriter::Create(
+                                 output_stream_, struct_type_, /*write_null_on_missing_file=*/true,
+                                 /*write_null_on_fetch_failure=*/false, exists_fail_fs, pool_));
+        // The reported failure names the check and keeps the underlying status message.
+        Status check_status = AddBatchOnce(writer, array);
+        ASSERT_NOK_WITH_MSG(check_status, "failed to check existence of blob file");
+        ASSERT_NOK_WITH_MSG(check_status, "mock exists error");
+    }
+    // Deferred check failure whose open then fails: a fetch failure. The re-check after the
+    // failed open cannot answer either, so it falls through to the open failure.
+    {
+        auto exists_fail_fs = std::make_shared<ExistsFailFileSystem>(
+            Status::IOError("mock exists error"), Status::IOError("mock open error"));
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<BlobFormatWriter> writer,
+                             BlobFormatWriter::Create(
+                                 output_stream_, struct_type_, /*write_null_on_missing_file=*/true,
+                                 /*write_null_on_fetch_failure=*/true, exists_fail_fs, pool_));
+        ASSERT_OK(AddBatchOnce(writer, array));
+        // One check before the open and one after it failed.
+        ASSERT_EQ(exists_fail_fs->ExistsCallCount(), 2);
+        ASSERT_OK_AND_ASSIGN(
+            uint64_t fetch_failure_nulls,
+            writer->GetWriterMetrics()->GetCounter(BlobMetrics::WRITE_NULL_ON_FETCH_FAILURE_COUNT));
+        ASSERT_EQ(fetch_failure_nulls, 1);
+    }
+    // With only write_null_on_fetch_failure, no existence check runs at all; the open succeeds
+    // and the blob is written as data. A separate output stream keeps the data bytes out of the
+    // already finished shared stream.
+    {
+        auto exists_fail_fs =
+            std::make_shared<ExistsFailFileSystem>(Status::IOError("mock exists error"));
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<OutputStream> side_stream,
+                             file_system_->Create(dir_->Str() + "/side.blob", /*overwrite=*/true));
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<BlobFormatWriter> writer,
+                             BlobFormatWriter::Create(
+                                 side_stream, struct_type_, /*write_null_on_missing_file=*/false,
+                                 /*write_null_on_fetch_failure=*/true, exists_fail_fs, pool_));
+        ASSERT_OK(AddBatchOnce(writer, array));
+        ASSERT_EQ(exists_fail_fs->ExistsCallCount(), 0);
+        ASSERT_OK_AND_ASSIGN(
+            uint64_t fetch_failure_nulls,
+            writer->GetWriterMetrics()->GetCounter(BlobMetrics::WRITE_NULL_ON_FETCH_FAILURE_COUNT));
+        ASSERT_EQ(fetch_failure_nulls, 0);
+        ASSERT_OK(side_stream->Flush());
+        ASSERT_OK(side_stream->Close());
     }
 }
 

--- a/src/paimon/format/lance/CMakeLists.txt
+++ b/src/paimon/format/lance/CMakeLists.txt
@@ -25,7 +25,6 @@ if(PAIMON_ENABLE_LANCE)
                    arrow
                    glog
                    fmt
-                   ${CMAKE_DL_LIBS}
                    Threads::Threads
                    SHARED_LINK_LIBS
                    paimon_shared

--- a/src/paimon/format/orc/CMakeLists.txt
+++ b/src/paimon/format/orc/CMakeLists.txt
@@ -38,7 +38,6 @@ if(PAIMON_ENABLE_ORC)
                    fmt
                    orc::orc
                    tbb
-                   ${CMAKE_DL_LIBS}
                    Threads::Threads
                    SHARED_LINK_LIBS
                    paimon_shared

--- a/src/paimon/format/parquet/CMakeLists.txt
+++ b/src/paimon/format/parquet/CMakeLists.txt
@@ -38,7 +38,6 @@ add_paimon_lib(paimon_parquet_file_format
                arrow
                glog
                fmt
-               ${CMAKE_DL_LIBS}
                Threads::Threads
                SHARED_LINK_LIBS
                paimon_shared

--- a/src/paimon/global_index/lucene/CMakeLists.txt
+++ b/src/paimon/global_index/lucene/CMakeLists.txt
@@ -36,7 +36,6 @@ if(PAIMON_ENABLE_LUCENE)
                    lucene
                    arrow
                    fmt
-                   ${CMAKE_DL_LIBS}
                    Threads::Threads
                    SHARED_LINK_LIBS
                    paimon_shared

--- a/src/paimon/global_index/lumina/CMakeLists.txt
+++ b/src/paimon/global_index/lumina/CMakeLists.txt
@@ -25,7 +25,6 @@ if(PAIMON_ENABLE_LUMINA)
                    arrow
                    glog
                    fmt
-                   ${CMAKE_DL_LIBS}
                    Threads::Threads
                    SHARED_LINK_LIBS
                    lumina::interface

--- a/test/inte/blob_table_inte_test.cpp
+++ b/test/inte/blob_table_inte_test.cpp
@@ -766,9 +766,9 @@ TEST_P(BlobTableInteTest, TestWriteNullOnFetchFailure) {
         << "expected:" << expected_with_rk->ToString();
 }
 
-TEST_P(BlobTableInteTest, TestWriteNullOnFetchFailureKeepsMissingFileFailing) {
-    // blob-write-null-on-fetch-failure only converts non-NotExist open failures; a missing
-    // descriptor file still fails the write when only this option is enabled.
+TEST_P(BlobTableInteTest, TestWriteNullOnFetchFailureCoversMissingFile) {
+    // The existence check runs only under blob-write-null-on-missing-file, so with only
+    // blob-write-null-on-fetch-failure a missing file is converted as an ordinary fetch failure.
     arrow::FieldVector fields = {arrow::field("f0", arrow::utf8()),
                                  arrow::field("f1", arrow::int32()),
                                  BlobUtils::ToArrowField("blob", true)};
@@ -788,7 +788,8 @@ TEST_P(BlobTableInteTest, TestWriteNullOnFetchFailureKeepsMissingFileFailing) {
 
     std::string raw_json = R"([
         ["str_0", 0, "blob_data_0"],
-        ["str_1", 1, "blob_data_1"]
+        ["str_1", 1, "blob_data_1"],
+        ["str_2", 2, "blob_data_2"]
     ])";
     auto raw_array = std::dynamic_pointer_cast<arrow::StructArray>(
         arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), raw_json).ValueOrDie());
@@ -796,8 +797,35 @@ TEST_P(BlobTableInteTest, TestWriteNullOnFetchFailureKeepsMissingFileFailing) {
     ASSERT_OK(DeleteDescriptorTarget(desc_array, "blob", /*row=*/1));
 
     auto schema = arrow::schema(fields);
-    ASSERT_NOK_WITH_MSG(WriteArray(table_path, {}, schema->field_names(), {desc_array}),
-                        "not exists");
+    ASSERT_OK_AND_ASSIGN(auto commit_msgs,
+                         WriteArray(table_path, {}, schema->field_names(), {desc_array}));
+    ASSERT_OK(Commit(table_path, commit_msgs));
+
+    ASSERT_OK_AND_ASSIGN(auto plan, ScanTable(table_path));
+    VerifyDataFileMetas(plan, /*expected_file_count=*/2, /*expected_row_counts=*/{3, 3},
+                        /*expected_min_seqs=*/{1, 1}, /*expected_max_seqs=*/{1, 1},
+                        /*expected_first_row_ids=*/{0, 0},
+                        /*expected_write_cols=*/
+                        {std::vector<std::string>{"f0", "f1"}, std::vector<std::string>{"blob"}});
+
+    ASSERT_OK_AND_ASSIGN(auto result, ReadTable(table_path, schema->field_names(), plan));
+    ASSERT_TRUE(result.chunked_array);
+    auto read_concat = arrow::Concatenate(result.chunked_array->chunks()).ValueOrDie();
+    auto read_struct = std::dynamic_pointer_cast<arrow::StructArray>(read_concat);
+    ASSERT_OK_AND_ASSIGN(auto resolved, ConvertDescriptorToRawBlob(read_struct, {"blob"}));
+
+    std::string expected_json = R"([
+        ["str_0", 0, "blob_data_0"],
+        ["str_1", 1, null],
+        ["str_2", 2, "blob_data_2"]
+    ])";
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), expected_json)
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(auto expected_with_rk, PrependRowKindColumn(expected_array));
+    ASSERT_TRUE(resolved->Equals(expected_with_rk))
+        << "result:" << resolved->ToString() << std::endl
+        << "expected:" << expected_with_rk->ToString();
 }
 
 TEST_P(BlobTableInteTest, TestBasic) {


### PR DESCRIPTION
### Purpose

Follow-up to #421.

`BlobFormatWriter` told a missing file apart from a fetch failure by testing `Status::NotExist` on a failed descriptor open. That makes the two write-null options depend on every file system plugin agreeing on which status code a missing file maps to, which is hard to keep uniform across all of the plugin interfaces: supporting it in #421 already required mapping `JDO_FILE_NOT_FOUND_ERROR` to `Status::NotExist` at the jindo boundary, and any plugin that reports a missing file as a plain IO error silently disables `blob-write-null-on-missing-file`.

- Decide whether the referenced file is missing with `FileSystem::Exists` instead of the status of a failed open. Java classifies the same way, through `UriReader.FileUriReader.exists` -> `FileIO.exists`; the only error code its writer tests is HTTP 404, which is protocol-defined rather than plugin-specific. The check runs only when `blob-write-null-on-missing-file` needs the classification, matching the gating of `FlinkRowWrapper.isNullAt` via `checkBlobDescriptorExists`: with only `blob-write-null-on-fetch-failure` enabled there is no check, and a missing file is converted (and counted) as a fetch failure like any other failed open. The default path (both options off) pays nothing.
- A failed open re-checks `FileSystem::Exists` once, so a file deleted between the up-front check and the open is still classified as missing rather than silently defeating `blob-write-null-on-missing-file`, whose writer does not convert a fetch failure. This narrows the race window rather than closing it; classifying from the open status instead would reintroduce the plugin-specific codes this PR removes.
- A failed existence check leaves it unknown whether the file is there. With `blob-write-null-on-fetch-failure` enabled it is deferred to the open, as `FlinkRowWrapper.deferExistsCheckFailure` does: a blob that opens fine is written as data, and only an open that also fails is handled as a fetch failure. Without fetch-failure handling to defer to, the write fails with a status naming the check and the blob URI.
- A descriptor that cannot be deserialized is now a fetch failure as well, which is what `BLOB_WRITE_NULL_ON_FETCH_FAILURE` already documented ("e.g. invalid descriptor") but the code did not do — it propagated unconditionally. Descriptor detection only inspects the version and magic header, so a descriptor truncated after those passes detection and then fails to deserialize. The status keeps its original code and detail (via `Status::WithMessage`) and gains an `invalid blob descriptor` prefix, because the underlying status comes from the byte reader and never mentions blobs.
- `BlobFormatWriter::Create` now rejects a null file system, so that configuration error surfaces at construction instead of being converted into silently NULL rows by `blob-write-null-on-fetch-failure`.
- Report both conversions as `blob.write.null-on-missing-file.count` and `blob.write.null-on-fetch-failure.count`, and name the blob URI, the BLOB field and the output file in the write-null warnings.

This PR also follows up the review comment on #421 (https://github.com/alibaba/paimon-cpp/pull/421#discussion_r3593647786): `${CMAKE_DL_LIBS}` was listed by hand on individual targets that never call `dlopen`/`dlsym`/`dladdr` themselves — a grep over `src/` and `include/` finds no such call. Those entries were carried on behalf of arrow, which declares dl as a usage requirement on its own interface, so CMake places `-ldl` after `libarrow.a` automatically on linkers that resolve symbols strictly left-to-right; every target that dropped an entry links arrow and inherits it transitively. dl is now declared only on the real providers (`arrow`, `lucene`, `jindosdk::nextarch`), with the convention recorded next to arrow's declaration so consumers do not add it back.

### Tests

- `BlobFormatWriterWriteNullTest.TestWriteNullClassifiesByExistence` (rewritten from `TestWriteNullClassifiesByStatusCode`): a mock file system whose `Open` always fails with `IOError` stands in for a plugin that reports a missing file as something other than `Status::NotExist`. The cases pin that classification follows `Exists` only when `blob-write-null-on-missing-file` is enabled: a file classified as missing is never opened under that option, while with only `blob-write-null-on-fetch-failure` the file is opened and its failure converted as a fetch failure. A `VanishingFileSystem` (present on the first `Exists`, absent afterwards) pins the deletion race: re-checked and classified as missing under `blob-write-null-on-missing-file` — alone and with both options enabled, attributed to the missing-file counter — converted as a fetch failure with only `blob-write-null-on-fetch-failure`, and existence never consulted when the missing-file option is off.
- `BlobFormatWriterWriteNullTest.TestWriteNullOnExistsCheckFailure` (reworked): a failed existence check defers to the open when `blob-write-null-on-fetch-failure` is enabled — a succeeding open writes the blob as data (verified by read-back), a failing open is handled as a fetch failure with one re-check — and fails the write with a status naming the check and keeping the underlying message when it is not; with only fetch-failure enabled the check never runs. Its mock delegates `Open` to a separate `LocalFileSystem` so the open still succeeds — `LocalFileSystem::Open` calls `Exists` on itself, and without that delegation the test could not tell whether the writer acted on the check at all — and optionally fails `Open` instead.
- `BlobFormatWriterWriteNullTest.TestWriteNullOnInvalidDescriptor`: a descriptor truncated after the magic header passes detection, fails to deserialize, and is handled as a fetch failure under both option settings, with read-back verification.
- `BlobFormatWriterWriteNullTest.TestWriteNullOnMissingFile` / `TestWriteNullOnBothOptionsEnabled`: unchanged in intent; the both-options case additionally asserts the two counters. `TestWriteNullOnFetchFailure`: a missing file is now converted (and counted) as a fetch failure, since no existence check runs without `blob-write-null-on-missing-file`.
- `BlobFormatWriterTest.TestCreateWithInvalidParameters`: extended with the null file system rejection.
- `BlobTableInteTest.TestWriteNullOnFetchFailureCoversMissingFile` (renamed from `TestWriteNullOnFetchFailureKeepsMissingFileFailing`): the end-to-end counterpart of the same change. With only `blob-write-null-on-fetch-failure` enabled, writing a descriptor whose file was deleted now succeeds; both the data file and the `.blob` file keep the full row count, and the read merges them back into a row whose blob is NULL. The test previously asserted that such a write fails, which is exactly the behavior this PR removes, so it was updated rather than kept.

Local validation: `paimon-blob-format-test` 41/41 passed; `pre-commit` (clang-format, cmake-format, cpplint, codespell) and `git diff --check` clean. Each regression test was checked for discriminating power by reverting the corresponding implementation change and confirming the test fails.

The `test/inte` binaries cannot be run on the development machine — they abort in Arrow's `json_simple.cc` `DCHECK(*out)` during `ArrayFromJSON`, including on blob tests this PR does not touch — so `paimon-blob-table-inte-test` was only compiled locally and its result relies on the Linux CI build.

The CMake change could not be validated meaningfully on the development machine: `CMAKE_DL_LIBS` expands to empty on macOS, so the removals are a no-op there; `format/lance`, `global_index/lucene` and `global_index/lumina` are parsed but their targets are guarded off, and `benchmark/CMakeLists.txt` is not parsed at all with `PAIMON_BUILD_BENCHMARKS=OFF`. It relies on the Linux CI build, and on CI covering those optional component flags.

### API and Format

- Header changes under `include/` are documentation-only: the option docs in `include/paimon/defs.h` now state that the missing-file classification applies only when `blob-write-null-on-missing-file` is enabled, and that a missing file otherwise follows `blob-write-null-on-fetch-failure`. The option constants are unchanged.
- No storage format change: NULL elements keep the existing `kNullBinLength` encoding.
- Behavior changes visible to callers: with only `blob-write-null-on-fetch-failure` enabled, a missing file is now converted to NULL as a fetch failure instead of failing the write, and no existence check runs; a failed existence check with fetch-failure enabled defers to the open instead of failing; an undeserializable descriptor is governed by `blob-write-null-on-fetch-failure` instead of always failing the write; `BlobFormatWriter::Create` rejects a null file system; and a failed existence check without fetch-failure handling reports `failed to check existence of blob file '<uri>'`.
- New internal metric name constants (`BlobMetrics`) in `src/paimon/format/blob/blob_format_writer.h`, reported through the existing `FormatWriter::GetWriterMetrics`.

### Documentation

No user-facing documentation change beyond the option semantics in `include/paimon/defs.h`; the class documentation in `blob_format_writer.h` states when the existence check runs and how the two options interact.

### Generative AI tooling

Generated-by: Claude Code (Claude Fable 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

