### PR TITLE
feat(parquet): support configuring Arrow pre-buffer hole-size-limit for range coalescing

### DIFF
--- a/src/paimon/format/parquet/parquet_file_batch_reader.cpp
+++ b/src/paimon/format/parquet/parquet_file_batch_reader.cpp
@@ -617,12 +617,28 @@ Result<::parquet::ArrowReaderProperties> ParquetFileBatchReader::CreateArrowRead
         OptionsUtils::GetValueFromMap<int64_t>(options, PARQUET_READ_CACHE_OPTION_PREFETCH_LIMIT,
                                                DEFAULT_PARQUET_READ_CACHE_OPTION_PREFETCH_LIMIT));
     PAIMON_ASSIGN_OR_RAISE(
+        int64_t cache_hole_size_limit,
+        OptionsUtils::GetValueFromMap<int64_t>(options, PARQUET_READ_CACHE_OPTION_HOLE_SIZE_LIMIT,
+                                               DEFAULT_PARQUET_READ_CACHE_OPTION_HOLE_SIZE_LIMIT));
+    PAIMON_ASSIGN_OR_RAISE(
         int64_t cache_range_size_limit,
         OptionsUtils::GetValueFromMap<int64_t>(options, PARQUET_READ_CACHE_OPTION_RANGE_SIZE_LIMIT,
                                                DEFAULT_PARQUET_READ_CACHE_OPTION_RANGE_SIZE_LIMIT));
+    if (cache_hole_size_limit < 0) {
+        return Status::Invalid(fmt::format("{} must be non-negative, but was {}",
+                                           PARQUET_READ_CACHE_OPTION_HOLE_SIZE_LIMIT,
+                                           cache_hole_size_limit));
+    }
+    if (cache_range_size_limit <= cache_hole_size_limit) {
+        return Status::Invalid(fmt::format("{} must be greater than {}, but was {} <= {}",
+                                           PARQUET_READ_CACHE_OPTION_RANGE_SIZE_LIMIT,
+                                           PARQUET_READ_CACHE_OPTION_HOLE_SIZE_LIMIT,
+                                           cache_range_size_limit, cache_hole_size_limit));
+    }
     auto cache_option = arrow::io::CacheOptions::Defaults();
     cache_option.lazy = cache_lazy;
     cache_option.prefetch_limit = cache_prefetch_limit;
+    cache_option.hole_size_limit = cache_hole_size_limit;
     cache_option.range_size_limit = cache_range_size_limit;
     arrow_reader_props.set_cache_options(cache_option);
     return arrow_reader_props;

--- a/src/paimon/format/parquet/parquet_file_batch_reader_test.cpp
+++ b/src/paimon/format/parquet/parquet_file_batch_reader_test.cpp
@@ -703,7 +703,9 @@ TEST_F(ParquetFileBatchReaderTest, TestCreateArrowReaderProperties) {
         ASSERT_EQ(arrow_reader_properties.batch_size(), 1024);
         ASSERT_EQ(arrow_reader_properties.use_threads(), true);
         ASSERT_EQ(arrow::GetCpuThreadPoolCapacity(), 3);
-        ASSERT_EQ(arrow_reader_properties.cache_options(), arrow::io::CacheOptions::Defaults());
+        auto expected_cache_options = arrow::io::CacheOptions::Defaults();
+        expected_cache_options.hole_size_limit = DEFAULT_PARQUET_READ_CACHE_OPTION_HOLE_SIZE_LIMIT;
+        ASSERT_EQ(arrow_reader_properties.cache_options(), expected_cache_options);
     }
     {
         std::map<std::string, std::string> options = {{PARQUET_READ_EXECUTOR_THREAD_COUNT, "0"}};
@@ -721,6 +723,40 @@ TEST_F(ParquetFileBatchReaderTest, TestCreateArrowReaderProperties) {
             ParquetFileBatchReader::CreateArrowReaderProperties(pool_, options, batch_size));
         ASSERT_EQ(arrow_reader_properties.use_threads(), true);
         ASSERT_EQ(arrow::GetCpuThreadPoolCapacity(), 6);
+    }
+    {
+        std::map<std::string, std::string> options = {
+            {PARQUET_READ_CACHE_OPTION_LAZY, "true"},
+            {PARQUET_READ_CACHE_OPTION_PREFETCH_LIMIT, "2"},
+            {PARQUET_READ_CACHE_OPTION_HOLE_SIZE_LIMIT, "1048576"},
+            {PARQUET_READ_CACHE_OPTION_RANGE_SIZE_LIMIT, "8388608"},
+        };
+        ASSERT_OK_AND_ASSIGN(
+            auto arrow_reader_properties,
+            ParquetFileBatchReader::CreateArrowReaderProperties(pool_, options, 1024));
+        const auto& cache_options = arrow_reader_properties.cache_options();
+        ASSERT_TRUE(cache_options.lazy);
+        ASSERT_EQ(cache_options.prefetch_limit, 2);
+        ASSERT_EQ(cache_options.hole_size_limit, 1024 * 1024);
+        ASSERT_EQ(cache_options.range_size_limit, 8 * 1024 * 1024);
+    }
+    {
+        std::map<std::string, std::string> options = {
+            {PARQUET_READ_CACHE_OPTION_HOLE_SIZE_LIMIT, "-1"},
+        };
+        ASSERT_NOK_WITH_MSG(
+            ParquetFileBatchReader::CreateArrowReaderProperties(pool_, options, 1024),
+            "parquet.read.cache-option.hole-size-limit must be non-negative");
+    }
+    {
+        std::map<std::string, std::string> options = {
+            {PARQUET_READ_CACHE_OPTION_HOLE_SIZE_LIMIT, "1048576"},
+            {PARQUET_READ_CACHE_OPTION_RANGE_SIZE_LIMIT, "1048576"},
+        };
+        ASSERT_NOK_WITH_MSG(
+            ParquetFileBatchReader::CreateArrowReaderProperties(pool_, options, 1024),
+            "parquet.read.cache-option.range-size-limit must be greater than "
+            "parquet.read.cache-option.hole-size-limit");
     }
 }
 

--- a/src/paimon/format/parquet/parquet_format_defs.h
+++ b/src/paimon/format/parquet/parquet_format_defs.h
@@ -63,6 +63,11 @@ static constexpr uint32_t DEFAULT_PARQUET_READ_EXECUTOR_THREAD_COUNT = 3;
 static inline const char PARQUET_READ_CACHE_OPTION_LAZY[] = "parquet.read.cache-option.lazy";
 static inline const char PARQUET_READ_CACHE_OPTION_PREFETCH_LIMIT[] =
     "parquet.read.cache-option.prefetch-limit";
+// Arrow I/O range coalescing limits, both measured in bytes. Adjacent ranges whose gap is
+// <= hole-size-limit can be merged; range-size-limit stops further merging once the combined
+// span would exceed it. A single input range may itself be larger than range-size-limit.
+static inline const char PARQUET_READ_CACHE_OPTION_HOLE_SIZE_LIMIT[] =
+    "parquet.read.cache-option.hole-size-limit";
 static inline const char PARQUET_READ_CACHE_OPTION_RANGE_SIZE_LIMIT[] =
     "parquet.read.cache-option.range-size-limit";
 // Strategy for refining row ranges using the selection bitmap produced by pushed-down
@@ -96,6 +101,7 @@ static inline const char PARQUET_READ_ENABLE_PAGE_INDEX_FILTER[] =
 static inline const char PARQUET_READ_ENABLE_PRE_BUFFER[] = "parquet.read.enable-pre-buffer";
 
 static constexpr uint32_t DEFAULT_PARQUET_READ_CACHE_OPTION_PREFETCH_LIMIT = 0;
+static constexpr uint32_t DEFAULT_PARQUET_READ_CACHE_OPTION_HOLE_SIZE_LIMIT = 4 * 1024 * 1024;
 static constexpr uint32_t DEFAULT_PARQUET_READ_CACHE_OPTION_RANGE_SIZE_LIMIT = 32 * 1024 * 1024;
 static constexpr uint32_t DEFAULT_PARQUET_READ_PREDICATE_NODE_COUNT_LIMIT = 512;
 static constexpr bool DEFAULT_PARQUET_READ_ENABLE_PAGE_INDEX_FILTER = true;

--- a/src/paimon/format/parquet/parquet_format_defs.h
+++ b/src/paimon/format/parquet/parquet_format_defs.h
@@ -101,7 +101,8 @@ static inline const char PARQUET_READ_ENABLE_PAGE_INDEX_FILTER[] =
 static inline const char PARQUET_READ_ENABLE_PRE_BUFFER[] = "parquet.read.enable-pre-buffer";
 
 static constexpr uint32_t DEFAULT_PARQUET_READ_CACHE_OPTION_PREFETCH_LIMIT = 0;
-static constexpr uint32_t DEFAULT_PARQUET_READ_CACHE_OPTION_HOLE_SIZE_LIMIT = 4 * 1024 * 1024;
+// Default value of hole size limit, inherited from Arrow
+static constexpr uint32_t DEFAULT_PARQUET_READ_CACHE_OPTION_HOLE_SIZE_LIMIT = 8 * 1024;
 static constexpr uint32_t DEFAULT_PARQUET_READ_CACHE_OPTION_RANGE_SIZE_LIMIT = 32 * 1024 * 1024;
 static constexpr uint32_t DEFAULT_PARQUET_READ_PREDICATE_NODE_COUNT_LIMIT = 512;
 static constexpr bool DEFAULT_PARQUET_READ_ENABLE_PAGE_INDEX_FILTER = true;


### PR DESCRIPTION
### Purpose

The Parquet reader already exposes `parquet.read.cache-option.lazy`, `parquet.read.cache-option.prefetch-limit`, and `parquet.read.cache-option.range-size-limit` to configure Arrow's pre-buffer `CacheOptions`, but the `hole_size_limit` was always left at Arrow's default (8 KiB). This byte-level gap threshold decides whether adjacent I/O ranges are coalesced into a single read request, which directly determines the I/O pattern on paths where Paimon's own `ReadAheadCache` is not in effect (e.g. non-prefetch reads or cache modes that skip caching).

This PR:

- Adds a new option `parquet.read.cache-option.hole-size-limit` (bytes) to control `arrow::io::CacheOptions::hole_size_limit`, defaulting to 8 KB (`DEFAULT_PARQUET_READ_CACHE_OPTION_HOLE_SIZE_LIMIT`) so that small gaps between column-chunk ranges are merged into fewer, larger reads, which benefits high-latency storage.
- Validates the configuration in `ParquetFileBatchReader::CreateArrowReaderProperties`:
  - `hole-size-limit` must be non-negative;
  - `range-size-limit` must be strictly greater than `hole-size-limit`.
- Documents the byte-level semantics of both coalescing limits in `parquet_format_defs.h`.

### Tests

- UT: `ParquetFileBatchReaderTest.TestCreateArrowReaderProperties` (extended)
  - Default cache options now carry `hole_size_limit = DEFAULT_PARQUET_READ_CACHE_OPTION_HOLE_SIZE_LIMIT`.
  - All four `parquet.read.cache-option.*` options set together are correctly propagated to `arrow::io::CacheOptions`.
  - Negative `hole-size-limit` is rejected with `Status::Invalid`.
  - `range-size-limit <= hole-size-limit` is rejected with `Status::Invalid`.

### API and Format

No public API change under `include/paimon/` and no storage format/protocol change. Adds one new read option key `parquet.read.cache-option.hole-size-limit` in `src/paimon/format/parquet/parquet_format_defs.h`; the effective default Arrow pre-buffer coalescing behavior changes as described above.

### Documentation

No new user-facing feature docs required; the new option and the semantics of the coalescing limits are documented via comments in `parquet_format_defs.h`.

### Generative AI tooling

No
